### PR TITLE
fix intellij-idea-eap app name

### DIFF
--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -7,7 +7,7 @@ cask 'intellij-idea-eap' do
   homepage 'https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.2+EAP'
   license :commercial
 
-  app 'IntelliJ IDEA.app'
+  app 'IntelliJ IDEA 2016.2 EAP.app'
 
   uninstall delete: '/usr/local/bin/idea'
 


### PR DESCRIPTION
The app name was broke causing `It seems the symlink source is not there` error.
I've fixed it to proper name. 



