### PR TITLE
Updated thunderbird-beta to correct sha256sum

### DIFF
--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'thunderbird-beta' do
   version '34.0b1'
-  sha256 '775e548e592f2788d991fe41ff2093bc902ceaa19bef83429e613375c7fa7887'
+  sha256 '7f6025c689633e893203490f11504b4790c46eca88393d7ab678b5405b8a8acb'
 
   url "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/#{version}/mac/en-US/Thunderbird%20#{version}.dmg"
   homepage 'https://www.mozilla.org/en-US/thunderbird/all-beta.html'


### PR DESCRIPTION
Corrected error preventing the cask from installing.

Error: sha256 mismatch
Expected: 775e548e592f2788d991fe41ff2093bc902ceaa19bef83429e613375c7fa7887
Actual: 7f6025c689633e893203490f11504b4790c46eca88393d7ab678b5405b8a8acb