### PR TITLE
Update sublime-text-dev to Build 3070

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'sublime-text-dev' do
-  version '3069'
-  sha256 '96f0ed890839bc554e8fd26b03c9404218feacb4aefbedc0fac9cdd87799654d'
+  version '3070'
+  sha256 'b398456b1ea72a1ae10da6d687612698056ffb76a6e534faa50c90a6a98ecf0c'
 
   url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%20#{version}.dmg"
   name 'Sublime Text'


### PR DESCRIPTION
I notice [sublime-text3][1] and [sublime-text-dev][2] use different formats for `version`.

I'm not sure which is preferred so I've left it in the same format for now.

[1]: https://github.com/caskroom/homebrew-versions/blob/master/Casks/sublime-text3.rb#L2
[2]: https://github.com/caskroom/homebrew-versions/blob/master/Casks/sublime-text-dev.rb#L2