### PR TITLE
resolve pkg source file error

### DIFF
--- a/Casks/java7.rb
+++ b/Casks/java7.rb
@@ -11,7 +11,7 @@ cask :v1 => 'java7' do
   homepage 'http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html'
   license :gratis
 
-  pkg 'JDK 7 Update 79.pkg'
+  pkg 'JDK 7 Update 80.pkg'
   postflight do
     system '/usr/bin/sudo', '-E', '--',
       '/usr/libexec/PlistBuddy', '-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk#{version}.jdk/Contents/Info.plist"
@@ -33,7 +33,7 @@ cask :v1 => 'java7' do
     end
   end
 
-  uninstall :pkgutil => 'com.oracle.jdk7u79',
+  uninstall :pkgutil => 'com.oracle.jdk7u80',
             :delete => [
                           MacOS.release <= :mavericks ? '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK' : ''
                        ].keep_if { |v| !v.empty? }


### PR DESCRIPTION
```
Downloading http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-ma
Already downloaded: /Library/Caches/Homebrew/java7-1.7.0_80.dmg
==> Running installer for java7; your password may be necessary.
==> Package installers may write to any location; options such as --appdir are i
Error: pkg source file not found: '/opt/homebrew-cask/Caskroom/java7/1.7.0_80/JDK 7 Update 79.pkg'
```
Solve the above error so that it looks into the newest 'JDK 7 Update 80.pkg'.