### PR TITLE
Update Appcode EAP (2016.1)

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,5 +1,5 @@
 cask 'appcode-eap' do
-  version '2016.1-RC2'
+  version '2016.1'
   sha256 'dec7447da549f6c2033e6bea8587413888e881f0019a436a711ed07fc42c2b58'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version}.dmg"
@@ -12,9 +12,16 @@ cask 'appcode-eap' do
   app 'AppCode.app'
 
   zap delete: [
-                '~/Library/Preferences/AppCode2016.1',
-                '~/Library/Application Support/AppCode2016.1',
-                '~/Library/Caches/AppCode2016.1',
-                '~/Library/Logs/AppCode2016.1',
+                "~/.Appcode#{version.major_minor}",
+                # TODO: expand/glob for '~/Library/Preferences/jetbrains.appcode.*.plist',
+                "~/Library/Preferences/AppCode#{version.major_minor}",
+                "~/Library/Application Support/AppCode#{version.major_minor}",
+                "~/Library/Caches/AppCode#{version.major_minor}",
+                "~/Library/Logs/AppCode#{version.major_minor}",
               ]
+
+  caveats <<-EOS.undent
+    Please manually change to the EAP update channel via:
+       Preferences > Appearance & Behavior > System Settings > Updates
+    EOS
 end

--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -20,8 +20,12 @@ cask 'appcode-eap' do
                 "~/Library/Logs/AppCode#{version.major_minor}",
               ]
 
+  # remove this when this cask is updated to an EAP release
   caveats <<-EOS.undent
-    Please manually change to the EAP update channel via:
+    There is currently no EAP preview release. Instead, the latest stable
+    version will be installed.
+    To receive future EAP releases via the IDE's built-in update system, go to
        Preferences > Appearance & Behavior > System Settings > Updates
-    EOS
+    and select the Early Access Program channel.
+  EOS
 end


### PR DESCRIPTION
This is the current stable release.
The Appcode EAP is suspended until a new preview is released.