### PR TITLE
updated airmail-beta (2.6.1,354)

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,353'
-  sha256 'a728b354f1065f2b3d92f053af42e5288546103522438f39e5f8ad210442fb29'
+  version '2.6.1,354'
+  sha256 'a97453b395de1348570dd1c0574892dde593d303e8c51a0f7098344ba01194e9'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '702b1b55240acf127b651b3461e2bc2b56c4abde0ece48ee65dff9b3247f09b4'
+          checkpoint: 'cf91435c81325101a9628459e0cc529c91f61d74121d5431bc7bc6f247375ddb'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
Updated airmail-beta to 2.6.1,354
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
