### PR TITLE
Added Earlybird 37.0a2 aka Thunderbird

### DIFF
--- a/Casks/earlybird.rb
+++ b/Casks/earlybird.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'earlybird' do
+  version '37.0a2'
+  sha256 'da335ece743f9211be7274e39a432cf4f1ec0886172cb0a731bd28489110964d'
+
+  url "https://ftp.mozilla.org/pub/mozilla.org/thunderbird/nightly/latest-earlybird/thunderbird-#{version}.en-US.mac.dmg"
+  name 'Earlybird'
+  name 'Thunderbird Nightly'
+  homepage 'https://www.mozilla.org/en-US/thunderbird/channel/'
+  license :mpl
+
+  app 'Earlybird.app'
+end


### PR DESCRIPTION
A better cask token is probably thunderbird-nightly or thunderbird-earlybird, to show the relationship to Thunderbird, but to keep with the contribution guidelines I created the token based on the .app name.
I included Thunderbird Nightly as an alternative name so it is clear what the app relationship is when looking at the info.