### PR TITLE
Rename SpotifyBeta.app and update to latest version.

### DIFF
--- a/Casks/spotifybeta.rb
+++ b/Casks/spotifybeta.rb
@@ -1,13 +1,14 @@
-cask :v1 => 'spotify-beta' do
-  version '1.0.1.811.g63b21681-72'
-  sha256 'c3671db9876ce4497971cb2ec269edad7a8ab34f8af6e38f18328e2cee2c3c43'
+cask :v1 => 'spotifybeta' do
+  version '1.0.0.909.ge4845795-1223'
+  sha256 '9279b76b13185d2cba4afcbf19464a97229b3a50620fbfff4311fef8cf9b8c50'
 
   url "http://download.spotify.com/beta/spotify-app-#{version}.dmg"
+  name 'Spotify Beta'
   name 'Spotify'
   homepage 'https://www.spotify.com'
   license :gratis
 
-  app 'Spotify.app'
+  app 'SpotifyBeta.app'
 
   uninstall :launchctl => 'com.spotify.webhelper'
 


### PR DESCRIPTION
This has changed back since #663. Spotify beta version is now named `SpotifyBeta.app` again.