### PR TITLE
Upgrade all TorBrowser.app localizations to v4.0.6 and change signing key

### DIFF
--- a/Casks/torbrowser-ar.rb
+++ b/Casks/torbrowser-ar.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ar' do
-  version '4.0.5'
-  sha256 '8b40d171c332b678441b48f9660d741b6c00ce1d045b307c8cbf58ef5200d4ed'
+  version '4.0.6'
+  sha256 '7ce01ad503f8c0d87a60372e6702131b59519c42a3cf11df4db40f97c99659a3'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ar.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-de.rb
+++ b/Casks/torbrowser-de.rb
@@ -4,7 +4,7 @@ cask :v1 => 'torbrowser-de' do
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_de.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-es.rb
+++ b/Casks/torbrowser-es.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-es' do
-  version '4.0.5'
-  sha256 'd8aff934aca6526efa5024dfa78d2a332ca27229f85a591d4d26653ff40bf1af '
+  version '4.0.6'
+  sha256 '0ba68beecf97708b0395582a9946353bb380a17b5f09131e36b60ad2c26081d0'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_es-ES.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-fa.rb
+++ b/Casks/torbrowser-fa.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-fa' do
-  version '4.0.5'
-  sha256 'bd5eaef79b6741498c71220603003a5700e93507c68177a9dbd29a2b1d8443aa'
+  version '4.0.6'
+  sha256 '30ff82bf0c357de63e9f1c571b481ded2a4ab244fbdd538dea72af4fc4b6565f'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_fa.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-fr.rb
+++ b/Casks/torbrowser-fr.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-fr' do
-  version '4.0.5'
-  sha256 '8a1a84b62a8269cd3082c5d61e3a59496d285cc928cccf0ebb2739b82c79da10'
+  version '4.0.6'
+  sha256 'f704525c7f3f2c2fdab9cb6c63a4fe2137882bb287fe41d550fb22cd34f06cca'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_fr.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-it.rb
+++ b/Casks/torbrowser-it.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-it' do
-  version '4.0.5'
-  sha256 '7a82741af135340cac6b2d848cb107e68d17c63b57c433902a60187dda91cba5'
+  version '4.0.6'
+  sha256 '384f2252222ad562156cbe54b3ca5fe37c9cc4345f3ce1c16a226a62f2af9174'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_it.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-ko.rb
+++ b/Casks/torbrowser-ko.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ko' do
-  version '4.0.5'
-  sha256 '690ed6cc6348c39c3abf6a6aef35c70a2346d9053dac798280f43dfb14baf041'
+  version '4.0.6'
+  sha256 'ec62cfc18b5c5e2af89e42e1bb4a7ba5adc06acabbf72b89ce1774a0bedda367'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ko.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-nl.rb
+++ b/Casks/torbrowser-nl.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-nl' do
-  version '4.0.5'
-  sha256 '1ecfaf3de303c101871f1c6a7f77beb71fda4f172bfa333e2962fa44a871b532'
+  version '4.0.6'
+  sha256 '214a5989ff63a655396beea229dd11d7c9be073318c4af0ec08250730c456d87'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_nl.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-pl.rb
+++ b/Casks/torbrowser-pl.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-pl' do
-  version '4.0.5'
-  sha256 '07026b35c5c63d59f8def654c8733bb0965f5a718ee542888ae216beb117757d'
+  version '4.0.6'
+  sha256 'ab2bbff4f6b718bea3c4cf8e1e82bcdfaf780a1797bd1cf0840ea2b92b15c758'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_pl.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-pt.rb
+++ b/Casks/torbrowser-pt.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-pt' do
-  version '4.0.5'
-  sha256 '7e9fac80b53ee0ceff9b01fc5822cef8fbdf157333f2eea8abd2b85ac8345ff1'
+  version '4.0.6'
+  sha256 '35759248e9828bf7a9c4ad08000dc3c23e86ea39a37a27dc14947385e345013e'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_pt-PT.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-ru.rb
+++ b/Casks/torbrowser-ru.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ru' do
-  version '4.0.5'
-  sha256 '8b1e39dd2373390f3d78d36f5a5685aeda85a9f64c861fe609cbd77fd59c414b'
+  version '4.0.6'
+  sha256 '641ed1696e5bc63d56c57cc80ebd0e834d87005933851808b479fd381d7040b5'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ru.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-tr.rb
+++ b/Casks/torbrowser-tr.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-tr' do
-  version '4.0.5'
-  sha256 '61fe632aff65d509fa204e6e602833d012c96f21885256009e2e05549c100d2d'
+  version '4.0.6'
+  sha256 'c0f5db9a33cfe149c8e8b6b3606f002062b3eb5bb65fce09a208cba718c2bb38'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_tr.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-vi.rb
+++ b/Casks/torbrowser-vi.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-vi' do
-  version '4.0.5'
-  sha256 'f379c3a1b79a0703c7b02bc3aba8a2471974ecfb3b5aba8249227a46f083d74b'
+  version '4.0.6'
+  sha256 'e652310b95684916c325bc7c4495f9f205ec84a6bcce58d89151ab92911d9e37'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_vi.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-zh.rb
+++ b/Casks/torbrowser-zh.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-zh' do
-  version '4.0.5'
-  sha256 'bd05b785d59ad613661be5b2260a1212476d03f4b8b4e4df34f481c26e65fa30'
+  version '4.0.6'
+  sha256 '5d04a052cd1ffac48cd859a29385ad46d6dfea52d3828d67b5d8bdf09d67bfd1'
 
   url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_zh-CN.dmg"
   gpg "#{url}.asc",
-      :key_id => '416f061063fee659'
+      :key_id => '4e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 


### PR DESCRIPTION
As was already mentioned in https://github.com/caskroom/homebrew-cask/pull/10200, a different signing key was used for this release including all localizations.