### PR TITLE
Update airmail-beta to version 3.0,369

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0,368'
-  sha256 'b1da1a93f570c78e3507b75518b18d4f010fcd915b3be7477b0afc460801ae63'
+  version '3.0.0.369,248'
+  sha256 '5f93aa3f6c5f34a31002a2071c8b4f8948958cea4236a91ca97aeec46f98a037'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/247?format=zip&'
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '8a87130261608652a570838658fe20503d580407c704fbcb885f49d661e290e1'
+          checkpoint: 'dc31be4a6b08bfd479186e6aff447be49d0e76f41bd82c0ae150d75bd8f49dff'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
