### PR TITLE
updated libreoffice-beta (5.1.3.2)

### DIFF
--- a/Casks/libreoffice-beta.rb
+++ b/Casks/libreoffice-beta.rb
@@ -1,8 +1,10 @@
 cask 'libreoffice-beta' do
-  version '5.1.2.1'
-  sha256 'cf211d607658b1f678d6ce9602e975b186b8abf389f995022cdbe48904ba6c1e'
+  version '5.1.3.2'
+  sha256 '969597335139d626a2fff98089fd3e2d4d7bd8ddd6753b355ec7a9d8889f4b5b'
 
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+  appcast 'https://download.documentfoundation.org/libreoffice/testing/',
+          checkpoint: 'b7b14688525109c2709454f77524a6a17110a48e1e2b8b5492d69080dae0e02e'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   license :mpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.