### PR TITLE
Change android-studio-canary to match mainline

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -3,16 +3,22 @@ cask :v1 => 'android-studio-canary' do
   sha256 'cc06d31f71a4bbc94e3027846f8293ffe898c77d55eccb3dee1fb073cd1e3d1c'
 
   url "http://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-ide-141.2095413-mac.zip"
-  homepage 'http://tools.android.com/download/studio'
+  name 'Android Studio Canary'
+  homepage 'https://sites.google.com/a/android.com/tools/download/studio/canary'
   license :apache
 
   app 'Android Studio.app'
 
   caveats <<-EOS.undent
-    If you have Java 7 or above installed, you may want to use it as Android Studio JDK, for example:
-
-    export STUDIO_JDK=/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk
-
-    Please take a look at this post: http://tools.android.com/recent/androidstudio1rc3_releasecandidate3released
+    #{token} requires Java. You can install the latest version with
+    brew cask install java
   EOS
+  zap :delete => [
+    '~/Library/Preferences/AndroidStudio*',
+    '~/Library/Preferences/com.google.android.studio.plist',
+    '~/Library/Application Support/AndroidStudio*',
+    '~/Library/Logs/AndroidStudio*',
+    '~/Library/Caches/AndroidStudio*',
+  ],
+  :rmdir => '~/AndroidStudioProjects'
 end


### PR DESCRIPTION
The Android Studio Canary cask seems to have been last synchronized with the changes in the mainline cask on 11 December 2014, in commit cf066db5f26e4f2b8a994a5d1792b1ded94b6150. This pull request adds all the subsequent updates on the mainline cask, which are as follows:

 - [Added name stanza.](https://github.com/caskroom/homebrew-cask/commit/98de62ed2186c5b1db8e39bd6a04b9b910b57bcc)
 - [Removed obsolete caveat for using Java 7 or above](https://github.com/radeksimko/homebrew-cask/commit/b53966cc8ae432eccdf5f0cb9b47509dc63eeb9c)
 - [Added zap stanza](https://github.com/TimVNL/homebrew-cask/commit/cd42121c21b56a1563979a65ba4e3fddcae5a2e5)

The homepage has been changed to the homepage for the canary channel.