### PR TITLE
wireshark-dev: 1.99.6

### DIFF
--- a/Casks/wireshark-dev.rb
+++ b/Casks/wireshark-dev.rb
@@ -1,10 +1,10 @@
 cask :v1 => 'wireshark-dev' do
-  version '1.99.2'
-  sha256 '8d05f1cdca29369f31762380fb655fe4cb837ad860b18ef6bf0384499a9e7104'
+  version '1.99.6'
+  sha256 'b73cb3684dd3270a6a4051dbb3feee284c37f87729a42448bd7016b498da494a'
 
   url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   homepage 'http://www.wireshark.org'
-  license :unknown
+  license :gpl
 
   pkg "Wireshark #{version} Intel 64.pkg"
   uninstall :pkgutil => 'org.wireshark.*'


### PR DESCRIPTION
Update `wireshark-dev` to 1.99.6 (and add the correct [license](https://www.wireshark.org/faq.html#q1.1))