### PR TITLE
Update Pycharm EAP (Pro & CE) to 2016.1.2 (stable!)

### DIFF
--- a/Casks/pycharm-ce-eap.rb
+++ b/Casks/pycharm-ce-eap.rb
@@ -1,15 +1,15 @@
 cask 'pycharm-ce-eap' do
-  version '2016.1.1,145.597.11'
-  sha256 '2fa86d695a2f4f161ea84a9c215de2b3de2cf054fa9ed6493fd9b8a228aab8c5'
+  version '2016.1.2'
+  sha256 'e68b9fa401500311bcc3cbbcbd6b3ab02849dcac3bdb6864389aec17c6c7e992'
 
-  url "https://download.jetbrains.com/python/pycharm-community-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
   name 'PyCharm Community Edition'
   homepage 'https://confluence.jetbrains.com/display/PYH/JetBrains+PyCharm+Preview+(EAP)'
   license :apache
 
   conflicts_with cask: 'pycharm-ce'
 
-  app "PyCharm CE #{version.before_comma} EAP.app"
+  app 'PyCharm CE.app'
 
   uninstall delete: '/usr/local/bin/charm'
 
@@ -21,4 +21,13 @@ cask 'pycharm-ce-eap' do
                 "~/Library/Caches/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharm#{version.major_minor}",
               ]
+
+  # remove this when this cask is updated to an EAP release
+  caveats <<-EOS.undent
+    There is currently no EAP preview release. Instead, the latest stable
+    version will be installed.
+    To receive future EAP releases via the IDE's built-in update system, go to
+       Preferences > Appearance & Behavior > System Settings > Updates
+    and select the Early Access Program channel.
+  EOS
 end

--- a/Casks/pycharm-eap.rb
+++ b/Casks/pycharm-eap.rb
@@ -1,15 +1,15 @@
 cask 'pycharm-eap' do
-  version '2016.1.1,145.597.11'
-  sha256 '8e1d02bf800ad5ab4696df9d2a0522616ded474bc3ee10816ed0fb5663e19028'
+  version '2016.1.2'
+  sha256 '7af26088b8191bdc5360ec36fead1bbad57cc463b1b18cc67b0e64c0d1285de2'
 
-  url "https://download.jetbrains.com/python/pycharm-professional-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/python/pycharm-professional-#{version}.dmg"
   name 'PyCharm'
   homepage 'https://confluence.jetbrains.com/display/PYH/JetBrains+PyCharm+Preview+(EAP)'
   license :commercial
 
   conflicts_with cask: 'pycharm'
 
-  app "PyCharm #{version.before_comma} EAP.app"
+  app 'PyCharm.app'
 
   uninstall delete: '/usr/local/bin/charm'
 
@@ -21,4 +21,13 @@ cask 'pycharm-eap' do
                 "~/Library/Caches/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharm#{version.major_minor}",
               ]
+
+  # remove this when this cask is updated to an EAP release
+  caveats <<-EOS.undent
+    There is currently no EAP preview release. Instead, the latest stable
+    version will be installed.
+    To receive future EAP releases via the IDE's built-in update system, go to
+       Preferences > Appearance & Behavior > System Settings > Updates
+    and select the Early Access Program channel.
+  EOS
 end


### PR DESCRIPTION
Jetbrains has again released a stable that supersedes the last EAP release, similarly to CLion etc. at version 2016.1.
That's a bit of a shame that this is becoming common, since it requires the user to manually change the update channel, which makes the EAP casks less useful.

----

If this keeps happening, it might be worth checking whether the channel can be changed programmatically.

Update: It looks like it’s as simple as adding

```xml
    <option name="UPDATE_CHANNEL_TYPE" value="eap" />
```

to `~/Library/Preferences/PyCharm#{version.major_minor}/options/updates.xml`.

That seems pretty feasible and non-destructive. (I see [something similar has been done before to localize Adobe software](https://github.com/caskroom/homebrew-versions/blob/f98ada9a40c7b2e3fe52a8c63cc3be3e62c5fbcc/Casks/adobe-illustrator-cc-de.rb#L14-L20).) What do you think?