### PR TITLE
updated vivaldi-snapshot (1.2.490.32)

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.2.490.27'
-  sha256 '9c204a13a2a4609dde56d19f11dec4b2fdf64285369a415fa978b2cd6f277660'
+  version '1.2.490.32'
+  sha256 '2d6cbf8bcb76571a92003272fe42e08609b184161a8c6ce786d4f9bb2a32cfb6'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'b58fe186dd414a2f2470235bd1fb89d1e8e7fa151799f9251522206b50dbe5ac'
+          checkpoint: '59dfb49431e6e498e8acdc81f50da82e22b864475d4a95887b706dbff2797135'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
