### PR TITLE
Update the destination of the symlink

### DIFF
--- a/Casks/bitbar-beta.rb
+++ b/Casks/bitbar-beta.rb
@@ -9,5 +9,5 @@ cask 'bitbar-beta' do
   homepage 'https://github.com/matryer/bitbar/'
   license :mit
 
-  app 'bitbar.app'
+  app 'BitBar Beta.app'
 end


### PR DESCRIPTION
The destination of the symlink should be in CamelCase, like the source. In case the stable and the beta versions are installed next to each other, I added a "Beta" to the name.