### PR TITLE
Change single to double quotes in mindjet-mindmanager url

### DIFF
--- a/Casks/mindjet-mindmanager9.rb
+++ b/Casks/mindjet-mindmanager9.rb
@@ -2,7 +2,7 @@ cask :v1 => 'mindjet-mindmanager9' do
   version '9.6.510'
   sha256 '23e2e2e3f712bc9d58b4a826abc3fb50ffac0134e93c4db9e055fa4874fe12d1'
 
-  url 'http://download.mindjet.com/Mindjet_MindManager_Mac_#{version}.dmg'
+  url "http://download.mindjet.com/Mindjet_MindManager_Mac_#{version}.dmg"
   name 'Mindjet MindManager 9'
   homepage 'http://www.mindjet.com/mindmanager/'
   license :commercial


### PR DESCRIPTION
I found this error just before the previous commit was merged. 
  https://github.com/caskroom/homebrew-versions/pull/935
Have confirmed that install works correctly.  