### PR TITLE
Upgrade iTerm2 Beta to 2.9.20160102

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,8 +1,8 @@
 cask 'iterm2-beta' do
-  version '2.9.20151111'
-  sha256 'fb1c566412656c4e9f5cfdc892a1ea960d0b3124479fd4c60dc65ce48ee37c2e'
+  version '2.9.20160102'
+  sha256 '239ee19a0dce38cd95735fb29b901d80c340eb41e9c8282109ba2d224496ee07'
 
-  url 'https://iterm2.com/downloads/beta/iTerm2-2_9_20151111.zip'
+  url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
   license :gpl


### PR DESCRIPTION
update version
add version substitution for the url
minor edits based on rubocop output