### PR TITLE
updated libreoffice-dev (5.2.0.0,beta1)

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,10 +1,10 @@
 cask 'libreoffice-dev' do
-  version '5.2.0.0,alpha1'
-  sha256 '1dedfc3f7321edae7a592fc0f56d06e71e09fd0a87132010e81f7770ac32a525'
+  version '5.2.0.0,beta1'
+  sha256 '017daa1e2d2af8331512199b6ec1838938ee07eee472f6216048aa903a840dcc'
 
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version.before_comma}.#{version.after_comma}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'b7b14688525109c2709454f77524a6a17110a48e1e2b8b5492d69080dae0e02e'
+          checkpoint: '769fef0ee2625c4adedf8d7d05a26f3c9367c657ab8edb587a8ca8e572a6e7fe'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   license :mpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.