### PR TITLE
Fix sha256 checksum for iTerm2-2_9_20160403-nightly.zip

### DIFF
--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -1,6 +1,6 @@
 cask 'iterm2-nightly' do
   version '2.9.20160403'
-  sha256 'b1992760bd943256d568cd2648a09b46b422489254984fc35aeb3a163f0ef7f9'
+  sha256 '7aeb775f7e23b7ae07e0cac621cddf5bbce147fdadbbbad88e27ff96b7480d1c'
 
   url "https://iterm2.com/downloads/nightly/iTerm2-#{version.dots_to_underscores}-nightly.zip"
   appcast 'https://iterm2.com/appcasts/nightly.xml',


### PR DESCRIPTION
The checksum was incorrect stopping the nightly from installing.  Fixes #1886.