### PR TITLE
Create eclipse-java-luna.rb

### DIFF
--- a/Casks/eclipse-java-luna.rb
+++ b/Casks/eclipse-java-luna.rb
@@ -1,0 +1,14 @@
+cask 'eclipse-java-luna' do
+  version '4.4.2'
+  sha512 '00e7890cf46d6b8ada002f39f7d2ed576c52eb87039b4e2ce92eeffce9866fea'
+
+  url 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/luna/SR2/eclipse-java-luna-SR2-macosx-cocoa-x86_64.tar.gz&r=1'
+  name 'Eclipse IDE for Java Developers'
+  homepage 'https://eclipse.org/'
+  license :eclipse
+
+  depends_on macos: '>= :leopard'
+  depends_on arch: :x86_64
+
+  app 'Eclipse.app'
+end


### PR DESCRIPTION
Some Eclipse plugins (eg. [Google Apps Script](https://developers.google.com/eclipse/?hl=en)) are only compatible with older versions of Eclipse.  Handy to have the option to install older versions.