### PR TITLE
update safari-technology-preview download url

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -2,7 +2,7 @@ cask 'safari-technology-preview' do
   version :latest
   sha256 :no_check
 
-  url 'https://secure-appldnld.apple.com/STP/SafariTechnologyPreview.dmg'
+  url 'http://appldnld.apple.com/STP/SafariTechnologyPreview.dmg'
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/technology-preview/'
   license :gratis


### PR DESCRIPTION
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download https://raw.githubusercontent.com/ptb/homebrew-versions/99acdbfa407422dee8e75dcb1030fd9881499cde/Casks/safari-technology-preview.rb` is error-free.
- [x] `brew cask style --fix safari-technology-preview.rb` left no offenses.

Previous download URL provided an out-of-date download. Current download page https://developer.apple.com/safari/download/ lists this new URL.