### PR TITLE
Created cask for rubymine version 7

### DIFF
--- a/Casks/rubymine7.rb
+++ b/Casks/rubymine7.rb
@@ -1,0 +1,25 @@
+cask :v1 => 'rubymine7' do
+  version '7.1.4'
+  sha256 'ec503be6a441850702c5e332c459ccb2ed71e1a337f82b01587377f76a4f379e'
+
+  url "https://download.jetbrains.com/ruby/RubyMine-#{version}.dmg"
+  name 'RubyMine'
+  homepage 'https://www.jetbrains.com/ruby/'
+  license :commercial
+
+  app 'RubyMine.app'
+
+  zap :delete => [
+                  '~/Library/Preferences/com.jetbrains.rubymine.plist',
+                  '~/Library/Preferences/RubyMine70',
+                  '~/Library/Application Support/RubyMine70',
+                  '~/Library/Caches/RubyMine70',
+                  '~/Library/Logs/RubyMine70',
+                  '/usr/local/bin/mine',
+                 ]
+
+  conflicts_with :cask => [
+                           'rubymine',
+                           'rubymine-bundled-jdk',
+                          ]
+end


### PR DESCRIPTION
Created cask for rubymine version 7 since version 8 is now mainline.