### PR TITLE
Add unity4 and unity45 versions.

### DIFF
--- a/Casks/unity4.rb
+++ b/Casks/unity4.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'unity4' do
+  version '4.6.4'
+  sha256 'd5d840f30d0987b3aef29dc3b651141cb5fb77fc3c28405b5ff667e03b01360a'
+
+  url "http://download.unity3d.com/download_unity/unity-#{version}.dmg"
+  homepage 'http://unity3d.com/unity/'
+  license :commercial
+
+  pkg 'Unity.pkg'
+
+  uninstall :pkgutil => 'com.unity3d.*'
+end

--- a/Casks/unity45.rb
+++ b/Casks/unity45.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'unity45' do
+  version '4.5.5'
+  sha256 'e42d3b8e3bc3fbc7448bb06b5210c1c0687ba3f784eb947b4586b9f129c6b0d4'
+
+  url "http://download.unity3d.com/download_unity/unity-#{version}.dmg"
+  homepage 'http://unity3d.com/unity/'
+  license :commercial
+
+  pkg 'Unity.pkg'
+
+  uninstall :pkgutil => 'com.unity3d.*'
+end


### PR DESCRIPTION
Now that Unity 5 is out, I thought a version for Unity 4.x would be good. Also a version for Unity 4.5.x because 4.6 introduced some backwards incompatible changes and others might also have projects that haven't yet been updated.