### PR TITLE
Update airmail-beta to version 2.6.1,363

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,362'
-  sha256 '84684e0a8234fcbbe0a63b3422b39869b5837c6a92e3e8d4cdb5df37c848ed48'
+  version '2.6.1,363'
+  sha256 '768f3ed8fedc93f0a8438bab7d5080607fb73c5fbad5ef487b119602606c2487'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/243?format=zip&'
+  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/244?format=zip&'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '6d7529efacd43349a85b5c8c942387928f56372665890945dd98313a40fbb500'
+          checkpoint: 'b5275b15ddf8ba13159293b3704ecdb7a53c688c36df0ba7740b990a602dd51d'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
