### PR TITLE
VMWare Fusion 7 released v7.1.3

### DIFF
--- a/Casks/vmware-fusion7.rb
+++ b/Casks/vmware-fusion7.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'vmware-fusion7' do
-  version '7.1.2-2779224'
-  sha256 '93e809ece4f915fcb462affabfce2d7c85eb08314b548e2cde44cb2a67ad7d76'
+  version '7.1.3-3204469'
+  sha256 '9ba3e002cc2ed3d3adc96b8b748d49c72069acac35f0fcc71ceaa7729895da17'
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   name 'VMware Fusion'


### PR DESCRIPTION
Updated for [12 Nov released](http://pubs.vmware.com/Release_Notes/en/fusion/7/fusion-713-release-notes.html) version of Fusion 7