### PR TITLE
updated airmail-beta (2.6.1,358)

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,356'
-  sha256 '6c2042d8b00df49648b2f839a3adc8137bd54ed3046368b2973d8a4b4dd2ec83'
+  version '2.6.1,358'
+  sha256 '7796e891a9f4c8e43cf8f0dc6e3670b7c35f172cb1d8ba1bc86273adb996abc4'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '7a134c5fb0300ab7a2f465afc2a4dd81a4f8ca215508b2da7dafbb5631a1ba6c'
+          checkpoint: '4b0e448f366d20f1c51e29a5b6e72083aacf30f752349e77ced78ecce23fc6cd'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.