### PR TITLE
Update iTerm2 Beta to 2.9.20150626

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'iterm2-beta' do
-  version '2.1.1'
-  sha256 'b8f1bbd11cdb3e26fd9fab6971c28ebeb422361b2cc5fd6e4a843836d5dedeb0'
+  version '2.9.20150626'
+  sha256 '18cf11393ed81d351d739257185bc33414c440c4281e576f9d0b54405970f902'
 
-  url 'https://iterm2.com/downloads/beta/iTerm2-2_1_1.zip'
+  url 'https://iterm2.com/downloads/beta/iTerm2-2_9_20150626.zip'
   homepage 'http://www.iterm2.com/'
   license :oss
 


### PR DESCRIPTION
iTerm 2 Version 3 Beta
[view changes](https://iterm2.com/version3.html)