### PR TITLE
Update HandbrakeCLI Nightly to v7105svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '7073svn'
-  sha256 '50a374f8b8984735e8f2b49d5be78f2dc713d433e3982ce539697c31fea190de'
+  version '7105svn'
+  sha256 '302b9310b11a7397fcf68b608d62ad592d71241c357638e346883711d41fa014'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'http://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v7105svn built 2015-04-20.