### PR TITLE
Add Lingon X 1.0

### DIFF
--- a/Casks/lingon-x1.rb
+++ b/Casks/lingon-x1.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'lingon-x1' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://www.peterborgapps.com/downloads/LingonX.zip'
+  appcast 'http://www.peterborgapps.com/updates/lingonx-appcast.xml'
+  homepage 'http://www.peterborgapps.com/lingon/'
+  license :commercial
+
+  app 'Lingon X.app'
+
+  depends_on :macos => '>= :mountain_lion'
+end


### PR DESCRIPTION
Adding Lingon X 1.0 to versions so Lingon X 2.0 can be added to homebrew-cask per caskroom/homebrew-cask#8844