### PR TITLE
Update Dash beta to 2.3.0

### DIFF
--- a/Casks/dash-beta.rb
+++ b/Casks/dash-beta.rb
@@ -1,10 +1,12 @@
 cask :v1 => 'dash-beta' do
-  version '2.2.1'
-  sha256 '2a652e850c1d9bd99977b6bc2b842ff7eeb07ba401a1bceab43d6998a60f6756'
+  version '2.3.0'
+  sha256 '5434eb1eb8a1429d4e1e6bcdb5b76a7b5930ceab1bbd94f41cb6a41e454e7512'
 
-  url 'https://dl0tgz6ee3upo.cloudfront.net/production/app/builds/002/376/285/original/e1c44c93cf9c3d49ff42b6349e56630c/Dash_Beta.app.zip'
+  # cloudfront.net is the official download host per the Dash beta page:
+  # https://rink.hockeyapp.net/download/ad59cd8c60434509b4b58951e1b7b483
+  url 'https://dl0tgz6ee3upo.cloudfront.net/production/app/builds/004/633/802/original/537af3eefba4513c44aedbab7606c3bf/Dash_Beta.app.zip'
   homepage 'http://kapeli.com/dash'
-  license :unknown
+  license :commercial
 
   app 'Dash Beta.app'
 end


### PR DESCRIPTION
This commit updates the version, license and sha256 stanzas, and also adds
a note to explain the source of the download URL.