### PR TITLE
Update RubyMine EAP (2016.1)

### DIFF
--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -20,8 +20,12 @@ cask 'rubymine-eap' do
                 "~/Library/Logs/RubyMine#{version.major_minor}",
               ]
 
+  # remove this when this cask is updated to an EAP release
   caveats <<-EOS.undent
-    Please manually change to the EAP update channel via:
+    There is currently no EAP preview release. Instead, the latest stable
+    version will be installed.
+    To receive future EAP releases via the IDE's built-in update system, go to
        Preferences > Appearance & Behavior > System Settings > Updates
-    EOS
+    and select the Early Access Program channel.
+  EOS
 end

--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -1,20 +1,27 @@
 cask 'rubymine-eap' do
-  version '2016.1-RC'
-  sha256 'a7f620c6841a3abdc73fa477697d9ffe2bb772d0ec0c50a3eb4fc868803ef982'
+  version '2016.1'
+  sha256 'c587ec3e282802c93be5826be79fddb003a6842b861f5c9a885c6c0c9638106d'
 
   url "https://download.jetbrains.com/ruby/RubyMine-#{version}.dmg"
-  name 'RubyMine EAP'
-  homepage 'https://confluence.jetbrains.com/display/RUBYDEV/RubyMine+EAP'
+  name 'RubyMine'
+  homepage 'https://confluence.jetbrains.com/display/RUBYDEV/Early+Access+Program'
   license :commercial
+
+  conflicts_with cask: 'rubymine'
 
   app 'RubyMine.app'
 
   zap delete: [
-                '~/Library/Preferences/com.jetbrains.rubymine-EAP.plist',
-                '~/Library/Preferences/RubyMine80',
-                '~/Library/Application Support/RubyMine-EAP',
-                '~/Library/Caches/RubyMine70',
-                '~/Library/Logs/RubyMine70',
-                '/usr/local/bin/mine',
+                "~/.RubyMine#{version.major_minor}",
+                # TODO: expand/glob for '~/Library/Preferences/jetbrains.rubymine.*.plist',
+                "~/Library/Preferences/RubyMine#{version.major_minor}",
+                "~/Library/Application Support/RubyMine#{version.major_minor}",
+                "~/Library/Caches/RubyMine#{version.major_minor}",
+                "~/Library/Logs/RubyMine#{version.major_minor}",
               ]
+
+  caveats <<-EOS.undent
+    Please manually change to the EAP update channel via:
+       Preferences > Appearance & Behavior > System Settings > Updates
+    EOS
 end


### PR DESCRIPTION
This is the current stable release.
The RubyMine EAP is suspended until a new preview is released.