### PR TITLE
Update HandbrakeCLI Nightly to v6782svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '6752svn'
-  sha256 'a9b2d95e47a72b5cd918bd3b2d8f2064cec1b5f8b96b441dabc60af63aefa4d2'
+  version '6782svn'
+  sha256 'a661254da12a5fcaaab80b822bed78e8e000800042380bf3ccdfacf017cdb7fa'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v6782svn built 2015-01-21.