### PR TITLE
Add Adobe Digital Editions v2.0.1

### DIFF
--- a/Casks/adobe-digital-editions-2.rb
+++ b/Casks/adobe-digital-editions-2.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'adobe-digital-editions-2' do
+  version '2.0.1'
+  sha256 :no_check    # required as upstream package is updated in-place
+
+  url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.dmg"
+  name 'Adobe Digital Editions 2.0.1'
+  homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
+  license :gratis
+
+  pkg 'Digital Editions 2.0 Installer.pkg', :allow_untrusted => true
+
+  uninstall :pkgutil => 'com.adobe.adobedigitaleditions.app', :delete => '/Applications/Adobe Digital Editions.app'
+  
+end

--- a/Casks/adobe-digital-editions-2.rb
+++ b/Casks/adobe-digital-editions-2.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'adobe-digital-editions-2' do
   version '2.0.1'
-  sha256 :no_check    # required as upstream package is updated in-place
+  sha256 'dcaec3e2cbb2faa7720a2ff06d13af4fe0433cdf991c76eeeed28cb0019b69c0' 
 
   url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.dmg"
   name 'Adobe Digital Editions 2.0.1'
@@ -10,5 +10,4 @@ cask :v1 => 'adobe-digital-editions-2' do
   pkg 'Digital Editions 2.0 Installer.pkg', :allow_untrusted => true
 
   uninstall :pkgutil => 'com.adobe.adobedigitaleditions.app', :delete => '/Applications/Adobe Digital Editions.app'
-  
 end

--- a/Casks/adobe-digital-editions2.rb
+++ b/Casks/adobe-digital-editions2.rb
@@ -9,5 +9,6 @@ cask :v1 => 'adobe-digital-editions2' do
 
   pkg 'Digital Editions 2.0 Installer.pkg', :allow_untrusted => true
 
-  uninstall :pkgutil => 'com.adobe.adobedigitaleditions.app', :delete => '/Applications/Adobe Digital Editions.app'
+  uninstall :pkgutil => 'com.adobe.adobedigitaleditions.app', 
+            :delete => '/Applications/Adobe Digital Editions.app'
 end

--- a/Casks/adobe-digital-editions2.rb
+++ b/Casks/adobe-digital-editions2.rb
@@ -1,8 +1,8 @@
-cask :v1 => 'adobe-digital-editions-2' do
+cask :v1 => 'adobe-digital-editions2' do
   version '2.0.1'
   sha256 'dcaec3e2cbb2faa7720a2ff06d13af4fe0433cdf991c76eeeed28cb0019b69c0' 
 
-  url "http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.dmg"
+  url 'http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.dmg'
   name 'Adobe Digital Editions 2.0.1'
   homepage 'https://www.adobe.com/solutions/ebook/digital-editions.html'
   license :gratis


### PR DESCRIPTION
New versions of ADE uses a new DRM scheme,
it is not broken yet so we cannot reformat or
backup ebooks. Old version 2.0.1 is cracked and works
with every epub store.