### PR TITLE
Update Airmail Beta to version 2.6.1,353

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,14 +1,14 @@
 cask 'airmail-beta' do
-  version '2.6.1,352'
-  sha256 '8ddc915a1e7e5031ff592925d55d8016992e17f497d90135d4dbafac127ee6f3'
+  version '2.6.1,353'
+  sha256 'a728b354f1065f2b3d92f053af42e5288546103522438f39e5f8ad210442fb29'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'fa45a73c4d4dc64377e3e5ffbd356fd416a573d676c8d9eb74465d1100f52a01'
+          checkpoint: '702b1b55240acf127b651b3461e2bc2b56c4abde0ece48ee65dff9b3247f09b4'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
-  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :commercial
 
   app 'AirMail Beta.app'
 end


### PR DESCRIPTION
This commit updates the version, sha256 and checkpoint stanzas. It
also changes the license from `:unknown` to `:commercial`