### PR TITLE
updated vivaldi-snapshot (1.0.380.2)

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.0.377.10'
-  sha256 '466201ddcea244a9fcb0cf8d45e297d3214fb33f8d5032923432b72653116fb5'
+  version '1.0.380.2'
+  sha256 '9b3cdac0ddd45bb262c9e0390ad541f86bfa1e3327784db1ebc4e06034012d32'
 
   url "https://vivaldi.com/download/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '1d350f1f6fd8ff4e9796e47716a2b193bef4fdbea209a37fa0bbe135067e634b'
+          checkpoint: '1d1d38ce477c28b361c017514e73ebcd671d0fe8bd0611409271a65ea9ebc4be'
   name 'Vivaldi'
   homepage 'https://vivaldi.com'
   license :gratis


### PR DESCRIPTION
Closes #1622.