### PR TITLE
updated firefoxnightly-ja (49.0a1)

### DIFF
--- a/Casks/firefoxnightly-ja.rb
+++ b/Casks/firefoxnightly-ja.rb
@@ -1,8 +1,8 @@
 cask 'firefoxnightly-ja' do
-  version '47.0a1'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '49.0a1'
+  sha256 'c77c52d616108421919fc41fb3b76f909fb71f91fd56d95660b1eb7c308621d6'
 
-  url "https://ftp.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/firefox-#{version}.ja.mac.dmg"
+  url "https://ftp.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/firefox-#{version}.ja-JP-mac.mac.dmg"
   name 'Mozilla Firefox'
   homepage 'https://nightly.mozilla.org/'
   license :mpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.