### PR TITLE
Upgrade thunderbird-ja to 38.2.0

### DIFF
--- a/Casks/thunderbird-ja.rb
+++ b/Casks/thunderbird-ja.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'thunderbird-ja' do
-  version '38.1.0'
-  sha256 '471cf51893bdfd22fd6af37b3d3a72a6cc805cd4079f01737a32519f4e195f19'
+  version '38.2.0'
+  sha256 '2014b6fac54d398f63c442cc531ddfa77b604ecd616a98e67b2197225135398b'
 
   url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=ja-JP-mac"
   name 'Mozilla Thunderbird'


### PR DESCRIPTION
Upgrade Thunderbird (Japanese) 38.2.0
[view changes](https://www.mozilla.org/en-US/thunderbird/38.2.0/releasenotes/)