### PR TITLE
updated firefox-zh-tw (48.0)

### DIFF
--- a/Casks/firefox-zh-tw.rb
+++ b/Casks/firefox-zh-tw.rb
@@ -1,6 +1,6 @@
 cask 'firefox-zh-tw' do
-  version '47.0.1'
-  sha256 '5d94c0829147b9ceeb4f01f2a23b0baf272e2bb5ece7fbfa6c3c408b6ddf2366'
+  version '48.0'
+  sha256 '645878ec11c398382c6fa0925aa74c9a004a02c5c0a4e6a40b5daad74e548714'
 
   # mozilla.org was verified as official when first introduced to the cask
   url "https://download.mozilla.org/?product=firefox-#{version}-SSL&os=osx&lang=zh-TW"


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
