### PR TITLE
Follow app brand name Airmail, not AirMail

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -6,9 +6,9 @@ cask 'airmail-beta' do
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
           checkpoint: 'c6232721b90c6ffd5d759c5b9911ec196b19c21c07bae51b326bc4341a642bfa'
-  name 'AirMail'
+  name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial
 
-  app 'AirMail Beta.app'
+  app 'Airmail Beta.app'
 end


### PR DESCRIPTION
The brand name is "Airmail" and the original filename is "Airmail Beta.app" but not "AirMail Beta.app".

## Checklist

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download airmail-beta.rb` is error-free.
- [x] `brew cask style --fix airmail-beta.rb` left no offenses.

```console
$ brew cask audit --download airmail-beta.rb
==> Downloading https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/261?format=zip&
Already downloaded: /Users/suin/Library/Caches/Homebrew/airmail-beta-3.0.2.380,261
==> Verifying checksum for Cask airmail-beta
audit for airmail-beta: passed
```

```console
$ brew cask style --fix airmail-beta.rb
==> Installing or updating 'rubocop-cask' gem
Fetching: public_suffix-2.0.2.gem (100%)
Successfully installed public_suffix-2.0.2
Fetching: rainbow-2.1.0.gem (100%)
Successfully installed rainbow-2.1.0
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.3.1.2.gem (100%)
Successfully installed parser-2.3.1.2
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: ruby-progressbar-1.8.1.gem (100%)
Successfully installed ruby-progressbar-1.8.1
Fetching: unicode-display_width-1.1.0.gem (100%)
Successfully installed unicode-display_width-1.1.0
Fetching: rubocop-0.41.2.gem (100%)
Successfully installed rubocop-0.41.2
Fetching: rubocop-cask-0.8.3.gem (100%)
Successfully installed rubocop-cask-0.8.3
9 gems installed

1 file inspected, no offenses detected
```