### PR TITLE
Add rust-nightly cask

### DIFF
--- a/Casks/rust-nightly.rb
+++ b/Casks/rust-nightly.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'rust' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg'
+  homepage 'http://www.rust-lang.org/'
+  license :mit
+
+  pkg 'rust-nightly-x86_64-apple-darwin.pkg'
+
+  uninstall :pkgutil => 'org.rust-lang.rust'
+end


### PR DESCRIPTION
Add rust-nightly cask to track the latest nightly release to complement https://github.com/caskroom/homebrew-cask/pull/8941