### PR TITLE
Updated `airmail-beta` to `2.6.1,359`.

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,358'
-  sha256 '7796e891a9f4c8e43cf8f0dc6e3670b7c35f172cb1d8ba1bc86273adb996abc4'
+  version '2.6.1,359'
+  sha256 'd0d5255b70bb23d90d64d467d112e9a197fca021d4061c352bdb6b401243d2db'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '4b0e448f366d20f1c51e29a5b6e72083aacf30f752349e77ced78ecce23fc6cd'
+          checkpoint: '5c922da1c9e722f9d03d79b3903cfaa61c79bfa90154c73551b4cddc4e38fab0'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download airmail-beta` is error-free.
- [x] `brew cask style --fix airmail-beta` left no offenses.