### PR TITLE
Add pgAdmin4 v1.0-beta1.

### DIFF
--- a/Casks/pgadmin4.rb
+++ b/Casks/pgadmin4.rb
@@ -1,0 +1,21 @@
+cask 'pgadmin4' do
+  version '1.0-beta1'
+  sha256 'ba004dcedff2a5d9bcc02ba50b3b0b429cd05a0f2ceba962a8afbea9120448f2'
+
+  # postgresql.org is the official download host per the vendor homepage
+  url "https://ftp.postgresql.org/pub/pgadmin3/pgadmin4/v#{version}/osx/pgadmin4-#{version}.dmg"
+  name 'pgAdmin4'
+  homepage 'http://pgadmin.org'
+  license :oss
+  gpg "#{url}.sig",
+      key_id: 'e0c4ceeb826b1fda4fb468e024adfaaf698f1519'
+
+  app 'pgAdmin 4.app'
+
+  zap delete: [
+                '~/.pgadmin',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.pgadmin.pgadmin4.sfl',
+                '~/Library/Preferences/org.pgadmin.pgAdmin 4.plist',
+                '~/Library/Saved Application State/org.pgadmin.pgAdmin4.savedState',
+              ]
+end


### PR DESCRIPTION
- [X] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [X] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [X] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Commit message includes cask’s name.
- [X] `brew cask audit --download pgadmin4` is error-free.
- [X] `brew cask style --fix pgadmin4` left no offenses.
- [X] `brew cask install pgadmin4` worked successfully.
- [X] `brew cask uninstall pgadmin4` worked successfully.

pgAdmin 4 is a complete rewrite of pgAdmin, written in
Python/Javascript, and deployable as a desktop or web application.
There's a much more modern look and feel, improved UI and workflows,
and more flexibility and reliability than pgAdmin 3. 