### PR TITLE
Migrate EAP versions of JetBrains IDEs to bundled JDKs

### DIFF
--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,16 +1,12 @@
 cask :v1 => 'intellij-idea-eap' do
   version '141.104.1'
-  sha256 'a59b096cbf012f42dbaf108026de12fa1a3caf16a0f87cbc5f20aa44fa2f2156'
+  sha256 '0246a773b9879bf8076e541d716d1a874b3a42410ddae53342fea21b8b685522'
 
-  url "http://download-cf.jetbrains.com/idea/ideaIU-#{version}.dmg"
+  url "http://download.jetbrains.com/idea/ideaIU-#{version}-custom-jdk-bundled.dmg"
   homepage 'https://confluence.jetbrains.com/display/IDEADEV/IDEA+14.1+EAP'
   license :commercial
 
   app 'IntelliJ IDEA 14 EAP.app'
-
-  postflight do
-    plist_set(':JVMOptions:JVMVersion', '1.6+')
-  end
 
   zap :delete => [
                   '~/Library/Application Support/IntelliJIdea14',

--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'rubymine-eap' do
-  version '140.2694'
-  sha256 '7376d5b04b49e503c203a2b1c9034a690835ea601847753710f3c8ec53566ebb'
+  version '141.96'
+  sha256 '1fb0c817a788dd2e3f01bb7ad942701073b86a66456a905af733984d202b2f3b'
 
-  url "http://download.jetbrains.com/ruby/RubyMine-#{version}.dmg"
+  url "http://download.jetbrains.com/ruby/RubyMine-#{version}-custom-jdk-bundled.dmg"
   homepage 'http://confluence.jetbrains.com/display/RUBYDEV/RubyMine+EAP'
-  license :unknown
+  license :commercial
 
   app 'RubyMine EAP.app'
 end


### PR DESCRIPTION
Oracles poor support for the Java JRE/JDK on recent versions of OS X leads to many problems for the Java-based IDE products from JetBrains, like IntelliJ, RubyMine, PyCharm...

Homebrew cask tried to make it as easy as possible to use any of the JetBrains IDEs with a recent Java JDK/JRE but this resulted in new problems, see caskroom/homebrew-cask#9943.

In the Early Access Program (EAP) versions of its products, JetBrains started to offer an alternative download for OS X that bundles a patched version of Java 8. I want to suggest that we migrate the EAP versions of the formulas in homebrew-versions to the downloads that include the bundled JDK. We only have to change the download link in the formula accordingly.

An alternative approach would be to provide separate formulas for the bundled and traditional versions of the EAP formulas, but since we already have **7 different versions** for the IntelliJ formula in this repo alone and not every user might know that the formula with the bundled jdk is the best pick going forward, I would vote against this approach.

What do you think? If we make the bundled version the default, should we inform the user about it in a caveats?

For reference, here is a list of the current IntelliJ formulas: 

intellij-idea-eap.rb # current early access version
intellij-idea-ce-eap.rb # current early access community version 

intellij-idea-bundled-jdk.rb # current stable version, bundled jdk 
intellij-idea-ce-bundled-jdk.rb # current stable community version, bundled jdk

intellij-idea13.rb  # current version -1
intellij-idea-ce13.rb # current community version -1

intellij-idea12.rb # current version -2