### PR TITLE
Update airmail-beta to version 3.0,366

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '2.6.1,364'
-  sha256 '447ce9fe31cdeab0c4e9ce7fb9d7ee6b44b47e3bdaf12b8abf541c4cf21472dd'
+  version '3.0,366'
+  sha256 '11d49794b27b11aac027256e402fd3e55830d32bd062343ba67d78f4160dccc6'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/245?format=zip&'
+  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/246?format=zip&'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'fb401617167497f4161a0aa16d8c7d773d895c3148d5c7ef34195d5924935731'
+          checkpoint: '63071cbc3e38e17842cab7d296e85dda1ed7cd90b3ac152aa70fc0a125124096'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.