### PR TITLE
Fixing version, sha256, and url for libreoffice43 cask

### DIFF
--- a/Casks/libreoffice43.rb
+++ b/Casks/libreoffice43.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'libreoffice43' do
-  version '4.3.6'
-  sha256 '02b78ed4e58090af93782fa6986493c115e92eae9bbc878c26cbd12633735445'
+  version '4.3.7'
+  sha256 'ad8cb940218ac52e240a7e26e6b079da31eb6f6205da732802b445d474353e8f'
 
-  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86/LibreOffice_#{version}_MacOS_x86.dmg"
+  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   name 'LibreOffice'
   homepage 'https://www.libreoffice.org/'
   license :mpl


### PR DESCRIPTION
This cask initially mirrored the cask in homebrew-cask but it turns out version 4.3.6 is no longer hosted, it should actually be 4.3.7. I've updated this cask and I will create a separate pull request to update homebrew-cask.