### PR TITLE
Update HandbrakeCLI Nightly to v6752svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '6714svn'
-  sha256 '57eb6aa19d84e281e8d696bf1f3ecb2b84b3d6d13144c133f94b00530161968a'
+  version '6752svn'
+  sha256 'a9b2d95e47a72b5cd918bd3b2d8f2064cec1b5f8b96b441dabc60af63aefa4d2'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v6752svn built 2015-01-15.