### PR TITLE
Update HandbrakeCLI Nightly to v6685svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '6675svn'
-  sha256 'd64d63700af9eb77ed1e90ae4288f0f8d171657d7fb91f84d519203e9458cf44'
+  version '6685svn'
+  sha256 'c3d0633c3f486c14880532561e3e9d59c9d213445cafec7c68077110608004d5'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v6685svn built 2015-01-05.