### PR TITLE
update wireshark-dev to version 2.0.0rc1

### DIFF
--- a/Casks/wireshark-dev.rb
+++ b/Casks/wireshark-dev.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'wireshark-dev' do
-  version '1.99.9'
-  sha256 'b936f35e6a83112b95d6ed512650ae2d0fb4a5fd9a639c783119e1baaf394973'
+  version '2.0.0rc1'
+  sha256 '2a8ced7cd6c1788b46aa366d91dfbad144842fdfb09443a3b72d2dfec058783b'
 
-  url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20Intel%2064.dmg"
+  url "https://www.wireshark.org/download/osx/Wireshark%20#{version}%20Intel%2064.dmg"
   homepage 'https://www.wireshark.org'
   license :gpl
 


### PR DESCRIPTION
NOTICE: 
`curl https://2.na.dl.wireshark.org/osx/Wireshark%202.0.0rc1%20Intel%2064.dmg`
will cause:
`curl: (60) SSL certificate problem: unable to get local issuer certificate`

And, `https://www.wireshark.org/download/osx/Wireshark%202.0.0rc1%20Intel%2064.dmg` is also official.