### PR TITLE
Fix typo in cask

### DIFF
--- a/Casks/audio-hijack-pro.rb
+++ b/Casks/audio-hijack-pro.rb
@@ -10,7 +10,7 @@ cask :v1 => 'audio-hijack-pro' do
   app 'Audio Hijack Pro.app'
 
   depends_on :macos => %w{
-                          :lion,
+                          :lion
                           :mountain_lion
                          }
 end


### PR DESCRIPTION
There was a typo in this cask, making it unusable.

$ brew cask audit
Error: Cask 'audio-hijack-pro' definition is invalid:
  invalid 'depends_on :macos' value: ":lion,"