### PR TITLE
Add Vagrant 1.7.2 and Virtualbox 4.3.30-101610

### DIFF
--- a/Casks/vagrant172.rb
+++ b/Casks/vagrant172.rb
@@ -12,4 +12,3 @@ cask :v1 => 'vagrant172' do
   uninstall :script => { :executable => 'uninstall.tool', :input => %w[Yes] },
             :pkgutil => 'com.vagrant.vagrant'
 end
-

--- a/Casks/vagrant172.rb
+++ b/Casks/vagrant172.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'vagrant172' do
+  version '1.7.2'
+  sha256 '78d02afada2f066368bd0ce1883f900f89b6dc20f860463ce125e7cb295e347c'
+
+  # bintray.com is the official download host per the vendor homepage
+  url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
+  homepage 'http://www.vagrantup.com'
+  license :mit
+
+  pkg 'Vagrant.pkg'
+
+  uninstall :script => { :executable => 'uninstall.tool', :input => %w[Yes] },
+            :pkgutil => 'com.vagrant.vagrant'
+end
+

--- a/Casks/virtualbox4330101610.rb
+++ b/Casks/virtualbox4330101610.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'virtualbox4330101610' do
+  version '4.3.30-101610'
+  sha256 '1616b058f232683e74ecd85ed60aebf3c27901893b371596e66e9080a1493ccb'
+
+  url "http://download.virtualbox.org/virtualbox/#{version.split('-')[0]}/VirtualBox-#{version}-OSX.dmg"
+  homepage 'http://www.virtualbox.org'
+  license :unknown
+
+  pkg 'VirtualBox.pkg'
+  uninstall :script => { :executable => 'VirtualBox_Uninstall.tool', :args => %w[--unattended] }
+end


### PR DESCRIPTION

### Problem
Virtualbox 5.0 was released and in response Vagrant released version 1.7.3 to maintain "current" support, but the package is still relatively broken. The latest versioned package for Vagrant is 1.7.1 and the latest for Virtualbox is 4.3.28, both outdated.

### Solution
* Package Vagrant 1.7.2
* Package Virtualbox 4.3.30