### PR TITLE
airmail-beta has no versioned download

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '2.6.1'
-  sha256 'df3f2c42a7ff30ac48cb012359fc4592e68adbd4d2de750b3e6145f3a65448de'
+  version :latest
+  sha256 :no_check
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'


### PR DESCRIPTION
Revert of commit [2723399](https://github.com/caskroom/homebrew-versions/commit/2723399480fe4957cef1e3bd805adb4a882aca84) which breaks the formula on every Airmail Beta update (sha mismatch)