### PR TITLE
rstudio-preview: updates to support nightly

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'rstudio-preview' do
-  version '0.99.174'
-  sha256 '50407f5f2fdcc84dab862d5c32e9264e8280338d625389ce9963e35cf83c7bc4'
+  version :latest
+  sha256 :no_check
 
-  url "https://s3.amazonaws.com/rstudio-dailybuilds/RStudio-#{version}.dmg"
+  url "http://tiny.cc/latestrstudiopreview"
   homepage 'http://www.rstudio.com/ide/download/preview'
   license :unknown
 


### PR DESCRIPTION
RStudio Preview is updated several times a week.

Instead of submitting an updated formula for every update, I've
modified the formula to mimic the iterm-nightly formula.

Unfortunately, RStudio doesn't (yet) provide a URL that points
to the latest RStudio Preview download, so I've created a URL
through tiny.cc that I will update when new versions of RStudio
Preview are released.