### PR TITLE
Update for 3.0.3 version of iterm2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,6 +1,6 @@
 cask 'iterm2-beta' do
-  version '3.0.2'
-  sha256 'b3c6c6ee0e9d30a525102a169a4e4fcb20e0fc12ab4af4e57ef5cfe8c4dc9ef4'
+  version '3.0.3'
+  sha256 '4987591f76eb69ee9e6aa8450b0121275045bd5d7c3f3c767a125b2fb28370ae'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}-preview.zip"
   name 'iTerm2'


### PR DESCRIPTION
- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.

