### PR TITLE
Add adium nightly version 1.6

### DIFF
--- a/Casks/adium-nightly16.rb
+++ b/Casks/adium-nightly16.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'adium-nightly16' do
+  version '1.6hgr5896'
+  sha256 '163e5a5eb521ccb7ccf033ac17c3a9323a052c13f8da97eb296e762c96096ab4'
+
+  url "http://nightly.adium.im/adium-adium-1.6/Adium_#{version}.dmg"
+  homepage 'http://nightly.adium.im/?repo_branch=adium-adium-1.6'
+  license :oss
+
+  app 'Adium.app'
+end


### PR DESCRIPTION
The version 1.6 nightly of adium actually appears to be currently developed more actively than the 1.7 version - but I thought it might be nice to have the nightly build available via brew cask as well as the beta (since the beta hasn't been updated in years)