### PR TITLE
Improve cask for AppCode EAP

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,10 +1,32 @@
 cask :v1 => 'appcode-eap' do
-  version '3.2.0'
-  sha256 'fa78dc8e2a7430e7173cecec7b6e369f3d2cf442facd7ee0df46592788b00715'
+  version '141.1399.2'
+  sha256 '2dd8a0a9246067ae6e092b9934cbadac6730a74fe400c8929b09792a0c0cda83'
 
-  url 'http://download.jetbrains.com/objc/AppCode-141.1689.23.dmg'
-  homepage 'http://confluence.jetbrains.com/display/OBJC/AppCode+EAP'
+  url "https://download.jetbrains.com/objc/AppCode-#{version}.dmg"
+  name 'AppCode'
+  homepage 'https://confluence.jetbrains.com/display/OBJC/AppCode+EAP'
   license :commercial
 
   app 'AppCode EAP.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.jetbrains.AppCode-EAP.plist',
+                  '~/Library/Preferences/AppCode32',
+                  '~/Library/Application Support/AppCode32',
+                  '~/Library/Caches/AppCode32',
+                  '~/Library/Logs/AppCode32',
+                 ]
+
+  conflicts_with :cask => 'appcode-eap-bundled-jdk'
+
+  caveats <<-EOS.undent
+    #{token} requires Java 6 like any other IntelliJ-based IDE.
+    You can install it with
+
+      brew cask install caskroom/homebrew-versions/java6
+
+    The vendor (JetBrains) doesn't support newer versions of Java (yet)
+    due to several critical issues, see details at
+    https://intellij-support.jetbrains.com/entries/27854363
+  EOS
 end


### PR DESCRIPTION
Unify this cask and the `appcode-eap-bundled-jdk` cask from #1070 as part of #879