### PR TITLE
Add Reflector (v1)

### DIFF
--- a/Casks/reflector1.rb
+++ b/Casks/reflector1.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'reflector1' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://download.airsquirrels.com/Reflector/Mac/Reflector.dmg'
+  appcast 'https://updates.airsquirrels.com/Reflector/Mac/Reflector.xml'
+  name 'Reflector'
+  homepage 'http://www.airsquirrels.com/reflector/'
+  license :commercial
+
+  depends_on :macos => '>= :snow_leopard'
+
+  app 'Reflector.app'
+end


### PR DESCRIPTION
Squirrels released Reflector 2 on 2015-04-14 (a paid upgrade). Therefore adding v1 to the homebrew-versions repo.