### PR TITLE
Added chefdk036, which installs ChefDK 0.3.6-1

### DIFF
--- a/Casks/chefdk036.rb
+++ b/Casks/chefdk036.rb
@@ -1,0 +1,34 @@
+cask :v1 => 'chefdk036' do
+  version '0.3.6-1'
+  sha256 '2cbb8a400cf037e51037d75eff3f703358477e976184d11caa9eb27dbd5d58e5'
+
+  # amazonaws is the official download host per the vendor homepage
+  url "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.8/x86_64/chefdk-#{version}.dmg"
+  name 'Chef Development Kit'
+  name 'ChefDK'
+  homepage 'https://downloads.getchef.com/chef-dk/'
+  license :apache
+
+  pkg "chefdk-#{version}.pkg"
+
+  uninstall :pkgutil => 'com.getchef.pkg.chefdk',
+            :delete  => [
+                         '/opt/chefdk/',
+                         '/usr/bin/berks',
+                         '/usr/bin/chef',
+                         '/usr/bin/chef-apply',
+                         '/usr/bin/chef-client',
+                         '/usr/bin/chef-shell',
+                         '/usr/bin/chef-solo',
+                         '/usr/bin/chef-zero',
+                         '/usr/bin/fauxhai',
+                         '/usr/bin/foodcritic',
+                         '/usr/bin/kitchen',
+                         '/usr/bin/knife',
+                         '/usr/bin/ohai',
+                         '/usr/bin/rubocop',
+                         '/usr/bin/shef',
+                         '/usr/bin/strain',
+                         '/usr/bin/strainer',
+                        ]
+end


### PR DESCRIPTION
* ChefDK 0.3.6-1 includes Chef 10 & 11 support
* ChefDK 0.4.0-1 doesn't support Chef 11 Servers