### PR TITLE
Upgrade emacs-nightly to 2016-07-14_01-41-56-453f883ef81388c39193b9289ef703954e9bc270

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,12 @@
 cask 'emacs-nightly' do
-  version '2016-07-14_01-41-56-453f883ef81388c39193b9289ef703954e9bc270'
-  sha256 'b28e649604dca73c242e91131dd8c37df52c0d2bd3239443adc2eaec2c365ae1'
+  version '2016-07-24_01-41-37-4d34210256c6e07cb713ece8d7ad998a873f0f94'
+  sha256 '33f010be39abd47b5574e88c00278b19498c7b801cb6538dedce38d50485482d'
 
-  url "http://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
+  url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
+  appcast 'https://emacsformacosx.com/atom/daily',
+          checkpoint: 'b43f26933d1d0ab8a623e3f95ad15f11753a514c01137d881988a5e532636435'
   name 'Emacs'
-  homepage 'http://emacsformacosx.com/'
+  homepage 'https://emacsformacosx.com/'
   license :gpl
 
   app 'Emacs.app'


### PR DESCRIPTION
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

Other fixes:

- Use HTTPS instead of HTTP;
- Add appcast.