### PR TITLE
Add Firefox 38 ESR

### DIFF
--- a/Casks/firefox-38esr.rb
+++ b/Casks/firefox-38esr.rb
@@ -1,0 +1,16 @@
+cask 'firefox-38esr' do
+  version '38.7.0'
+  sha256 '9bb953b21f54559b1d25bf4f6026108d54151376f6895dd9c39bb738e295b90b'
+
+  url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/en-US/Firefox%20#{version}esr.dmg"
+  name 'Mozilla Firefox'
+  homepage 'https://www.mozilla.org/en-US/firefox/organizations/'
+  license :mpl
+
+  app 'Firefox.app'
+
+  zap delete: [
+                '~/Library/Application Support/Firefox',
+                '~/Library/Caches/Firefox',
+              ]
+end


### PR DESCRIPTION
Mozilla intends to support Firefox Extended Support Releases (ESR) for 9 major versions [(proposal)](https://wiki.mozilla.org/Enterprise/Firefox/ExtendedSupport:Proposal), while releasing an ESR every 7 majors. I.e., there is a two version overlap where two ESRs are supported.

Firefox 38 ESR will thus still be supported for two more versions (45 ESR was released yesterday). I think it's in the interest of Homebrew users and in the spirit of Mozilla's ESR plan to keep Casks of supported ESRs around.

FF 38 ESR & this cask are expected to retire 2016-06-07.