### PR TITLE
Update HandbrakeCLI Nightly to v6822svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,10 +1,12 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '6782svn'
-  sha256 'a661254da12a5fcaaab80b822bed78e8e000800042380bf3ccdfacf017cdb7fa'
+  version '6822svn'
+  sha256 '06b3024888643041779f4ac301266739ef6a6c4a30972a951aec881fb28f50c3'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'
   license :gpl
+
+  depends_on :macos => '>= :snow_leopard'
 
   binary 'HandBrakeCLI'
 end


### PR DESCRIPTION
HandBrakeCLI Nightly v6822svn built 2015-01-28.