### PR TITLE
Update the version of IntelliJ Ultimate 12 to 12.1.7b

### DIFF
--- a/Casks/intellij-idea12.rb
+++ b/Casks/intellij-idea12.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'intellij-idea12' do
-  version '12.1.7'
-  sha256 '5fd6130f66e2a64a4083c77e4dc1efde153bee333ce729553f39d0b106508466'
+  version '12.1.7b'
+  sha256 '4f98af36f7747323d6a83a8d758aa0d6f02f20faa5da5a9e5bd8b7856cfe429a'
 
   url "http://download.jetbrains.com/idea/ideaIU-#{version}.dmg"
   homepage 'https://www.jetbrains.com/idea/index.html'


### PR DESCRIPTION
The previous version (12.1.7) is no longer available from the Jetbrains website.