### PR TITLE
Update airmail-beta to version 2.6.1,360

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,359'
-  sha256 'd0d5255b70bb23d90d64d467d112e9a197fca021d4061c352bdb6b401243d2db'
+  version '2.6.1,360'
+  sha256 'd28b200703c7369c03cdba8a8a8e75718cf9cd23ba5862031e4ae2e3db4ebacd'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '5c922da1c9e722f9d03d79b3903cfaa61c79bfa90154c73551b4cddc4e38fab0'
+          checkpoint: '32d79ffe649ea698e68673885fd2cd843b76f35e7f36840ea48458e4fdda4667'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.