### PR TITLE
Add Adobe Photoshop Lightroom 4.4.1

### DIFF
--- a/Casks/adobe-photoshop-lightroom441.rb
+++ b/Casks/adobe-photoshop-lightroom441.rb
@@ -1,0 +1,20 @@
+cask 'adobe-photoshop-lightroom441' do
+  version '4.4.1'
+  sha256 '6d703aa5ea0022141c88746829e80c60f1169d746022655937c4196a6ca35dad'
+
+  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.to_i}.x/Lightroom_#{version.to_i}_LS11_mac_#{version.gsub('.', '_')}.dmg"
+  name 'Adobe Photoshop Lightroom'
+  homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
+  license :commercial
+
+  pkg "Adobe Photoshop Lightroom #{version.to_i}.pkg"
+
+  uninstall pkgutil: "com.adobe.Lightroom#{version.to_i}",
+            quit:    "com.adobe.Lightroom#{version.to_i}",
+            delete:  "/Applications/Adobe Photoshop Lightroom #{version.to_i}.app"
+
+  zap       delete: [
+                      '~/Library/Application Support/Adobe/Lightroom',
+                      "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist",
+                    ]
+end

--- a/Casks/adobe-photoshop-lightroom441.rb
+++ b/Casks/adobe-photoshop-lightroom441.rb
@@ -2,19 +2,19 @@ cask 'adobe-photoshop-lightroom441' do
   version '4.4.1'
   sha256 '6d703aa5ea0022141c88746829e80c60f1169d746022655937c4196a6ca35dad'
 
-  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.to_i}.x/Lightroom_#{version.to_i}_LS11_mac_#{version.gsub('.', '_')}.dmg"
+  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.major}.x/Lightroom_#{version.major}_LS11_mac_#{version.dots_to_underscores}.dmg"
   name 'Adobe Photoshop Lightroom'
   homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
   license :commercial
 
-  pkg "Adobe Photoshop Lightroom #{version.to_i}.pkg"
+  pkg "Adobe Photoshop Lightroom #{version.major}.pkg"
 
-  uninstall pkgutil: "com.adobe.Lightroom#{version.to_i}",
-            quit:    "com.adobe.Lightroom#{version.to_i}",
-            delete:  "/Applications/Adobe Photoshop Lightroom #{version.to_i}.app"
+  uninstall pkgutil: "com.adobe.Lightroom#{version.major}",
+            quit:    "com.adobe.Lightroom#{version.major}",
+            delete:  "/Applications/Adobe Photoshop Lightroom #{version.major}.app"
 
   zap       delete: [
                       '~/Library/Application Support/Adobe/Lightroom',
-                      "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist",
+                      "~/Library/Preferences/com.adobe.Lightroom#{version.major}.plist",
                     ]
 end

--- a/Casks/adobe-photoshop-lightroom571.rb
+++ b/Casks/adobe-photoshop-lightroom571.rb
@@ -2,19 +2,19 @@ cask 'adobe-photoshop-lightroom571' do
   version '5.7.1'
   sha256 '155a91e2c90927a05ccaa244a99fed4784fa7cf26d08c634f5f111629f6b0418'
 
-  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.to_i}.x/Lightroom_#{version.to_i}_LS11_mac_#{version.gsub('.', '_')}.dmg"
+  url "http://download.adobe.com/pub/adobe/lightroom/mac/#{version.major}.x/Lightroom_#{version.major}_LS11_mac_#{version.dots_to_underscores}.dmg"
   name 'Adobe Photoshop Lightroom'
   homepage 'https://www.adobe.com/products/photoshop-lightroom.html'
   license :commercial
 
-  pkg "Adobe Photoshop Lightroom #{version.to_i}.pkg"
+  pkg "Adobe Photoshop Lightroom #{version.major}.pkg"
 
-  uninstall pkgutil: "com.adobe.Lightroom#{version.to_i}",
-            quit:    "com.adobe.Lightroom#{version.to_i}",
-            delete:  "/Applications/Adobe Photoshop Lightroom #{version.to_i}.app"
+  uninstall pkgutil: "com.adobe.Lightroom#{version.major}",
+            quit:    "com.adobe.Lightroom#{version.major}",
+            delete:  "/Applications/Adobe Photoshop Lightroom #{version.major}.app"
 
   zap       delete: [
                       '~/Library/Application Support/Adobe/Lightroom',
-                      "~/Library/Preferences/com.adobe.Lightroom#{version.to_i}.plist",
+                      "~/Library/Preferences/com.adobe.Lightroom#{version.major}.plist",
                     ]
 end


### PR DESCRIPTION
Lightroom 4 previously existed as lightroom4.rb. It was removed here 9abfcf267b78a8a5adbc04a0eb1fccacdfaab002

Re-adding it and updating to 4.4.1 in a manner that is consistent with adobe-photoshop-lightroom571.rb

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

