### PR TITLE
Firefox ESR 38.6.1 (locales en-US, zh-CN, uk, ru)

### DIFF
--- a/Casks/firefox-esr-ru.rb
+++ b/Casks/firefox-esr-ru.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr-ru' do
-  version '38.4.0'
-  sha256 '5c1226b4acd02713a9e166004ba8e55aa6300c59078e1d84c34ac19f81edac0a'
+  version '38.6.1'
+  sha256 '5ad748abed1c78923988222ca5bb69730123d4756e8ae128e15b5ad4e39db4fe'
 
   url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=ru"
   name 'Mozilla Firefox'

--- a/Casks/firefox-esr-ru.rb
+++ b/Casks/firefox-esr-ru.rb
@@ -2,7 +2,7 @@ cask 'firefox-esr-ru' do
   version '38.6.1'
   sha256 '5ad748abed1c78923988222ca5bb69730123d4756e8ae128e15b5ad4e39db4fe'
 
-  url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=ru"
+  url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/ru/Firefox%20#{version}esr.dmg"
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/ru/firefox/organizations/'
   license :mpl

--- a/Casks/firefox-esr-uk.rb
+++ b/Casks/firefox-esr-uk.rb
@@ -2,7 +2,7 @@ cask 'firefox-esr-uk' do
   version '38.6.1'
   sha256 '173982d204a2db1a383d8e64ab6c0f074a97ffe318085dfbccd13f701a154838'
 
-  url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=uk"
+  url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/uk/Firefox%20#{version}esr.dmg"
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/uk/firefox/organizations/'
   license :mpl

--- a/Casks/firefox-esr-uk.rb
+++ b/Casks/firefox-esr-uk.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr-uk' do
-  version '38.4.0'
-  sha256 '02aac6a4a86c99cd0d16309bd26a40a969bcd9a87d819babb5c133e684cf67b3'
+  version '38.6.1'
+  sha256 '173982d204a2db1a383d8e64ab6c0f074a97ffe318085dfbccd13f701a154838'
 
   url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=uk"
   name 'Mozilla Firefox'

--- a/Casks/firefox-esr-zh-cn.rb
+++ b/Casks/firefox-esr-zh-cn.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr-zh-cn' do
-  version '38.4.0'
-  sha256 '7a2094e6483990906cd316309e03ec404f50de1077ea0f4332ecf649bad7e3ac'
+  version '38.6.1'
+  sha256 '21b4627fa774199453f22ef3877b7cd2926850ed8cdfb8a19498674c7eb45483'
 
   url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=zh-CN"
   name 'Mozilla Firefox'

--- a/Casks/firefox-esr-zh-cn.rb
+++ b/Casks/firefox-esr-zh-cn.rb
@@ -2,7 +2,7 @@ cask 'firefox-esr-zh-cn' do
   version '38.6.1'
   sha256 '21b4627fa774199453f22ef3877b7cd2926850ed8cdfb8a19498674c7eb45483'
 
-  url "https://download.mozilla.org/?product=firefox-#{version}esr-SSL&os=osx&lang=zh-CN"
+  url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/zh-CN/Firefox%20#{version}esr.dmg"
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/zh-CN/firefox/organizations/'
   license :mpl

--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr' do
-  version '38.6.0'
-  sha256 '4bd7e28da15996957654adfb69e5b8450da9fe8627664d8cbaec7cc9be77a480'
+  version '38.6.1'
+  sha256 'd8cc970186ba6812f20c49906affd08fe2d563fc0ab63919bd1bf3091275cbc0'
 
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/en-US/Firefox%20#{version}esr.dmg"
   name 'Mozilla Firefox'


### PR DESCRIPTION
Updates all existing locale casks of Firefox ESR to the latest version.
Download URL made consistent across these casks, now all have the form:
`https://download-installer.cdn.mozilla.net/pub/firefox/releases/VERSION/mac/LOCALE/Firefox VERSION.dmg`.