### PR TITLE
Update Omnifocus Beta to 2.2.1

### DIFF
--- a/Casks/omnifocus-beta.rb
+++ b/Casks/omnifocus-beta.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'omnifocus-beta' do
-  version '2.2.x-r234144'
-  sha256 '934fb59cf57e6594c2e26dda85f3594fe04c5cd0236c7088bd534ca2186c141b'
+  version '2.2.x-r235338'
+  sha256 '56196c7d5f09b84ea8cb68901f165a00238c9016e2d94539babc04a3f6ae79bd'
 
-  url "http://omnistaging.omnigroup.com/omnifocus-2/releases/OmniFocus-#{version}-Test.dmg"
+  url "http://omnistaging.omnigroup.com/omnifocus-2.2.x/releases/OmniFocus-#{version}-Test.dmg"
   name 'OmniFocus'
-  homepage 'http://omnistaging.omnigroup.com/omnifocus-2/'
+  homepage 'http://omnistaging.omnigroup.com/omnifocus-2.2.x/'
   license :commercial
 
   app 'OmniFocus.app'


### PR DESCRIPTION
This commit updates the version and sha256 stanzas. It also changes
the download and homepage URLs as they have been tweaked for the
2.2.x series of betas.