### PR TITLE
rstudio-preview: update to always pull latest

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'rstudio-preview' do
-  version '0.99.174'
-  sha256 '50407f5f2fdcc84dab862d5c32e9264e8280338d625389ce9963e35cf83c7bc4'
+  version :latest
+  sha256 :no_check
 
-  url "https://s3.amazonaws.com/rstudio-dailybuilds/RStudio-#{version}.dmg"
+  url "http://www.rstudio.org/download/latest/preview/desktop/mac/RStudio-latest.dmg"
   homepage 'http://www.rstudio.com/ide/download/preview'
   license :unknown
 

--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -2,7 +2,7 @@ cask :v1 => 'rstudio-preview' do
   version :latest
   sha256 :no_check
 
-  url "http://www.rstudio.org/download/latest/preview/desktop/mac/RStudio-latest.dmg"
+  url 'http://www.rstudio.org/download/latest/preview/desktop/mac/RStudio-latest.dmg'
   homepage 'http://www.rstudio.com/ide/download/preview'
   license :unknown
 


### PR DESCRIPTION
Instead of submitting an updated formula for every update, I've
modified the formula to mimic the iterm-nightly formula.

I submitted a similar pull request (#688) that used my own URL
 but was told that was, understandably, an unsafe approach.

RStudio has kindly provided a link that will always point to the
latest Preview version of RStudio and I have updated the formula
to use this URL.

Thanks RStudio!