### PR TITLE
Update the Firefox Nightly URL

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -2,7 +2,7 @@ cask :v1 => 'firefox-nightly' do
   version '45.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-#{version}.en-US.mac.dmg"
+  url "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-#{version}.en-US.mac.dmg"
   name 'Firefox'
   name 'Mozilla Firefox'
   homepage 'https://nightly.mozilla.org/'


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/1223565/11354672/43475190-9256-11e5-9888-d2c2f0c630e3.png)

--

From https://ftp.mozilla.org/pub/firefox/nightly/latest-trunk/README.txt

```
This directory is no longer in use. Please use
  https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/
instead.
```