### PR TITLE
Fix charles beta

### DIFF
--- a/Casks/charles-applejava.rb
+++ b/Casks/charles-applejava.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'charles-applejava' do
+  version '3.10.2'
+  sha256 'ab848f02d034860aa1ded7758c629a79dac70a79ef6b380d4d98169d36998c26'
+
+  url "http://www.charlesproxy.com/assets/release/#{version.gsub(/b\d$/, '')}/charles-proxy-#{version}-applejava.dmg"
+  homepage 'http://www.charlesproxy.com/download/'
+  license :commercial
+
+  app 'Charles.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Charles',
+                  '~/Library/Preferences/com.xk72.charles.config',
+                 ]
+end

--- a/Casks/charles-beta-applejava.rb
+++ b/Casks/charles-beta-applejava.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'charles-beta-applejava' do
+  version '3.11b2'
+  sha256 'a51e64996eb5489f2bd0e460bb0c8f4565e3151067fae7b8b3a434835abe3e5e'
+
+  url "http://www.charlesproxy.com/assets/release/#{version.gsub(/b\d$/, '')}/charles-proxy-#{version}-applejava.dmg"
+  homepage 'http://www.charlesproxy.com/download/beta/'
+  license :commercial
+
+  app 'Charles.app'
+
+  zap :delete => [
+                  '~/Library/Application Support/Charles',
+                  '~/Library/Preferences/com.xk72.charles.config',
+                 ]
+end

--- a/Casks/charles-beta.rb
+++ b/Casks/charles-beta.rb
@@ -2,7 +2,7 @@ cask :v1 => 'charles-beta' do
   version '3.11b2'
   sha256 '878355debe41814ef35cac2fbf59fe6b98ad9e75b62a3db7d2358ca863f65ce6'
 
-  url "http://www.charlesproxy.com/assets/release/#{version.gsub(/b\d$/, '')}/charles-proxy-#{version}-applejava.dmg"
+  url "http://www.charlesproxy.com/assets/release/#{version.gsub(/b\d$/, '')}/charles-proxy-#{version}.dmg"
   homepage 'http://www.charlesproxy.com/download/beta/'
   license :commercial
 


### PR DESCRIPTION
The charles-beta cask should follow the behavior of the charles cask and get the release that uses Java 8. In support of this, there should also be casks for the releases that use the old Apple JDK, hence charles-beta-applejava and charles-applejava.