### PR TITLE
Moved phpstorm-eap to phpstorm-eap-bundled-jdk and added normal phpstorm-eap

### DIFF
--- a/Casks/phpstorm-eap-bundled-jdk.rb
+++ b/Casks/phpstorm-eap-bundled-jdk.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'phpstorm-eap' do
   version '142.4912'
-  sha256 '399f96606592a33ecc7969853d824f04dba9fe36013d43e176e56570124b841d'
+  sha256 '0a4138da08a4e1a25199f4a2ab90328c5c43c0c7a5ca861ac2af4db8f0bb485b'
 
-  url "http://download.jetbrains.com/webide/PhpStorm-EAP-#{version}.dmg"
+  url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version}-custom-jdk-bundled.dmg"
   name 'PhpStorm EAP'
   homepage 'https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Early+Access+Program'
   license :commercial

--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -2,7 +2,7 @@ cask :v1 => 'phpstorm-eap' do
   version '142.4912'
   sha256 '399f96606592a33ecc7969853d824f04dba9fe36013d43e176e56570124b841d'
 
-  url "http://download.jetbrains.com/webide/PhpStorm-EAP-#{version}.dmg"
+  url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version}.dmg"
   name 'PhpStorm EAP'
   homepage 'https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Early+Access+Program'
   license :commercial


### PR DESCRIPTION
Copied original phpstorm-eap to phpstorm-eap-bundled-jdk because the link in normal phpstorm-eap is bundled with jdk and no non bundled version exists for phpstorm-eap like normal phpstorm