### PR TITLE
Update Omnioutliner Beta to build 4.4.x-r251827

### DIFF
--- a/Casks/omnioutliner-beta.rb
+++ b/Casks/omnioutliner-beta.rb
@@ -1,6 +1,6 @@
 cask 'omnioutliner-beta' do
-  version '4.4.x-r250030'
-  sha256 '2b8c51ef4d5321b7701858264ea5f0da8358281259d8a1c94d1ac0d55792ba7e'
+  version '4.4.x-r251827'
+  sha256 'c2be9c83f1009b6407aea2b6b35da8210b8545a5acfe7aafe0853082b414d056'
 
   url "http://omnistaging.omnigroup.com/omnioutliner-4/releases/OmniOutliner-#{version}-Test.dmg"
   name 'OmniOutliner'


### PR DESCRIPTION
This commit updates the version and sha256 tokens.