### PR TITLE
Move macpaw-gemini into cask-versions (1.5.17,1461238766)

### DIFF
--- a/Casks/gemini-classic.rb
+++ b/Casks/gemini-classic.rb
@@ -1,0 +1,21 @@
+cask 'gemini-classic' do
+  version '1.5.17,1461238766'
+  sha256 'dc5ff641b38cb5798a26dc1b49f7c06566de5a79234f4a31c50eb6d2d985fcda'
+
+  # devmate.com/com.macpaw.site.Gemini was verified as official when first introduced to the cask
+  url "https://dl.devmate.com/com.macpaw.site.Gemini/#{version.before_comma}/#{version.after_comma}/MacPawGemini-#{version.before_comma}.zip"
+  appcast 'https://updates.devmate.com/com.macpaw.site.Gemini.xml',
+          checkpoint: '8746733eba43d74853ec04ad49467f7be9bcfcb62d047eac5a2af25aab554367'
+  name 'MacPaw Gemini'
+  homepage 'https://macpaw.com/gemini-classic'
+  license :commercial
+
+  app 'MacPaw Gemini.app'
+
+  zap delete: [
+                '~/Library/Application Support/MacPaw Gemini',
+                '~/Library/Caches/com.macpaw.site.Gemini',
+                '~/Library/Preferences/com.macpaw.site.Gemini.plist',
+                '~/Library/Saved Application State/com.macpaw.site.Gemini.savedState',
+              ]
+end


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

