### PR TITLE
Use the new package for java 6 that works on el capitan

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -1,14 +1,12 @@
 cask :v1 => 'java6' do
   version '1.6.0_65'
-  sha256 '97bc9b3c47af1f303710c8b15f2bcaedd6b40963c711a18da8eac1e49690a8a0'
+  sha256 '1b7b88c7c7ca3a1c50eacee1977dee974a50157ff7c88d0e73902bd98fc58a86'
 
-  url 'http://support.apple.com/downloads/DL1572/en_US/JavaForOSX2014-001.dmg'
-  homepage 'http://support.apple.com/kb/DL1572'
+  url 'https://support.apple.com/downloads/DL1572/en_US/javaforosx.dmg'
+  homepage 'https://support.apple.com/kb/DL1572'
   license :unknown
 
   pkg 'JavaForOSX.pkg'
 
   uninstall :pkgutil => 'com.apple.pkg.JavaForMacOSX107'
-  
-  depends_on :macos => '<= :yosemite'
 end


### PR DESCRIPTION
This build will run and install even if rootless is enabled on the drive.