### PR TITLE
Upgrade all TorBrowser.app localizations to v4.5

### DIFF
--- a/Casks/torbrowser-ar.rb
+++ b/Casks/torbrowser-ar.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ar' do
-  version '4.0.8'
-  sha256 '817c7a62e3c2643a9b6ee964a2cd8f6e03f1079270d5ac140b2191546db23e38'
+  version '4.5'
+  sha256 'f36db7b68966079ca68eac548ebe7b7e8a364d808ae68132c09dce9d6553c9f9'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ar.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_ar.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-de.rb
+++ b/Casks/torbrowser-de.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-de' do
-  version '4.0.8'
-  sha256 'ae8b4574cd937b96e2ba4826a44c5a0cdb890e9ed91e9feb18e3736257bce9c1'
+  version '4.5'
+  sha256 'f0f421d87512140adbbff5de64ff27837fdd52678e9a11776112204f4009c7e1'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_de.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_de.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-es.rb
+++ b/Casks/torbrowser-es.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-es' do
-  version '4.0.8'
-  sha256 '8a361b4358c5072e033013f373ce8dd4a9a56d8edb782f0d89072e5a48cec084'
+  version '4.5'
+  sha256 '12db03acee9d952e46526a35be01176e9e246b0d3b9bbc7e31ca43b2217e5eed'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_es-ES.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_es-ES.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-fa.rb
+++ b/Casks/torbrowser-fa.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-fa' do
-  version '4.0.8'
-  sha256 'e8bba0a5056e56e08e8bb755781ab1c24261d406c8d369c3ce165b5388146ece'
+  version '4.5'
+  sha256 '5d46931da89399c6c87b7afa8da4a9f381a698e3c4b51541929eec35de40e282'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_fa.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_fa.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-fr.rb
+++ b/Casks/torbrowser-fr.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-fr' do
-  version '4.0.8'
-  sha256 '748043147e1fc3603fe816963ba1dd4b692375e237f7d832ec0975d9dcd5f853'
+  version '4.5'
+  sha256 '85c415c4fab398aaaff204343c3a05b447dbafccf1fbbc2a61f5f83a76b329d1'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_fr.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_fr.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-it.rb
+++ b/Casks/torbrowser-it.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-it' do
-  version '4.0.8'
-  sha256 'c29d6e796994880d1e0ff020540bf7b527d8684a48f1517d07c6278ef0d605cc'
+  version '4.5'
+  sha256 '2a62042a594c346fb7c565aa4661a475373cc310859c004e40e7a0f621a4b53f'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_it.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_it.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-ko.rb
+++ b/Casks/torbrowser-ko.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ko' do
-  version '4.0.8'
-  sha256 'eaed23db169bdc9bdbe63186e7dc5190b867f9bba6f3b6e18c57da09c3d13da1'
+  version '4.5'
+  sha256 '30d0a51e92a2dbd045dd4e08d7aefad364df38a9b081a7423a868070c625998d'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ko.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_ko.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-nl.rb
+++ b/Casks/torbrowser-nl.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-nl' do
-  version '4.0.8'
-  sha256 '64b45bd0cb6d01d0d819516c4e0210487b8bf53e67167af9e22ef37b8a99e3c4'
+  version '4.5'
+  sha256 'ed351f032d93b8cdb4e2e4d4af6ee6ca400864b8e7e7be9f861da549e42beb03'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_nl.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_nl.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-pl.rb
+++ b/Casks/torbrowser-pl.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-pl' do
-  version '4.0.8'
-  sha256 '32e9b702bdd9c4334662d5917c7f16f8496b4cc823f162301328217a91459a7c'
+  version '4.5'
+  sha256 '133e9e11be4e0ba48cc42cfc3929a9fd18073467a7a7dbaa0f0e61952458b2cb'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_pl.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_pl.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-pt.rb
+++ b/Casks/torbrowser-pt.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-pt' do
-  version '4.0.8'
-  sha256 '3ba7e8daa1fbcbdb0c1d2fbd7a6164a3538bc406aa07a7a5849918ee90be2929'
+  version '4.5'
+  sha256 'f87f6b5bc27b4c47bc05480a056f734ab10a7fe8f515468585712e7cc147d3b8'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_pt-PT.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_pt-PT.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-ru.rb
+++ b/Casks/torbrowser-ru.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-ru' do
-  version '4.0.8'
-  sha256 'f8ce2c005244c02e543f1bed4f5c19f7177e0ad8454e8f32552f6ba37bba620e'
+  version '4.5'
+  sha256 '2bad98adaeef9beab8c47cb6e881efba0f865184a8f51ae04410f8d46f9d1891'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_ru.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_ru.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-tr.rb
+++ b/Casks/torbrowser-tr.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-tr' do
-  version '4.0.8'
-  sha256 '13bf94925954cb9ce4b128feadb76f909c292d9ee428a2e820577bfa03b0f381'
+  version '4.5'
+  sha256 '9cf139c9f9a545ade63a79faad49067462d54e8e056b81a7c5fc60036db8b5a5'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_tr.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_tr.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-vi.rb
+++ b/Casks/torbrowser-vi.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-vi' do
-  version '4.0.8'
-  sha256 '8c490e3062c977c183cdf29c9d6ad4ff2f9b80d3003897cc1308604fe550e4d9'
+  version '4.5'
+  sha256 '008bdab85c6e17888702b5f537c8150ec21d0312215696c22ff3f7a7db06ae0e'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_vi.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_vi.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 

--- a/Casks/torbrowser-zh.rb
+++ b/Casks/torbrowser-zh.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'torbrowser-zh' do
-  version '4.0.8'
-  sha256 '661fb573ddde8a656e346108635e714b7be48a5165d80955e8d2235dada6cd2b'
+  version '4.5'
+  sha256 'f6a6a8f592aa4c5ca7f424033f791f34cf4b96c89f1182b97c02584652b8070b'
 
-  url "https://www.torproject.org/dist/torbrowser/#{version}/TorBrowser-#{version}-osx32_zh-CN.dmg"
+  url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_zh-CN.dmg"
   gpg "#{url}.asc",
-      :key_id => '4e2c6e8793298290'
+      :key_id => 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   license :oss
 


### PR DESCRIPTION
As was already mentioned in https://github.com/caskroom/homebrew-cask/pull/10884, all localizations were switched to 64-bit builds in v4.5. GPG long key IDs were also replaced by the full fingerprints.