### PR TITLE
Upgrade RubyMine EAP to 141.373

### DIFF
--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -1,10 +1,31 @@
 cask :v1 => 'rubymine-eap' do
-  version '140.2694'
-  sha256 '7376d5b04b49e503c203a2b1c9034a690835ea601847753710f3c8ec53566ebb'
+  version '141.373'
+  sha256 '58cdd199dfe556c00014203d38509ee0682a7516b041dbf0c1edd5a48cc032eb'
 
-  url "http://download.jetbrains.com/ruby/RubyMine-#{version}.dmg"
-  homepage 'http://confluence.jetbrains.com/display/RUBYDEV/RubyMine+EAP'
-  license :unknown
+  url "https://download.jetbrains.com/ruby/RubyMine-#{version}.dmg"
+  name 'RubyMine EAP'
+  homepage 'https://confluence.jetbrains.com/display/RUBYDEV/RubyMine+EAP'
+  license :commercial
 
   app 'RubyMine EAP.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.jetbrains.rubymine-EAP.plist',
+                  '~/Library/Preferences/RubyMine70',
+                  '~/Library/Application Support/RubyMine70',
+                  '~/Library/Caches/RubyMine70',
+                  '~/Library/Logs/RubyMine70',
+                  '/usr/local/bin/mine',
+                 ]
+
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end


### PR DESCRIPTION
- Unify with other IntelliJ-based formulas (see #879)
- Mention formula with bundled JDK as alternative in caveats