### PR TITLE
updated airmail-beta (3.0.2.379,260)

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0.2.378,259'
-  sha256 '2253ba96d279edfd1300e87b35add22c1585c6d802803c911db21c1792a27e29'
+  version '3.0.2.379,260'
+  sha256 'd747b4df458b0b880d7926b9fed9c8f66e2f51cbafd2905c38ba81547d17649f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '1449b8545d1fa8d863395267e73f540561d3ccc454017a50a29ed0a94d6fb58e'
+          checkpoint: '267b5bd344892fa5b793d51bc2dbeac5c0e20effdf9b3418fceb613aa2c60814'
   name 'AirMail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.