### PR TITLE
Add Audacity 2.1.0

### DIFF
--- a/Casks/audacity210.rb
+++ b/Casks/audacity210.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'audacity210' do
+  version '2.1.0'
+  sha256 '0485ab70a86ab6d500b9365b24d279f10971b9260f0b537142b48832f8f84389'
+
+  url "http://downloads.sourceforge.net/project/audacity/audacity/#{version}/audacity-macosx-ub-#{version}.dmg"
+  name 'Audacity'
+  homepage 'http://audacity.sourceforge.net/'
+  license :gpl
+
+  app 'Audacity/Audacity.app'
+end


### PR DESCRIPTION
Audacity was removed from main repo per https://github.com/caskroom/homebrew-cask/pull/12975. Adding legacy version to `caskroom-versions` (last accessible version available via SourceForge). I decided to name the cask `audacity210`, let me know if `audacity21` or something else would be more appropriate.