### PR TITLE
Added Adobe CS6 Collection Editions & Language Versions

### DIFF
--- a/Casks/adobe-design-standard-cs6-de.rb
+++ b/Casks/adobe-design-standard-cs6-de.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-de' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-de_DE.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-de_DE.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6-es.rb
+++ b/Casks/adobe-design-standard-cs6-es.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-es' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-es_ES.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-es_ES.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6-fr.rb
+++ b/Casks/adobe-design-standard-cs6-fr.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-fr' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-fr_FR.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-fr_FR.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6-it.rb
+++ b/Casks/adobe-design-standard-cs6-it.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-it' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-it_IT.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-it_IT.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6-ja.rb
+++ b/Casks/adobe-design-standard-cs6-ja.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-ja' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS16.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-ja_JP.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-ja_JP.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6-nl.rb
+++ b/Casks/adobe-design-standard-cs6-nl.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6-nl' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-nl_NL.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-nl_NL.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-standard-cs6.rb
+++ b/Casks/adobe-design-standard-cs6.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-standard-cs6' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSGN/CS6/osx10/DesignStandard_CS6_LS16.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design Standard' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-en_US.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/uninstall-en_US.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-de.rb
+++ b/Casks/adobe-design-web-premium-cs6-de.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-de' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-de_DE.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-de_DE.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-es.rb
+++ b/Casks/adobe-design-web-premium-cs6-es.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-es' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-es_ES.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-es_ES.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-fr.rb
+++ b/Casks/adobe-design-web-premium-cs6-fr.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-fr' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-fr_FR.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-fr_FR.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-it.rb
+++ b/Casks/adobe-design-web-premium-cs6-it.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-it' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-it_IT.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-it_IT.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-ja.rb
+++ b/Casks/adobe-design-web-premium-cs6-ja.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-ja' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS16.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-ja_JP.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-ja_JP.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-design-web-premium-cs6-nl.rb
+++ b/Casks/adobe-design-web-premium-cs6-nl.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-design-web-premium-cs6-nl' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/DSST/CS6/osx10/DesignWebPremium_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Design and Web Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-nl_NL.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/uninstall-nl_NL.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-de.rb
+++ b/Casks/adobe-master-collection-cs6-de.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-de' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-de_DE.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-de_DE.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-es.rb
+++ b/Casks/adobe-master-collection-cs6-es.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-es' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-es_ES.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-es_ES.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-fr.rb
+++ b/Casks/adobe-master-collection-cs6-fr.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-fr' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-fr_FR.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-fr_FR.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-it.rb
+++ b/Casks/adobe-master-collection-cs6-it.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-it' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-it_IT.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-it_IT.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-ja.rb
+++ b/Casks/adobe-master-collection-cs6-ja.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-ja' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS16.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-ja_JP.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-ja_JP.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6-nl.rb
+++ b/Casks/adobe-master-collection-cs6-nl.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6-nl' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS4.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-nl_NL.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-nl_NL.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-master-collection-cs6.rb
+++ b/Casks/adobe-master-collection-cs6.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-master-collection-cs6' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STAM/CS6/osx10/MasterCollection_CS6_LS16.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Master Collection' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-en_US.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-en_US.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6-de.rb
+++ b/Casks/adobe-production-premium-cs6-de.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6-de' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-de_DE.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-de_DE.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6-es.rb
+++ b/Casks/adobe-production-premium-cs6-es.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6-es' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-es_ES.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-es_ES.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6-fr.rb
+++ b/Casks/adobe-production-premium-cs6-fr.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6-fr' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-fr_FR.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-fr_FR.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6-it.rb
+++ b/Casks/adobe-production-premium-cs6-it.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6-it' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-it_IT.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-it_IT.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6-ja.rb
+++ b/Casks/adobe-production-premium-cs6-ja.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6-ja' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-ja_JP.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-ja_JP.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end

--- a/Casks/adobe-production-premium-cs6.rb
+++ b/Casks/adobe-production-premium-cs6.rb
@@ -1,0 +1,33 @@
+cask :v1 => 'adobe-production-premium-cs6' do
+  version :latest
+  sha256 :no_check
+
+  # This Cask only works for Adobe dmgs containing the deploy folder,
+  # i.e. the Adobe Collections, not the single Product Installers!
+
+  # For correct download URL see links provided at
+  # https://helpx.adobe.com/x-productkb/policy-pricing/cs6-product-downloads.html
+
+  url 'http://trials2.adobe.com/AdobeProducts/STVD/CS6/osx10/ProductionPremium_CS6_LS7.dmg',
+    :user_agent => :fake,
+    :cookies => { 'MM_TRIALS' => '1234' }
+  name 'Adobe CS6 Production Premium' # name must exactly match directory in dmg!
+  homepage 'http://www.adobe.com/mena_en/products/creativesuite.html'
+  license :commercial
+
+  # staged_path not available in Installer/Uninstall Stanza, workaround by nesting with preflight/postflight
+  # see https://github.com/caskroom/homebrew-cask/pull/8887
+  # and https://github.com/caskroom/homebrew-versions/pull/296
+
+  preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-en_US.xml"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/killall', '-kill', 'SafariNotificationAgent'
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/uninstall-en_US.xml"
+  end
+
+  caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'
+end


### PR DESCRIPTION
Here they are. Sadly much work, as I am still waiting for any kind of response to https://github.com/caskroom/homebrew-cask/issues/11366. Would have been only 45% of the work now needed.

Manually tested many of them in fresh VMs, but not all due to the huge amount of download volume and time needed. But I ensured they are logically correct. That said, I tested all of the English and German versions and some of the Spanish and French versions.