### PR TITLE
Update airmail-beta's symlink

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -6,5 +6,5 @@ cask :v1 => 'airmail-beta' do
   homepage 'http://airmailapp.com/beta/'
   license :unknown
 
-  app 'AirMail Beta.app'
+  app 'AirMail 2 Beta.app'
 end


### PR DESCRIPTION
Looks like Airmail has been renamed from "Airmail Beta.app"
to "Airmail 2 Beta.app"