### PR TITLE
Bump version number and fix string interpolation in phpstorm-bundled-jdk.rb

### DIFF
--- a/Casks/phpstorm-bundled-jdk.rb
+++ b/Casks/phpstorm-bundled-jdk.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'phpstorm-bundled-jdk' do
-  version '9.0.1'
+  version '9.0.2'
   sha256 '274f050445971108e503655cad01d407ee24b078a9a8d7075bd260bea4c3eb35'
 
-  url 'http://download-cf.jetbrains.com/webide/PhpStorm-#{version}-custom-jdk-bundled.dmg'
+  url "http://download-cf.jetbrains.com/webide/PhpStorm-#{version}-custom-jdk-bundled.dmg"
   name 'PhpStorm'
   homepage 'https://www.jetbrains.com/phpstorm/'
   license :commercial


### PR DESCRIPTION
Right after this was merged, they released another minor version. Also, the PR had the wrong quote marks.