### PR TITLE
Add docker-beta v1.11.1-beta13.1

### DIFF
--- a/casks/docker-beta.rb
+++ b/casks/docker-beta.rb
@@ -1,0 +1,13 @@
+cask 'docker-beta' do
+  version '1.11.1-beta13.1'
+  sha256 '431462c640961333d80fcd26995e6543093d2bc5a7384e86ce5f958b56d4c5ea'
+
+  url 'https://dyhfha9j6srsj.cloudfront.net/Docker.dmg'
+  name 'Docker for Mac - Beta'
+  homepage 'https://beta.docker.com/docs/'
+  license :gpl
+
+  app 'Docker.app'
+
+  caveats "Using #{token} requires an invitation code. Visit https://beta.docker.com to request a code."
+end


### PR DESCRIPTION
#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download docker-beta` is error-free.
- [x] `brew cask style --fix docker-beta` left no offenses.
- [x] `brew cask install docker-beta` worked successfully.
- [x] `brew cask uninstall docker-beta` worked successfully.
