### PR TITLE
Littleipsum v1.1.2

### DIFF
--- a/Casks/littleipsum1.rb
+++ b/Casks/littleipsum1.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'littleipsum1' do
+  version '1.1.2'
+  sha256 '5fa88e5cd2cc1c837ac3e9ff3a23ce1569835d56c71e2741243ce9f0424099db'
+
+  url "http://littleipsum.com/download/LittleIpsum%20#{version}.zip"
+  name "LittleIpsum"
+  homepage 'http://littleipsum.com'
+  license :closed
+
+  app 'LittleIpsum.app'
+end


### PR DESCRIPTION
Moved from homebrew-cask to homebrew-versions, see https://github.com/caskroom/homebrew-cask/pull/13269