### PR TITLE
microsoft-office-preview (new cask)

### DIFF
--- a/Casks/microsoft-office-preview.rb
+++ b/Casks/microsoft-office-preview.rb
@@ -1,0 +1,31 @@
+cask :v1 => 'microsoft-office-preview' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://officecdn.microsoft.com/pr/OfficeMac/OfficePreview.pkg'
+  name 'Microsoft Office 2016 Preview'
+  homepage 'https://products.office.com/en-us/mac/mac-preview'
+  license :commercial
+
+  pkg 'OfficePreview.pkg'
+
+  uninstall :pkgutil => [
+                         'com.microsoft.package.Fonts',
+                         'com.microsoft.package.Frameworks',
+                         'com.microsoft.package.Microsoft_AutoUpdate.app',
+                         'com.microsoft.package.Microsoft_Excel.app',
+                         'com.microsoft.package.Microsoft_OneNote.app',
+                         'com.microsoft.package.Microsoft_Outlook.app',
+                         'com.microsoft.package.Microsoft_PowerPoint.app',
+                         'com.microsoft.package.Microsoft_Word.app',
+                         'com.microsoft.package.Proofing_Tools',
+                         'com.microsoft.pkg.licensing'
+                        ],
+             :delete => [
+                         '/Applications/Microsoft Excel.app',
+                         '/Applications/Microsoft OneNote.app',
+                         '/Applications/Microsoft Outlook.app',
+                         '/Applications/Microsoft PowerPoint.app',
+                         '/Applications/Microsoft Word.app',
+                        ]
+end


### PR DESCRIPTION
This is the [Microsoft Office 2016 for Mac Preview](https://products.office.com/en-us/mac/mac-preview). It will receive frequent updates until a stable build is released later this year.

I wasn't sure which support folders were used in this version but not Office 2011, so I left out the `zap` stanza for now.

Refs caskroom/homebrew-cask#12448