### PR TITLE
Updated webstorm-bundled-jdk to 10.0.4

### DIFF
--- a/Casks/webstorm-bundled-jdk.rb
+++ b/Casks/webstorm-bundled-jdk.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'webstorm-bundled-jdk' do
-  version '10.0.3'
-  sha256 'bba78b0123e0ce40a1f99079e91b4edd8afdbbc19b9260745501f52cbdad40bb'
+  version '10.0.4'
+  sha256 '539e8505c47e1f96349316ebc6441ef8f87c8b461fd6db88608a2269ba95246d'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version}-custom-jdk-bundled.dmg"
   name 'WebStorm'


### PR DESCRIPTION
As stated above I've updated the webstorm-bundled-jdk cask to the latest version (10.0.4).