### PR TITLE
UPDATED: airmail-beta to 3.6.1,364

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,363'
-  sha256 '768f3ed8fedc93f0a8438bab7d5080607fb73c5fbad5ef487b119602606c2487'
+  version '2.6.1,364'
+  sha256 '447ce9fe31cdeab0c4e9ce7fb9d7ee6b44b47e3bdaf12b8abf541c4cf21472dd'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/244?format=zip&'
+  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/245?format=zip&'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'b5275b15ddf8ba13159293b3704ecdb7a53c688c36df0ba7740b990a602dd51d'
+          checkpoint: 'fb401617167497f4161a0aa16d8c7d773d895c3148d5c7ef34195d5924935731'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.