### PR TITLE
updated vivaldi-snapshot (1.2.485.14)

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.2.479.8'
-  sha256 'f4f61fad3b9a30ed57a1e6df3cc6a294655ea21e17e8a580c54a797cc4b4824f'
+  version '1.2.485.14'
+  sha256 'a8063fbe9adf3ff69c854447635dc9b61acb26f433ba549ea52a8f042c1c08ee'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '38306b7f2db6d7289516fd9b8a8b8ce0df52472688b0e4865e2ba540df75a7ec'
+          checkpoint: 'dee9c9c2003a81675f8c0e468b0fd124a53170288eeca8d2ee3579d578a6145d'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
