### PR TITLE
Update Android Studio Canary to 2.0 Preview 7 and prevent conflict

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,13 +1,16 @@
 cask 'android-studio-canary' do
-  version '2.0.0.5-143.2532994'
-  sha256 '9d86b86a902fc756ecdc600f39a5b847fc119d7af80303f6f30d65974ae6bd07'
+  version '2.0.0.7-143.2554821'
+  sha256 'aec07fb4542d29b84dd36327ccb478e5897e347fbf26449b4573ac450a0790fe'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.sub(%r{-.*}, '')}/android-studio-ide-#{version.sub(%r{.*?-}, '')}-mac.zip"
   name 'Android Studio Canary'
   homepage 'https://sites.google.com/a/android.com/tools/download/studio/canary'
   license :apache
 
-  app 'Android Studio.app'
+  # To prevent a conflict with Android Studio 1.5, we should rename Android Studio to Android Studio 2
+  # For more information, please visit : http://tools.android.com/tips/using-multiple-android-studio-versions
+  # Please note that Android Studio 2.0 Preview, use a different folder for user data and settings than Android Studio 1.5
+  app 'Android Studio.app', :target => 'Android Studio 2.app'
 
   zap delete: [
                 '~/Library/Preferences/AndroidStudio*',


### PR DESCRIPTION
Hello,

I have updated Android Studio Canary to version 2.0 Preview 7.
I have also a target to app, to prevent a conflict with v1.5 latest stable version.
As user settings and IDE data are not in the same directory, there is no more work to do.
And we have the two version installed side-by-side.

**For more information :**
Release announcement : http://tools.android.com/recent/androidstudio20preview7available
Using Multiple Android Studio Versions : http://tools.android.com/tips/using-multiple-android-studio-versions

Thank you for your work,
ValCapri