### PR TITLE
Update airmail-beta to version 3.0,368

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0,366'
-  sha256 '11d49794b27b11aac027256e402fd3e55830d32bd062343ba67d78f4160dccc6'
+  version '3.0,368'
+  sha256 'b1da1a93f570c78e3507b75518b18d4f010fcd915b3be7477b0afc460801ae63'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/246?format=zip&'
+  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/247?format=zip&'
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '63071cbc3e38e17842cab7d296e85dda1ed7cd90b3ac152aa70fc0a125124096'
+          checkpoint: '8a87130261608652a570838658fe20503d580407c704fbcb885f49d661e290e1'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.