### PR TITLE
Updated to latest and fixed URL schema

### DIFF
--- a/Casks/blender-beta.rb
+++ b/Casks/blender-beta.rb
@@ -1,8 +1,7 @@
 cask :v1 => 'blender-beta' do
-  version '2.75-rc1'
-  sha256 '6609f4329bca8535a8640696e27a50d8ab68798d0a7ae63873141246c7b3baca'
-
-  url 'http://download.blender.org/release/Blender2.75/blender-#{version}-OSX_10.6-x86_64.zip'
+  version '2.75-80f344f'
+  sha256 '5815d43f9c6f22f90a7a78eed3076e93a9ea0dfa377251ec28ed85f127f03a55'
+  url "https://builder.blender.org/download/blender-#{version}-OSX-10.6-x86_64.zip"
   name 'Blender'
   homepage 'https://www.blender.org/'
   license :gpl

--- a/Casks/blender-beta.rb
+++ b/Casks/blender-beta.rb
@@ -1,6 +1,7 @@
 cask :v1 => 'blender-beta' do
   version '2.75-80f344f'
   sha256 '5815d43f9c6f22f90a7a78eed3076e93a9ea0dfa377251ec28ed85f127f03a55'
+
   url "https://builder.blender.org/download/blender-#{version}-OSX-10.6-x86_64.zip"
   name 'Blender'
   homepage 'https://www.blender.org/'

--- a/Casks/blender-daily.rb
+++ b/Casks/blender-daily.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'blender-beta' do
+cask :v1 => 'blender-daily' do
   version '2.75-80f344f'
   sha256 '5815d43f9c6f22f90a7a78eed3076e93a9ea0dfa377251ec28ed85f127f03a55'
 


### PR DESCRIPTION
Updated blender-beta to latest daily build and fixed incorrect URL schema (as url was in single quotes but uses #{version})