### PR TITLE
Update kicad for OSX to r5572 nightly binary.

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'kicad' do
+cask :v1 => 'kicad-nightly' do
   version 'r5572.20150404-034315'
   sha256 '08bdff67c5c851154b58ff8556c70dbe986f1899e557ff6bf23ab7f658ac696c'
 

--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'kicad' do
+  version 'r5572.20150404-034315'
+  sha256 '08bdff67c5c851154b58ff8556c70dbe986f1899e557ff6bf23ab7f658ac696c'
+
+  url "http://downloads.kicad-pcb.org/osx/kicad-#{version}.dmg"
+  homepage 'http://www.kicad-pcb.org/'
+  license :gpl
+
+  artifact 'kicad', :target => Pathname.new(File.expand_path('~')).join('Library/Application Support/kicad')
+  suite 'Kicad'
+end


### PR DESCRIPTION
 Kicad for OSX now has nightly build binaries uploaded to kicad-pcb.org. This cask installs the latest binary as well as the necesssary Application Support folder.