### PR TITLE
Fix app name of phpstorm-eap for install

### DIFF
--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -9,7 +9,7 @@ cask 'phpstorm-eap' do
 
   conflicts_with cask: 'phpstorm'
 
-  app 'PhpStorm 2016.2 EAP.app'
+  app 'PhpStorm 2016.2.1 EAP.app'
 
   uninstall delete: '/usr/local/bin/pstorm'
 


### PR DESCRIPTION
##### Instructions

- Look for and complete the section relevant to your submission. Delete the others, including these `Instructions`.
- `{{cask_file}}` represents the cask file you’re submitting/editing (if applicable).
- If there’s a checkbox you can’t complete for any reason, that’s OK. Just explain in detail why you weren’t able to do so.

### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

The wrong app name will cause a problem for install.