### PR TITLE
Add the latest beta of Saleae Logic Analyzer 1.2.5.

### DIFF
--- a/Casks/logic-beta.rb
+++ b/Casks/logic-beta.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'logic-beta' do
+  version '1.2.5'
+  sha256 '6699a0da5b14c85da662d2df3b8c6453459a49c1be7e833854bbb000bfce9288'
+
+  url "http://downloads.saleae.com/betas/#{version}/Logic-#{version}-Darwin.dmg"
+  name 'Logic'
+  homepage 'https://www.saleae.com/'
+  license :commercial
+
+  app 'Logic.app'
+end


### PR DESCRIPTION
This version is recommended for certain hardware versions by Saleae.