### PR TITLE
Add Revisions beta version 2.1

### DIFF
--- a/Casks/revisions-beta.rb
+++ b/Casks/revisions-beta.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'revisions-beta' do
+  version '2.1-r928'
+  sha256 'fb91a2dd876becd034445813bac037cf99cb4f3691f2d140c6425fe52427789f'
+
+  url "https://revisionsapp.com/downloads/revisions-#{version}-public-beta.dmg"
+  name 'Revisions'
+  homepage 'https://revisionsapp.com/'
+  license :commercial
+
+  app 'Revisions.app'
+end


### PR DESCRIPTION
This commit adds a new cask for the Revisions app. I haven't included
a comment to say where the download link was obtained as it is from a
public page on the vendor site: https://www.revisionsapp.com/releases