### PR TITLE
Update Android Studio Canary to 2.2.0.1,145.2915834

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.2.0.0,145.2878421'
-  sha256 '1c8f72c1ff3b11f7aefd859b1dcd226c6a26996b0d50867afb16b20b8528db83'
+  version '2.2.0.1,145.2915834'
+  sha256 '80c4277262743c2eed23a61a7d491d10ee46553cbe3207e1e369f1e1455d8a33'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
#### Editing an existing cask

- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` left no offenses.
