### PR TITLE
[RFC] add dependency on homebrew docker formula for docker-machine?

### DIFF
--- a/Casks/dockermachine010.rb
+++ b/Casks/dockermachine010.rb
@@ -15,5 +15,6 @@ cask :v1 => 'dockermachine010' do
     system '/bin/chmod', '--', '0755', "#{staged_path}/docker-machine_darwin-amd64"
   end
 
+  depends_on :formula => 'docker'
   depends_on :arch => :x86_64
 end


### PR DESCRIPTION
Not sure if we want to add the explicit dependency on homebrew docker in case homebrew-versions users want to use a different version.

Thoughts?