### PR TITLE
Fix url and homepage in Mozart2 Cask

### DIFF
--- a/Casks/mozart2.rb
+++ b/Casks/mozart2.rb
@@ -3,9 +3,9 @@ cask :v1 => 'mozart2' do
   sha256 '4f077b0658557e532bfa7519977ce9870c55350a1cb395ef77bcab623c70ee04'
 
   # sourceforge.net is the official download host per the vendor homepage
-  url 'http://downloads.sourceforge.net/project/mozart-oz/v2.0.0-alpha.0/mozart2-2.0.0-alpha.0%2Bbuild.4116.bdeaf6c-x86_64-darwin.dmg'
+  url 'http://downloads.sourceforge.net/sourceforge/mozart-oz/mozart2-2.0.0-alpha.0+build.4116.bdeaf6c-x86_64-darwin.dmg'
   name 'Mozart'
-  homepage 'http://www.mozart-oz.org'
+  homepage 'http://mozart.github.io/'
   license :oss
 
   app 'Mozart2.app'


### PR DESCRIPTION
* Specify url in a preferable URL format as stated at
https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#sourceforge-urls
* Provide a valid link to Mozart2 homepage