### PR TITLE
Add chirp-daily v20160507

### DIFF
--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -1,0 +1,19 @@
+cask 'chirp-daily' do
+  version '20160507'
+  sha256 '28412b8d5992d6efaa457a74071cc7c4875b011d230945ddbd0ce071bbdbb3f0'
+
+  url "http://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-#{version}.app.zip"
+  name 'CHIRP'
+  homepage 'http://chirp.danplanet.com/projects/chirp/wiki/Home'
+  license :oss
+
+  depends_on arch: :intel
+
+  app "chirp-daily-#{version}.app"
+
+  caveats <<-EOS.undent
+    #{token} also requires the KK7DS Python Runtime as described at
+
+      http://chirp.danplanet.com/projects/chirp/wiki/Download#CHIRP-Downloads
+  EOS
+end

--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -8,12 +8,7 @@ cask 'chirp-daily' do
   license :oss
 
   depends_on arch: :intel
+  depends_on cask: 'caskroom/cask/kk7ds-python-runtime'
 
   app "chirp-daily-#{version}.app"
-
-  caveats <<-EOS.undent
-    #{token} also requires the KK7DS Python Runtime as described at
-
-      http://chirp.danplanet.com/projects/chirp/wiki/Download#CHIRP-Downloads
-  EOS
 end


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download chirp-daily` is error-free.
- [x] `brew cask style --fix chirp-daily` left no offenses.
- [x] `brew cask install chirp-daily` worked successfully.
- [x] `brew cask uninstall chirp-daily` worked successfully.

CHIRP is distributed as a series of automatically-generated builds. Any time we make a change to CHIRP, a build is created for it the next day. Thus, CHIRP is versioned by the date on which it was created, which makes it easy to determine if you have an older build. We don't put experimental things into CHIRP before they are ready, except where specifically called out with a warning. Thus, you do not need to worry about finding a stable version to run. You should always be on the latest build available.