### PR TITLE
Update libreoffice43.rb

### DIFF
--- a/Casks/libreoffice43.rb
+++ b/Casks/libreoffice43.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'libreoffice43' do
-  version '4.3.7'
+  version '4.3.7.2'
   sha256 'ad8cb940218ac52e240a7e26e6b079da31eb6f6205da732802b445d474353e8f'
 
-  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+  url "https://downloadarchive.documentfoundation.org/libreoffice/old/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   name 'LibreOffice'
   homepage 'https://www.libreoffice.org/'
   license :mpl


### PR DESCRIPTION
Older versions are now on https://downloadarchive.documentfoundation.org/. The sha256 did not change, so it's the exact same version.