### PR TITLE
add wiznote-beta.rb

### DIFF
--- a/Casks/wiznote-beta.rb
+++ b/Casks/wiznote-beta.rb
@@ -1,0 +1,11 @@
+cask 'wiznote-beta' do
+  version '2016-07-07'
+  sha256 '9ea993765583ed812ae66a372035b804e1f08084593e451b9877d4aa966f7d68'
+
+  url "http://cdn.wiz.cn/download/2016/wiznote-macos-#{version}.dmg"
+  name 'WizNote'
+  homepage 'http://www.wiz.cn/wiznote-mac.html'
+  license :gratis
+
+  app 'WizNote.app'
+end


### PR DESCRIPTION
The wiznote beta is released, so I add wiznote-beta:

<http://tieba.baidu.com/p/4655608505?pid=93402615615&cid=93423872091>
![Wiznote Mac 2.3.3 is out](https://cloud.githubusercontent.com/assets/1926185/16679177/130de23a-4518-11e6-85cc-63cb686d61bf.jpg)

# checklist

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

