### PR TITLE
Replace Homebrew constants with Hbc variables (fix test suite)

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,10 +28,10 @@ require 'hbc'
 
 # pretend like we installed the cask tap
 project_root = Pathname.new(File.expand_path("#{File.dirname(__FILE__)}/../"))
-taps_dest = HOMEBREW_LIBRARY.join('Taps/caskroom')
+taps_dest = Hbc.homebrew_prefix.join(*%w{Library Taps caskroom})
 
 # create directories
 FileUtils.mkdir_p taps_dest
-HOMEBREW_PREFIX.join('bin').mkdir
+FileUtils.mkdir_p Hbc.homebrew_prefix.join('bin')
 
 FileUtils.ln_s project_root, taps_dest.join('homebrew-cask')


### PR DESCRIPTION
This most likely caused tests in this tap to fail: 
https://github.com/caskroom/homebrew-cask/commit/b40b0c99e1ea43ca3a7126dd099356bf8e7c4720

so I'm fixing it in a very similar manner.