### PR TITLE
Updated airmail-beta to version 3.0 (372,252)

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0.371,250'
-  sha256 '5a20938e37107b64575c986d15692573c0100dc64cf8acbcda96049920f5e89e'
+  version '3.0.372,252'
+  sha256 '817dc063946736ae7de253865d0afcdf44def6b9772bfb3fc87446061642eab3'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '82a85b04636f8325ee8cd2cc759260ce6c257231987f0c3adfc6ac0373d8ee93'
+          checkpoint: '839aa2f5404215e19347dcaa6150c33267eae05c5a8a42a7ee899f9c8a4e7a97'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.