### PR TITLE
Updates java9-beta formula to get JDK 9 build 125

### DIFF
--- a/Casks/java9-beta.rb
+++ b/Casks/java9-beta.rb
@@ -1,6 +1,6 @@
 cask 'java9-beta' do
-  version '1.9,121'
-  sha256 '9490a6dc220fa55f78849f0a6d17ced2b786284e9424e73016c520df1933490f'
+  version '1.9,125'
+  sha256 'f75bfc64b9dd1c8d1b3a9cd8c025eab1577aed23c56ad2d8afe3315ed2c01a4d'
 
   url "http://www.java.net/download/java/jdk#{version.before_comma.minor}/archive/#{version.after_comma}/binaries/jdk-#{version.before_comma.minor}-ea+#{version.after_comma}_osx-x64_bin.dmg",
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }


### PR DESCRIPTION
This PR updates the `java9-beta` formula to install JDK 9 build 125, previous version installed build 121.

#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.

Actually this last one failed, although I don't think it is a blocker for this PR as the change is only the version and the checksum.

```
/usr/local/Library/Taps/caskroom/homebrew-versions/Casks ± ❯ brew cask style --fix java9-beta
Error: can't modify frozen String
  Most likely, this means you have an outdated version of homebrew-cask. Please run:

      brew uninstall --force brew-cask; brew untap phinze/cask; brew update; brew cleanup; brew cask cleanup

  If this doesn’t fix the problem, please report this bug:

      https://github.com/caskroom/homebrew-cask#reporting-bugs

/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/locations.rb:129:in `sub!'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/locations.rb:129:in `path'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/style.rb:36:in `block in cask_paths'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/style.rb:36:in `map'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/style.rb:36:in `cask_paths'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/style.rb:20:in `run'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli/style.rb:9:in `run'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli.rb:83:in `run_command'
/usr/local/Library/Taps/caskroom/homebrew-cask/lib/hbc/cli.rb:121:in `process'
/usr/local/Library/Taps/caskroom/homebrew-cask/cmd/brew-cask.rb:26:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/brew.rb:22:in `require?'
/usr/local/Library/brew.rb:93:in `<main>'
```
