### PR TITLE
Add XQuartz beta

### DIFF
--- a/Casks/xquartz-beta.rb
+++ b/Casks/xquartz-beta.rb
@@ -1,0 +1,40 @@
+cask :v1 => 'xquartz-beta' do
+  version '2.7.8_beta1'
+  sha256 '69bc5fd69546d481dbd62d849ce4dd93345ffb4eb39b106343e4888ae79fc49d'
+
+  url "https://xquartz.macosforge.org/downloads/SL/XQuartz-#{version}.dmg"
+  appcast 'http://xquartz-dl.macosforge.org/sparkle/beta.xml',
+          :sha256 => 'd7af66b0da65a8297d06e901a34acc1fbfe41603302a05a1377a40e46f69b7a2'
+  name 'XQuartz'
+  homepage 'http://xquartz.macosforge.org/'
+  license :oss
+
+  pkg 'XQuartz.pkg'
+
+  postflight do
+    Pathname.new(File.expand_path('~')).join('Library', 'Logs').mkpath
+
+    # Set default path to X11 to avoid the need of manual setup
+    system '/usr/bin/defaults', 'write', 'com.apple.applescript', 'ApplicationMap', '-dict-add', 'X11', 'file://localhost/Applications/Utilities/XQuartz.app/'
+    # Set the Sparkle feed to be the one for beta releases since there's not a way in the UI
+    system '/usr/bin/defaults', 'write', 'org.macosforge.xquartz.X11', 'SUFeedURL', 'http://xquartz.macosforge.org/downloads/sparkle/beta.xml'
+
+    # Load & start XServer to avoid the need of relogin
+    system '/bin/launchctl', 'load', '/Library/LaunchAgents/org.macosforge.xquartz.startx.plist'
+  end
+
+  uninstall :quit => 'org.macosforge.xquartz.X11',
+            :launchctl => 'org.macosforge.xquartz.startx',
+            :pkgutil => 'org.macosforge.xquartz.pkg',
+            :delete => '/opt/X11/'
+  zap       :delete => [
+                        '~/Library/Caches/org.macosforge.xquartz.X11',
+                        '~/Library/Logs/X11',
+                        '~/Library/Logs/X11.org.macosforge.xquartz.log',
+                        '~/Library/Logs/X11.org.macosforge.xquartz.log.old',
+                        '~/Library/Preferences/org.macosforge.xquartz.X11.plist',
+                        '~/Library/Saved Application State/org.macosforge.xquartz.X11.savedState',
+                        '~/.Xauthority',
+                       ],
+            :rmdir => '~/.fonts'
+end


### PR DESCRIPTION
Based on the xquartz cask in the main repo, but now with more beta!

Also updates the prefs plist to point Sparkle at the beta feed, since there's no way to do so inside the UI.