### PR TITLE
updated libreoffice-dev (5.2.0.3)

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,16 +1,17 @@
 cask 'libreoffice-dev' do
-  version '5.2.0.0,beta1'
-  sha256 '017daa1e2d2af8331512199b6ec1838938ee07eee472f6216048aa903a840dcc'
+  version '5.2.0.3'
+  sha256 'd31cfc1a0ed6651bd2bb3a158be6d2c9bd621b53670e56131e2dde5e4fe43d0d'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
-  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version.before_comma}.#{version.after_comma}_MacOS_x86-64.dmg"
+
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: '769fef0ee2625c4adedf8d7d05a26f3c9367c657ab8edb587a8ca8e572a6e7fe'
+          checkpoint: '786aaf1616a2abb056f0c9318893f737a5b537b6481b85830af5b6f351f17f51'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   license :mpl
   gpg "#{url}.asc",
       key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  app 'LibreOfficeDev.app'
+  app 'LibreOffice.app'
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.