### PR TITLE
Update ableton-live-suite to version 9.6.1

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,11 +1,11 @@
 cask 'ableton-live-suite' do
-  version '9.6'
+  version '9.6.1'
 
   if Hardware::CPU.is_32_bit?
-    sha256 '48e29692b5e04b6f141cdcc71a7d9070d5c67bae7ee35c12f22d204c67204aac'
+    sha256 '83c5615ba0a2f9155e929c65c258979d30aff1f2208d7f737d0b1e5aa929ea92'
     url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_32.dmg"
   else
-    sha256 'eb1c8991561059c2a1724996dc5b1f744762be002f676703905f432331071dac'
+    sha256 '2951e547feae13c9f415c39c6045ebf0f2edf1f278bdf7bc40fd1d8a769e184b'
     url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   end
 


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.