### PR TITLE
Add Adobe Photoshop CS6

### DIFF
--- a/Casks/adobe-photoshop-cs.rb
+++ b/Casks/adobe-photoshop-cs.rb
@@ -1,0 +1,12 @@
+class AdobePhotoshopCs < Cask
+  url 'http://trials2.adobe.com/AdobeProducts/PHSP/13/osx10/Photoshop_13_LS16.dmg',
+      :cookies => {
+                    'MM_TRIALS' => '1234'
+                  }
+  homepage 'https://www.adobe.com/products/cs6.html'
+  version '13.0.0'
+  sha256 'f377a661660a5b00c46ef71dd5a835989d1374ed97bb891e9bdf98fa3a686a5e'
+  caveats do
+    manual_installer 'Adobe Photoshop CS6/Install.app'
+  end
+end

--- a/Casks/adobe-photoshop-cs6.rb
+++ b/Casks/adobe-photoshop-cs6.rb
@@ -1,4 +1,4 @@
-class AdobePhotoshopCs < Cask
+class AdobePhotoshopCs6 < Cask
   url 'http://trials2.adobe.com/AdobeProducts/PHSP/13/osx10/Photoshop_13_LS16.dmg',
       :cookies => {
                     'MM_TRIALS' => '1234'


### PR DESCRIPTION
I've added an cask for Photoshop CS6, in spite of the the fact that I could not determine how to install the app automatically. Also, Adobe provides an uninstaller application (/Applications/Adobe Photoshop CS6/Uninstall Adobe Photoshop CS6), but I didn't create an uninstall stanza for it because it's a GUI uninstaller that can't be run from the command line.