### PR TITLE
Revert "Update airmail-beta's symlink"

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -6,5 +6,5 @@ cask :v1 => 'airmail-beta' do
   homepage 'http://airmailapp.com/beta/'
   license :unknown
 
-  app 'AirMail 2 Beta.app'
+  app 'AirMail Beta.app'
 end


### PR DESCRIPTION
Looks like the latest beta release of Airmail is back to being called "Airmail Beta.app"