### PR TITLE
Add emacs-pretest 25.1-rc1

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,0 +1,13 @@
+cask 'emacs-pretest' do
+  version '25.1-rc1'
+  sha256 '572dff6723feef0bda86218cfabe09663ed6df1b6a34594084f9a7dbdf957c77'
+
+  url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
+  appcast 'https://emacsformacosx.com/atom/pretest',
+          checkpoint: 'dd33e548cd86328cfd8e9524640c5596e2897276ed1735878da86eaa677288ad'
+  name 'Emacs'
+  homepage 'https://emacsformacosx.com/'
+  license :gpl
+
+  app 'Emacs.app'
+end


### PR DESCRIPTION
#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

---

We already have `emacs` (in core) and `emacs-nightly`, and it's natural to add `emacs-pretest` to complete the set of offerings from emacsforosx.com.