### PR TITLE
Update URL for Omnioutliner Betas

### DIFF
--- a/Casks/omnioutliner-beta.rb
+++ b/Casks/omnioutliner-beta.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'omnioutliner-beta' do
-  version '4.3.x-r235551'
-  sha256 '8584a222621871aa178d27ab5ebba3da042f1ef8b269390148c5e26fe0b8bc50'
+  version '4.3.x-r238997'
+  sha256 '7abf46e9183ba617edc9d80e7587a32e3e555d5ca5868668f5bb7759f7b472c5'
 
-  url "http://omnistaging.omnigroup.com/omnioutliner-4/releases/OmniOutliner-#{version.sub(%r{.*-},'')}-Test.dmg"
+  url "http://omnistaging.omnigroup.com/omnioutliner-4/releases/OmniOutliner-#{version}-Test.dmg"
   name 'OmniOutliner'
   homepage 'http://omnistaging.omnigroup.com/omnioutliner-4/'
   license :commercial


### PR DESCRIPTION
The URL pattern used for Omnioutliner was updated. This commit
updates the url stanza format, and takes the opportunity to
update the version and sha256 stanzas at the same time.