### PR TITLE
Update AppCode EAP to latest build

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'appcode-eap' do
   version '3.2.0'
-  sha256 '2dd8a0a9246067ae6e092b9934cbadac6730a74fe400c8929b09792a0c0cda83'
+  sha256 'fa78dc8e2a7430e7173cecec7b6e369f3d2cf442facd7ee0df46592788b00715'
 
-  url 'http://download.jetbrains.com/objc/AppCode-141.1399.2.dmg'
+  url 'http://download.jetbrains.com/objc/AppCode-141.1689.23.dmg'
   homepage 'http://confluence.jetbrains.com/display/OBJC/AppCode+EAP'
   license :commercial
 


### PR DESCRIPTION
This commit updates the sha256 and url stanzas. The version of the
app itself has not changed.