### PR TITLE
Updated Little Snitch nightly to version 3.6-nightly-(4348)

### DIFF
--- a/Casks/little-snitch-nightly.rb
+++ b/Casks/little-snitch-nightly.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'little-snitch-nightly' do
-  version '3.4-nightly-(4208)'
-  sha256 'e3b91297945dcaaf7707f8f81301635012d56ea5342d817e21239d9b3f0945e7'
+  version '3.6-nightly-(4348)'
+  sha256 '05db23d4dc754eda32dcac727fee320a6bb272ff1f7b76f9ad527ace91679441'
 
   url "http://www.obdev.at/downloads/littlesnitch/nightly/LittleSnitch-#{version}.dmg"
   homepage 'http://www.obdev.at/products/littlesnitch/index.html'


### PR DESCRIPTION
Rolled the version number forward, and updated the sha256.