### PR TITLE
Add VirtualBox 4.3.26-98988 as virtualbox432698988

### DIFF
--- a/Casks/virtualbox432698988.rb
+++ b/Casks/virtualbox432698988.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'virtualbox432698988' do
+  version '4.3.26-98988'
+  sha256 '3efddddbed7648d5bdfe11a7a341591d05135cda7298792d93334a5faa83d124'
+
+  url "http://download.virtualbox.org/virtualbox/#{version.split('-')[0]}/VirtualBox-#{version}-OSX.dmg"
+  homepage 'http://www.virtualbox.org'
+  license :unknown
+
+  pkg 'VirtualBox.pkg'
+  uninstall :script => { :executable => 'VirtualBox_Uninstall.tool', :args => %w[--unattended] }
+end


### PR DESCRIPTION
I'd like to add VirtualBox 4.3.26-98988 to the alternate versions set. Retrieved sha256 hash by running shasum -a 256 VirtualBox-4.3.26-98988-OSX.dmg