### PR TITLE
Readd JDownloader2 cask

### DIFF
--- a/Casks/jdownloader2.rb
+++ b/Casks/jdownloader2.rb
@@ -1,0 +1,29 @@
+cask :v1 => 'jdownloader2' do
+  version :latest
+  sha256 :no_check
+
+  if MacOS.release <= :snow_leopard
+    url 'http://installer.jdownloader.org/JD2Setup_10_6orlower.dmg'
+  else
+    url 'http://installer.jdownloader.org/JD2Setup.dmg'
+  end
+
+  name 'JDownloader 2'
+  homepage 'http://jdownloader.org'
+  license :gpl
+
+  preflight do
+    system '#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub',
+           '-q',
+           '-dir',
+           '#{staged_path}',
+           '-Dinstall4j.suppressStdout=true',
+           '-Dinstall4j.debug=false',
+           '-VcreateDesktopLinkAction$Boolean=false',
+           '-VaddToDockAction$Boolean=false',
+           '> /dev/null',
+           '2>&1'
+  end
+
+  app 'JDownloader 2.0/JDownloader2.app'
+end


### PR DESCRIPTION
This cask now uses the dmg linked from their [homepage](http://jdownloader.org/download/index) and tries to silent install.

The silent install still prints a lot to the console and creates a shortcut on the current users desktop and adds a icon to the dock. Any ideas how to fix that?

As JDownloader2 seems to be the only version directly presented on their homepage should this cask still go to homebrew-versions? or replace the [caskroom/homebrew-cask jdownloader.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/jdownloader.rb) cask?