### PR TITLE
Fix PhpStorm 2016.1.1 EAP: version / zap stanza

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr' do
-  version '45.0.1'
-  sha256 'facdd65a6346ac24f10607d4b848fbb1c8d271b241c1a426d81e2abf2a3aea7d'
+  version '45.0.2'
+  sha256 '15097c3b63ef505bf78300fa4366ea5e55967e32defc31cd3bf301a31f4d2161'
 
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/en-US/Firefox%20#{version}esr.dmg"
   name 'Mozilla Firefox'

--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -1,13 +1,13 @@
 cask 'phpstorm-eap' do
-  version '145.844.5'
+  version '2016.1.1,145.844.5'
   sha256 'e339ff19d9458262c80386b0bbf74004887e286d4c6149df83332c29e9f8a29c'
 
-  url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version}.dmg"
+  url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version.after_comma}.dmg"
   name 'PhpStorm EAP'
   homepage 'https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Early+Access+Program'
   license :commercial
 
-  app 'PhpStorm 2016.1.1 EAP.app'
+  app "PhpStorm #{version.before_comma} EAP.app"
 
   uninstall delete: '/usr/local/bin/pstorm'
 


### PR DESCRIPTION
Fixes zap stanza / `#{version.major_minor}`, which was broken by #1889 (see [comment there](https://github.com/caskroom/homebrew-versions/pull/1889#issuecomment-209691729).

----

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.