### PR TITLE
Update AppCode EAP to version 142.4675.7

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,32 +1,21 @@
 cask :v1 => 'appcode-eap' do
-  version '141.2455.5'
-  sha256 'd3b03735359c7342c005bd97a3bbc816ab1b86b7e12398f4177b797bc695b436'
+  version '142.4675.7'
+  sha256 '88e430d88eaef3dd0870d4821cffcaf34f4d8552b1f112dc5100bda9afe424d3'
 
-  url "https://download.jetbrains.com/objc/AppCode-#{version}.dmg"
+  url "https://download.jetbrains.com/objc/AppCode-#{version}-custom-jdk-bundled.dmg"
   name 'AppCode'
   homepage 'https://confluence.jetbrains.com/display/OBJC/AppCode+EAP'
   license :commercial
 
-  app 'AppCode.app'
+  app 'AppCode EAP.app'
 
   zap :delete => [
                   '~/Library/Preferences/com.jetbrains.AppCode-EAP.plist',
-                  '~/Library/Preferences/AppCode32',
-                  '~/Library/Application Support/AppCode32',
-                  '~/Library/Caches/AppCode32',
-                  '~/Library/Logs/AppCode32',
+                  '~/Library/Preferences/AppCode33',
+                  '~/Library/Application Support/AppCode33',
+                  '~/Library/Caches/AppCode33',
+                  '~/Library/Logs/AppCode33',
                  ]
 
   conflicts_with :cask => 'appcode-eap-bundled-jdk'
-
-  caveats <<-EOS.undent
-    #{token} requires Java 6 like any other IntelliJ-based IDE.
-    You can install it with
-
-      brew cask install caskroom/homebrew-versions/java6
-
-    The vendor (JetBrains) doesn't support newer versions of Java (yet)
-    due to several critical issues, see details at
-    https://intellij-support.jetbrains.com/entries/27854363
-  EOS
 end


### PR DESCRIPTION
This commit updates the version, sha256 and url stanzas. I've also
removed the caveats about needing a Java install as this EAP only
features the bundled JDK version now.