### PR TITLE
Update clipmenu-alpha.rb for bug fixed

### DIFF
--- a/Casks/clipmenu-alpha.rb
+++ b/Casks/clipmenu-alpha.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'clipmenu-alpha' do
+cask 'clipmenu-alpha' do
   version '1.0.0a1'
   sha256 'ce92a6efa7397d39e0d73bdd5394438ceb1f66543c2e4695969d7acfaad1434e'
 


### PR DESCRIPTION
The error message below will displayed when trying to run `brew cask list` and `brew cask install clipmenu-alpha` before bug fixed:  
````
Error: Cask 'clipmenu-alpha' definition is invalid: Bad header line: '{:v1=>"clipmenu-alpha"}' does not match file name
````