### PR TITLE
webkit-nightly.rb: fixed missing quote

### DIFF
--- a/Casks/webkit-nightly.rb
+++ b/Casks/webkit-nightly.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'webkit-nightly' do
-  version r191756'
+  version 'r191756'
   sha256 'ab70e5eb5a44be00455219bbb2d46fd7ab5241e28c533b39e46f319735106faa'
 
   url "http://builds.nightly.webkit.org/files/trunk/mac/WebKit-SVN-#{version}.dmg"


### PR DESCRIPTION
@fanquake Looks like your latest update removed a quote. Perhaps an error on the update script (if you’re already using that)?