### PR TITLE
vagrant-manager241

### DIFF
--- a/Casks/vagrant-manager241.rb
+++ b/Casks/vagrant-manager241.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'vagrant-manager241' do
+  version '2.4.1'
+  sha256 'ce01f4be6f0d6d514a74aa2fa0313b8b4b50de087610161ec1da6d472f9b8203'
+
+  # github.com is the official download host per the vendor homepage
+  url "https://github.com/lanayotech/vagrant-manager/releases/download/#{version}/vagrant-manager-#{version}.dmg"
+  name 'Vagrant Manager'
+  homepage 'http://vagrantmanager.com/'
+  license :mit
+
+  app 'Vagrant Manager.app'
+end


### PR DESCRIPTION
Version 241 for vagrant manager. This old version doesn't contain some regressions of version 244.

* [Issue 111](lanayotech/vagrant-manager#111)
* [Issue 107](lanayotech/vagrant-manager#107)
