### PR TITLE
Changes to support caskroom/homebrew-cask#13966

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -14,8 +14,8 @@ cask 'atom-beta' do
   depends_on macos: '>= :mountain_lion'
 
   app 'Atom Beta.app'
-  binary 'Atom Beta.app/Contents/Resources/app/apm/node_modules/.bin/apm', target: 'apm'
-  binary 'Atom Beta.app/Contents/Resources/app/atom.sh', target: 'atom-beta'
+  binary "#{appdir}/Atom Beta.app/Contents/Resources/app/apm/node_modules/.bin/apm", target: 'apm'
+  binary "#{appdir}/Atom Beta.app/Contents/Resources/app/atom.sh", target: 'atom-beta'
 
   postflight do
     suppress_move_to_applications

--- a/Casks/cocoapods0.rb
+++ b/Casks/cocoapods0.rb
@@ -11,7 +11,7 @@ cask 'cocoapods0' do
   container type: :tar
 
   app 'CocoaPods.app'
-  binary 'CocoaPods.app/Contents/Helpers/pod'
+  binary "#{appdir}/CocoaPods.app/Contents/Helpers/pod"
 
   postflight do
     # Because Homebrew-Cask symlinks the binstub directly, stop the app from asking the user to install the binstub.

--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -11,7 +11,7 @@ cask 'julia-nightly' do
   depends_on macos: '>= :lion'
 
   app "Julia-#{version.sub(%r{(.+)-(.+)}, '\1-dev-\2')}.app"
-  binary "Julia-#{version.sub(%r{(.+)-(.+)}, '\1-dev-\2')}.app/Contents/Resources/julia/bin/julia"
+  binary "#{appdir}/Julia-#{version.sub(%r{(.+)-(.+)}, '\1-dev-\2')}.app/Contents/Resources/julia/bin/julia"
 
   zap delete: '~/.julia'
 end

--- a/Casks/macvim-kaoriya.rb
+++ b/Casks/macvim-kaoriya.rb
@@ -18,7 +18,7 @@ cask 'macvim-kaoriya' do
 
   app 'MacVim.app'
 
-  mvim = 'MacVim.app/Contents/MacOS/mvim'
+  mvim = "#{appdir}/MacVim.app/Contents/MacOS/mvim"
   executables = %w[macvim-askpass mvim mvimdiff mview mvimex gvim gvimdiff gview gvimex]
   executables += %w[vi vim vimdiff view vimex] if ARGV.include? '--override-system-vim'
   executables.each { |e| binary mvim, target: e }

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -12,7 +12,7 @@ cask 'sublime-text-dev' do
   conflicts_with cask: 'caskroom/versions/sublime-text3'
 
   app 'Sublime Text.app'
-  binary 'Sublime Text.app/Contents/SharedSupport/bin/subl'
+  binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"
 
   uninstall quit: 'com.sublimetext.3'
 

--- a/Casks/sublime-text3.rb
+++ b/Casks/sublime-text3.rb
@@ -12,7 +12,7 @@ cask 'sublime-text3' do
   conflicts_with cask: 'caskroom/versions/sublime-text-dev'
 
   app 'Sublime Text.app'
-  binary 'Sublime Text.app/Contents/SharedSupport/bin/subl'
+  binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"
 
   uninstall quit: 'com.sublimetext.3'
 

--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -11,7 +11,7 @@ cask 'tower-beta' do
   license :commercial
 
   app 'Tower.app'
-  binary 'Tower.app/Contents/MacOS/gittower'
+  binary "#{appdir}/Tower.app/Contents/MacOS/gittower"
 
   zap delete: [
                 '~/Library/Application Support/com.fournova.Tower2',

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -12,7 +12,7 @@ cask 'visual-studio-code-insiders' do
   auto_updates true
 
   app 'Visual Studio Code - Insiders.app'
-  binary 'Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code'
+  binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"
 
   zap delete: [
                 '~/Library/Application Support/Code - Insiders',

--- a/Casks/vmware-fusion6.rb
+++ b/Casks/vmware-fusion6.rb
@@ -8,7 +8,7 @@ cask 'vmware-fusion6' do
   license :commercial
 
   app 'VMware Fusion.app'
-  binary 'VMware Fusion.app/Contents/Library/vmrun'
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/vmrun"
 
   uninstall_preflight do
     system '/usr/bin/sudo', '-E', '--',

--- a/Casks/vmware-fusion7.rb
+++ b/Casks/vmware-fusion7.rb
@@ -8,11 +8,11 @@ cask 'vmware-fusion7' do
   license :commercial
 
   app 'VMware Fusion.app'
-  binary 'VMware Fusion.app/Contents/Library/vmnet-cfgcli'
-  binary 'VMware Fusion.app/Contents/Library/vmnet-cli'
-  binary 'VMware Fusion.app/Contents/Library/vmrun'
-  binary 'VMware Fusion.app/Contents/Library/vmware-vdiskmanager'
-  binary 'VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool'
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/vmnet-cfgcli"
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/vmnet-cli"
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/vmrun"
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/vmware-vdiskmanager"
+  binary "#{appdir}/VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool"
 
   uninstall_preflight do
     set_ownership "#{staged_path}/VMware Fusion.app"


### PR DESCRIPTION
Modified all Casks with `binary` attribute to use `#{appdir}` to support changes from caskroom/homebrew-cask#13966