### PR TITLE
intellij-idea-eap & intellij-idea-ce-eap - fix app names

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -7,7 +7,7 @@ cask 'intellij-idea-ce-eap' do
   homepage 'https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.1+EAP'
   license :apache
 
-  app 'IntelliJ IDEA 2016.1 CE EAP.app'
+  app 'IntelliJ IDEA CE.app'
 
   zap delete: [
                 '~/Library/Application Support/IdeaIC2016.1',

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -7,7 +7,7 @@ cask 'intellij-idea-eap' do
   homepage 'https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.1+EAP'
   license :commercial
 
-  app 'IntelliJ IDEA 2016.1 EAP.app'
+  app 'IntelliJ IDEA.app'
 
   zap delete: [
                 '~/Library/Preferences/com.jetbrains.intellij.plist',


### PR DESCRIPTION
The app names have change between 2016.1 EAP and 2016.1.2 RC2.
I fix it on the 2 formula.