### PR TITLE
updated iterm2-beta (3.0.3)

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -2,7 +2,7 @@ cask 'iterm2-beta' do
   version '3.0.3'
   sha256 '4987591f76eb69ee9e6aa8450b0121275045bd5d7c3f3c767a125b2fb28370ae'
 
-  url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}-preview.zip"
+  url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
   license :gpl


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The old URL format is outdated from version 3.0.3 but still work until version 3.0.2.
This commit will correct the URL format that work with version 3.0.2 and newer.
Don't know why #2240 passed the test before.