### PR TITLE
Android Studio Canary 1.3 Preview 5

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'android-studio-canary' do
-  version '1.3.0.2'
-  sha256 '9c8eece980d4b785bdaf1254376e98397f866dc6f4937c0d14823bfb19b760d5'
+  version '1.3.0.4'
+  sha256 'cdb7d45fc8ed890ad9e51eebdf3c86b6784c461049a83e50be3cc8704c1f969d'
 
-  url "http://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-ide-141.1989493-mac.zip"
+  url "http://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-ide-141.2017176-mac.zip"
   homepage 'http://tools.android.com/download/studio'
   license :apache
 


### PR DESCRIPTION
While it's not been announced yet, it's available in the Canary channel. The fourth preview has been out for a while.