### PR TITLE
Update HandbrakeCLI Nightly to v7031svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '7010svn'
-  sha256 '1ab548fe2c78fa8115736e0c26091283e2ab990825385012bf652ce3803322ac'
+  version '7031svn'
+  sha256 '29584bd078000dc79c95c56aa9483e7bc5d6cce048349414e4016bcea68ef76d'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v7031svn built 2015-03-31.