### PR TITLE
Cask repair: vlc-nightly

### DIFF
--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -10,9 +10,5 @@ cask 'vlc-nightly' do
   depends_on macos: '>= :lion'
   container type: :dmg
 
-  # Renamed to prevent conflict with current VLC, if installed.
-  app 'VLC.app', target: 'VLC (Nightly).app'
-
-  caveats "As prerelease software, #{token} could be unstable, defective or not run at all."
-  caveats "While #{token} will install alonside a current VLC, they share preferences which could become corrupt and require resetting."
+  app 'VLC.app'
 end

--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -8,7 +8,6 @@ cask 'vlc-nightly' do
   license :oss
 
   depends_on macos: '>= :lion'
-  container type: :dmg
 
   app 'VLC.app'
 end

--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -8,6 +8,11 @@ cask 'vlc-nightly' do
   license :oss
 
   depends_on macos: '>= :lion'
+  container type: :dmg
 
-  app 'vlc-3.0.0-git/VLC.app'
+  # Renamed to prevent conflict with current VLC, if installed.
+  app 'VLC.app', target: 'VLC (Nightly).app'
+
+  caveats "As prerelease software, #{token} could be unstable, defective or not run at all."
+  caveats "While #{token} will install alonside a current VLC, they share preferences which could become corrupt and require resetting."
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download vlc-nightly` is error-free.
- [x] `brew cask style --fix vlc-nightly` left no offences.

I was getting the error:

```shell
Error: It seems the App source is not there: '/usr/local/Caskroom/vlc-nightly/latest/vlc-3.0.0-git/VLC.app'
```

- Added correct container type 'dmg'
- Added target to allow installation alongside current VLC.app, sharing prefs.
- Added two caveats(!)

Up until yesterday I was manually installing (_I should start using casks more!_) and added the caveats as both have affected me while hacking on a libass-based tool that needs VLC 3.0.0 nightlies.

Fixing prefs corruption is as simple as clicking the 'Reset all' button in VLC's prefs panel, but if someone has spent time tuning up their config in VLC 2.x, it's probably worth warning that sharing prefs with the nightly could cause loss of that configuration.