### PR TITLE
Add Omnipresence beta track (currently 1.4)

### DIFF
--- a/Casks/omnipresence-beta.rb
+++ b/Casks/omnipresence-beta.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'omnipresence-beta' do
+  version '1.4.x-r232733'
+  sha256 'c21289a7a90b4efc8f0eb9cf3775bb4bb19145688229cd886718881b2c34377a'
+
+  url "http://omnistaging.omnigroup.com/omnipresence/releases/OmniPresence-#{version}-Test.dmg"
+  name 'OmniPresence Beta'
+  homepage 'http://www.omnigroup.com/omnipresence'
+  license :commercial
+
+  app 'OmniPresence.app'
+
+  depends_on :macos => '>= :yosemite'
+end


### PR DESCRIPTION
This creates a new cask for the Omnipresence beta (at v1.4 at the
time of creation).