### PR TITLE
Fix checksum in quicktime-player7 cask

### DIFF
--- a/Casks/quicktime-player7.rb
+++ b/Casks/quicktime-player7.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'quicktime-player7' do
   version '7.6.6'
-  sha256 '704b5eee2ad953f301a652033db317e6997b9e5910db4b1f8d511b04ab62f2bc'
+  sha256 '954c2376d2d747821614dc802249cf3c708a4792abed08945d7261de3894e759'
 
   url "http://support.apple.com/downloads/DL923/en_US/QuickTimePlayer#{version}_SnowLeopard.dmg"
   homepage 'http://support.apple.com/kb/dl923'


### PR DESCRIPTION
Fixes incorrect sha256 checksum in the quicktime-player7 cask. Was getting this when installing perian, since it was a dependency.

```
tehnix% brew cask install perian                               
==> Caveats
perian has been officially discontinued upstream.
It may stop working correctly (or at all) in recent versions of OS X.

==> Satisfying dependencies
==> Installing Cask dependencies: caskroom/versions/quicktime-player7
caskroom/versions/quicktime-player7 ...
==> Downloading http://support.apple.com/downloads/DL923/en_US/QuickTimePlayer7.6.6_SnowLeopard.dmg
######################################################################## 100.0%
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 704b5eee2ad953f301a652033db317e6997b9e5910db4b1f8d511b04ab62f2bc
Actual: 954c2376d2d747821614dc802249cf3c708a4792abed08945d7261de3894e759
File: /Library/Caches/Homebrew/quicktime-player7-7.6.6.dmg
To retry an incomplete download, remove the file above.
```