### PR TITLE
Remove outdated config file from delete stanza of IDEA-based IDEs

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -12,7 +12,6 @@ cask 'appcode-eap' do
   app 'AppCode 2016.2 EAP.app'
 
   zap delete: [
-                "~/.Appcode#{version.major_minor}",
                 "~/Library/Preferences/AppCode#{version.major_minor}",
                 "~/Library/Application Support/AppCode#{version.major_minor}",
                 "~/Library/Caches/AppCode#{version.major_minor}",

--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -12,7 +12,6 @@ cask 'clion-eap' do
   app 'CLion 2016.2 EAP.app'
 
   zap delete: [
-                '~/.CLion2016.2',
                 '~/Library/Preferences/CLion2016.2',
                 '~/Library/Application Support/CLion2016.2',
                 '~/Library/Caches/CLion2016.2',

--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -12,7 +12,6 @@ cask 'datagrip-eap' do
   app 'DataGrip.app'
 
   zap delete: [
-                "~/.DataGrip#{version.major_minor}",
                 "~/Library/Preferences/DataGrip#{version.major_minor}",
                 "~/Library/Application Support/DataGrip#{version.major_minor}",
                 "~/Library/Caches/DataGrip#{version.major_minor}",

--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -15,7 +15,6 @@ cask 'intellij-idea-ce-eap' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
-                "/~.IdeaIC#{version.major_minor}",
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
                 "~/Library/Preferences/IdeaIC#{version.major_minor}",
                 "~/Library/Caches/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -15,7 +15,6 @@ cask 'intellij-idea-ce' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
-                "/~.IdeaIC#{version.major_minor}",
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
                 "~/Library/Preferences/IdeaIC#{version.major_minor}",
                 "~/Library/Caches/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -14,7 +14,6 @@ cask 'intellij-idea-eap' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
-                "~/.IntelliJIdea#{version.major_minor}",
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
                 "~/Library/Application Support/IntelliJIdea#{version.major_minor}",

--- a/Casks/mps-eap.rb
+++ b/Casks/mps-eap.rb
@@ -12,7 +12,6 @@ cask 'mps-eap' do
   app "MPS #{version.major_minor} EAP.app"
 
   zap delete: [
-                "~/MPSSamples.#{version.major_minor}",
                 "~/Library/Application Support/MPS#{version.major_minor.no_dots}",
                 "~/Library/Preferences/MPS#{version.major_minor.no_dots}",
                 "~/Library/Caches/MPS#{version.major_minor.no_dots}",

--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -14,7 +14,6 @@ cask 'phpstorm-eap' do
   uninstall delete: '/usr/local/bin/pstorm'
 
   zap delete: [
-                '~/.PhpStorm2016.2',
                 '~/Library/Preferences/PhpStorm2016.2',
                 '~/Library/Caches/PhpStorm2016.2',
                 '~/Library/Logs/PhpStorm2016.2',

--- a/Casks/pycharm-ce-eap.rb
+++ b/Casks/pycharm-ce-eap.rb
@@ -15,7 +15,6 @@ cask 'pycharm-ce-eap' do
   uninstall delete: '/usr/local/bin/charm'
 
   zap delete: [
-                "~/.PyCharm#{version.major_minor}",
                 "~/Library/Preferences/PyCharm#{version.before_comma.major_minor}",
                 "~/Library/Application Support/PyCharm#{version.before_comma.major_minor}",
                 "~/Library/Caches/PyCharm#{version.before_comma.major_minor}",

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -15,7 +15,6 @@ cask 'pycharm-ce' do
   uninstall delete: '/usr/local/bin/charm'
 
   zap delete: [
-                "~/.PyCharm#{version.major_minor}",
                 "~/Library/Caches/PyCharm#{version.major_minor}",
                 "~/Library/Preferences/PyCharm#{version.major_minor}",
                 "~/Library/Logs/PyCharm#{version.major_minor}",

--- a/Casks/pycharm-eap.rb
+++ b/Casks/pycharm-eap.rb
@@ -14,7 +14,6 @@ cask 'pycharm-eap' do
   uninstall delete: '/usr/local/bin/charm'
 
   zap delete: [
-                '~/.PyCharm2016.2',
                 '~/Library/Preferences/PyCharm2016.2',
                 '~/Library/Application Support/PyCharm2016.2',
                 '~/Library/Caches/PyCharm2016.2',

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -11,7 +11,6 @@ cask 'pycharm-edu' do
   app 'PyCharm Edu.app'
 
   zap delete: [
-                "~/.PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Preferences/PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Application Support/PyCharmEdu#{version.major_minor.no_dots}",
                 "~/Library/Caches/PyCharmEdu#{version.major_minor.no_dots}",

--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -14,7 +14,6 @@ cask 'rubymine-eap' do
   uninstall delete: '/usr/local/bin/mine'
 
   zap delete: [
-                '~/.RubyMine2016.2',
                 '~/Library/Preferences/RubyMine2016.2',
                 '~/Library/Application Support/RubyMine2016.2',
                 '~/Library/Caches/RubyMine2016.2',

--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -14,7 +14,6 @@ cask 'webstorm-eap' do
   uninstall delete: '/usr/local/bin/wstorm'
 
   zap delete: [
-                '~/.WebStorm2016.2',
                 "~/Library/Preferences/WebStorm#{version.before_comma}",
                 "~/Library/Application Support/WebStorm#{version.before_comma}",
                 "~/Library/Caches/WebStorm#{version.before_comma}",


### PR DESCRIPTION
#### Editing an existing cask

- [ ] Commit message includes cask’s name (and new version, if applicable).
    - affects several casks, which are not explicitly listed
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

-----

These configuration dotfiles in the home directory used to exist in older versions, but aren't used anymore.
See previous [discussion](https://github.com/caskroom/homebrew-versions/pull/2066#discussion-diff-63899190) in #2066 and [Jetbrains' documentation](https://www.jetbrains.com/help/idea/2016.1/directories-used-by-intellij-idea-to-store-settings-caches-plugins-and-logs.html?origin=old_help#d152420e69).