### PR TITLE
Updated Datagrip EAP (2016.1 EAP, build 145.735.3)

### DIFF
--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -1,11 +1,20 @@
 cask 'datagrip-eap' do
-  version '145.404.2'
-  sha256 'c83131497cd8d75acaa001b9dd4a9b602b6c09ce29d912cde9ddb908f4bd245c'
+  version '2016.1,145.735.3'
+  sha256 '1307ec1722361c8777f1f2f7a57977e246b161d5969ce24d3c0caabdb7212370'
 
-  url "https://download.jetbrains.com/datagrip/datagrip-#{version}.dmg"
+  url "https://download.jetbrains.com/datagrip/datagrip-#{version.after_comma}.dmg"
   name 'Datagrip EAP'
   homepage 'https://confluence.jetbrains.com/display/DBE/DataGrip+2016.1+EAP'
   license :commercial
 
-  app 'Datagrip EAP.app'
+  app "Datagrip #{version.major_minor_patch} EAP.app"
+
+  zap delete: [
+                "~/.DataGrip#{version.major_minor}", # TODO: confirm this one
+                # TODO: expand/glob for '~/Library/Preferences/jetbrains.datagrip.*.plist',
+                "~/Library/Preferences/DataGrip#{version.major_minor}",
+                "~/Library/Application Support/DataGrip#{version.major_minor}",
+                "~/Library/Caches/DataGrip#{version.major_minor}",
+                "~/Library/Logs/DataGrip#{version.major_minor}",
+              ]
 end

--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -7,7 +7,7 @@ cask 'datagrip-eap' do
   homepage 'https://confluence.jetbrains.com/display/DBE/DataGrip+2016.1+EAP'
   license :commercial
 
-  app "Datagrip #{version.major_minor_patch} EAP.app"
+  app "Datagrip #{version.before_comma} EAP.app"
 
   zap delete: [
                 "~/.DataGrip#{version.major_minor}", # TODO: confirm this one


### PR DESCRIPTION
The files

* `~/.DataGrip2016.1`
* `~/Library/Preferences/jetbrains.datagrip.*.plist`

are not present on my machine, so I cannot confirm their spelling / location.
(The other 4 zap entries are present; note the camelcase.)