### PR TITLE
added iterm2-legacy 2.1.4

### DIFF
--- a/Casks/iterm2-legacy.rb
+++ b/Casks/iterm2-legacy.rb
@@ -1,0 +1,20 @@
+cask 'iterm2-legacy' do
+  # note: "2" is not a version number, but indicates a different vendor
+  version '2.1.4'
+  sha256 '1062b83e7808dc1e13362f4a83ef770e1c24ea4ae090d1346b49f6196e9064cd'
+
+  url "https://iterm2.com/downloads/stable/iTerm2-#{version.gsub('.', '_')}.zip"
+  appcast 'https://iterm2.com/appcasts/final.xml',
+          checkpoint: '6f840c00431993ab1151c01facfd8d4dfbb13a94589657a6cb5d72505db3f448'
+  name 'iTerm2'
+  homepage 'https://www.iterm2.com/'
+  license :gpl
+
+  auto_updates true
+  depends_on macos: '>= :lion'
+  depends_on arch: :intel
+
+  app 'iTerm.app'
+
+  zap delete: '~/Library/Preferences/com.googlecode.iterm2.plist'
+end

--- a/Casks/iterm2-legacy.rb
+++ b/Casks/iterm2-legacy.rb
@@ -3,14 +3,13 @@ cask 'iterm2-legacy' do
   version '2.1.4'
   sha256 '1062b83e7808dc1e13362f4a83ef770e1c24ea4ae090d1346b49f6196e9064cd'
 
-  url "https://iterm2.com/downloads/stable/iTerm2-#{version.gsub('.', '_')}.zip"
-  appcast 'https://iterm2.com/appcasts/final.xml',
-          checkpoint: '6f840c00431993ab1151c01facfd8d4dfbb13a94589657a6cb5d72505db3f448'
+  url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
   license :gpl
 
   auto_updates true
+  conflicts_with cask: 'iterm2'
   depends_on macos: '>= :lion'
   depends_on arch: :intel
 


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

this is a port of the [formula](https://github.com/caskroom/homebrew-cask/blob/42437e5fcd93b1a3c95376794e6d5eee2b096160/Casks/iterm2.rb) from caskroom/homebrew-cask; i'm adding
this because there are backwards incompatibilities between iterm2 2.x
and iterm2 3.x, and people may need to stay on 2.x