### PR TITLE
pgAdmin4 1.0-beta3

### DIFF
--- a/Casks/pgadmin4.rb
+++ b/Casks/pgadmin4.rb
@@ -1,6 +1,6 @@
 cask 'pgadmin4' do
-  version '1.0-beta2'
-  sha256 'b6523c47e552e64e3112f9bb9902faf0a21905023f491de8997658aa876ca077'
+  version '1.0-beta3'
+  sha256 'b93bcae497d531cc870c3feb9dd5424b1f16793fdcceb03158bd07ac1a073e62'
 
   # postgresql.org is the official download host per the vendor homepage
   url "https://ftp.postgresql.org/pub/pgadmin3/pgadmin4/v#{version}/osx/pgadmin4-#{version}.dmg"

--- a/Casks/pgadmin4.rb
+++ b/Casks/pgadmin4.rb
@@ -2,7 +2,7 @@ cask 'pgadmin4' do
   version '1.0-beta3'
   sha256 'b93bcae497d531cc870c3feb9dd5424b1f16793fdcceb03158bd07ac1a073e62'
 
-  # postgresql.org is the official download host per the vendor homepage
+  # ftp.postgresql.org was verified as official when first introduced to the cask
   url "https://ftp.postgresql.org/pub/pgadmin3/pgadmin4/v#{version}/osx/pgadmin4-#{version}.dmg"
   name 'pgAdmin4'
   homepage 'http://pgadmin.org'


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The new beta for pgadmin4 was released a couple of days ago. The changes are available through redmine (needs registration): https://redmine.postgresql.org/versions/33

To summarize:

- Bug #1241: Inconsistent grid workflows
- Bug #1242: Cleanup busy indication for tree view and tab panes
- Bug #1360: query tool cut/paste keyboard shortcuts don't work
- Bug #1380: Error "get preferences error" displayed if Click on Clear Query tool window with Desktop Runtime Application
- Bug #1393: Cannot create serial/bigserial columns
- Bug #1399: The CodeMirror instance on the SQL tab doesn't always render properly
- Bug #1400: Application loading indicator
- Bug #1405: Unable to download query result to CSV in MacOSX
- Bug #1422: "Move to last page" warning shown unnecessarily
- Bug #1423: SQL panel should be greyed in Edit Data mode
- Bug #1425: Loading panel does not hide in Mac runtime
- Bug #1434: select2 control is broken in multi-select mode
- Bug #1435: "Move to last page" should also scroll to end
- Bug #1448: Internal server error displayed on web browser with latest git pull
- Bug #1471: OSX Usability Issues
- Feature #1389: Auto-discover installed servers on startup
