### PR TITLE
Add Cura.app v15.06.03 (latest beta)

### DIFF
--- a/Casks/cura-beta.rb
+++ b/Casks/cura-beta.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'cura-beta' do
+  version '15.06.03'
+  sha256 '60c2fe1c5d7b5e738b7906e67ee66b6ba80a9d0a91f98cd6704af039afa2f732'
+
+  url "http://software.ultimaker.com/15.06/Cura-#{version}-Darwin.dmg"
+  name 'Cura'
+  homepage 'https://ultimaker.com/en/products/software'
+  license :oss
+
+  app 'Cura.app'
+
+  zap :delete => '~/.cura'
+end


### PR DESCRIPTION
This Cask has been moved from homebrew-cask and renamed 'cura-beta'.
It has been upgraded to the latest version.

Please find the stable version in homebrew-cask.