### PR TITLE
Update HandbrakeCLI Nightly to v6897svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '6859svn'
-  sha256 '656a716c4c75d325cdfda874db4215ba280355b672c6f19ae5dd01325955d5af'
+  version '6897svn'
+  sha256 '3cfd28e62a517fc5fdecd82b7fe2cb14c3ca3061694b5b0c2b0a1938f1f8b638'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v6897svn built 2015-02-13.