### PR TITLE
Remove fonts when zapping Microsoft Office 2011

### DIFF
--- a/Casks/microsoft-office-2011.rb
+++ b/Casks/microsoft-office-2011.rb
@@ -29,6 +29,7 @@ cask 'microsoft-office-2011' do
                        '/Library/Preferences/com.microsoft.office.licensing.plist',
                        '/Library/Preferences/com.microsoft.outlook.databasedaemon.plist',
                        '/Library/Preferences/com.microsoft.outlook.officereminders.plist',
+                       '/Library/Fonts/Microsoft',
                        '~/Library/Application Support/Microsoft/Office',
                        '~/Library/Preferences/com.microsoft.Excel.plist',
                        '~/Library/Preferences/com.microsoft.Outlook.plist',


### PR DESCRIPTION
Fonts are now removed when zapping office 2011, as per [Troubleshooting steps](https://support.office.com/en-us/article/Troubleshoot-Office-2011-for-Mac-issues-by-completely-uninstalling-before-you-reinstall-ba8d8d13-0015-4eea-b60b-7719c2cedd17)