### PR TITLE
Fixed URL in oclint-nightly and parallels8 Casks

### DIFF
--- a/Casks/oclint-nightly.rb
+++ b/Casks/oclint-nightly.rb
@@ -2,7 +2,7 @@ cask :v1 => 'oclint-nightly' do
   version '0.9.dev.02251e4'
   sha256 'b37aa6e04fe7545d7daf7a93c0afd49998946ee918ea5bb1782dd17e0deb4c2f'
 
-  url 'http://archives.oclint.org/nightly/oclint-#{version}-x86_64-darwin-14.0.0.tar.gz'
+  url "http://archives.oclint.org/nightly/oclint-#{version}-x86_64-darwin-14.0.0.tar.gz"
   homepage 'http://oclint.org'
   license :unknown
 

--- a/Casks/parallels8.rb
+++ b/Casks/parallels8.rb
@@ -2,7 +2,7 @@ cask :v1 => 'parallels8' do
   version '8.0.18619.1001606'
   sha256 '5b87b2c240e71176cad5097ed7f1928598c9e001da4ad1d8a4516708908c4305'
 
-  url 'http://download.parallels.com/desktop/v8/update3.hotfix1/ParallelsDesktop-#{version}.dmg'
+  url "http://download.parallels.com/desktop/v8/update3.hotfix1/ParallelsDesktop-#{version}.dmg"
   homepage 'http://kb.parallels.com/en/114623'
   license :closed
 


### PR DESCRIPTION
Upon running brew cask audit this morning, the following casks failed the audit.

> Error: Cask 'oclint-nightly' definition is invalid: 'url' stanza failed with: bad URI(is not URI?): http://archives.oclint.org/nightly/oclint-#{version}-x86_64-darwin-14.0.0.tar.gz

> Error: Cask 'parallels8' definition is invalid: 'url' stanza failed with: bad URI(is not URI?): http://download.parallels.com/desktop/v8/update3.hotfix1/ParallelsDesktop-#{version}.dmg

The following URLs originally had single quotes, but when using the syntax of #{version} in the URL, it should be double quotes.
