### PR TITLE
Updating Sublime Text 3 Dev to 3074

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'sublime-text-dev' do
-  version '3073'
-  sha256 'eb9a136eefc0d820f3c0400ede2b71f6a19a339c72b771d57bbb59593a6f179e'
+  version '3074'
+  sha256 'c49c915db44bf016ada8bd73a856b44da25fc8b2e905515703e89fb277c53e79'
 
   # rackcdn.com is the official download host per the vendor homepage
   url "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%20#{version}.dmg"


### PR DESCRIPTION
Updating [Sublime Text 3 Development](http://sublimetext.com/3dev) to latest
version 3074. Tested on Yosemite