### PR TITLE
update simpholders from build 87 to 108

### DIFF
--- a/Casks/simpholders-2-alpha.rb
+++ b/Casks/simpholders-2-alpha.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'simpholders-2-alpha' do
   version '2.0 Alpha'
-  sha256 '53c62d2a5817e0b7c3bb77b83dca74819ecee8e799ddc5a0832787a2456ed0a4'
+  sha256 '0c1cfb1d32be915b9284735a7739d25b3a5f55db010f5c27d24a60ae34d1a580'
 
-  url 'http://simpholders.com/site/assets/files/1098/sp20a-87.zip'
+  url 'http://simpholders.com/site/assets/files/1098/sp20a-108.zip'
   homepage 'http://simpholders.com/'
   license :unknown
 


### PR DESCRIPTION
We fixed the most common bugs which you found in the first alpha.
Adjustments to better incorporate the Yosemite style.