### PR TITLE
Update HandbrakeCLI Nightly to v7201svn

### DIFF
--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'handbrakecli-nightly' do
-  version '7168svn'
-  sha256 '297b32cb22386bcbbddfc4cb1cdf4048e17aaa583f9fae0792292b971231c2ec'
+  version '7201svn'
+  sha256 'd71fbf6905e19d4b3d3e0982a05e1fb985a008ec6c18a1d620d2bb6f47999d43'
 
   url "http://download.handbrake.fr/nightly/HandBrake-#{version}-MacOSX.6_CLI_x86_64.dmg"
   homepage 'https://handbrake.fr'


### PR DESCRIPTION
HandBrakeCLI Nightly v7201svn built 2015-05-17.