### PR TITLE
Update OmniFocus beta to 2.2.3

### DIFF
--- a/Casks/omnifocus-beta.rb
+++ b/Casks/omnifocus-beta.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'omnifocus-beta' do
-  version '2.2.x-r235511'
-  sha256 '5f11983b2d4ec9e447a5b69dd3c09e70a100f9434fd6bcb8ad98f4bfe82f071c'
+  version '2.2.x-r238263'
+  sha256 '2524ac2ec3541bd65a5aabac111c72f47a05d589b17e313ea37668a498476f58'
 
   url "http://omnistaging.omnigroup.com/omnifocus-2.2.x/releases/OmniFocus-#{version}-Test.dmg"
   name 'OmniFocus'


### PR DESCRIPTION
This commit freshens up the OmniFocus beta by changing the version
to include a more recent build number, and updates the sha256
stanza as well.