### PR TITLE
fix header line in cask to match file name

### DIFF
--- a/Casks/fantastical1.rb
+++ b/Casks/fantastical1.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'fantastical' do
+cask :v1 => 'fantastical1' do
   version '1.3.18'
   sha256 '00069dca92be66b04351cb9b19146c305696fb5970b33e71c1b2d687bbc5f2a8'
   url "http://cdn.flexibits.com/Fantastical_#{version}.zip"


### PR DESCRIPTION
Fixing following error
```
$ brew cask install fantastical1
Error: Cask 'fantastical1' definition is invalid: Bad header line: 'fantastical' does not match file name
```