### PR TITLE
Remove caveat about losing data in torbrowser-alpha

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -10,9 +10,4 @@ cask 'torbrowser-alpha' do
       key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
 
   app 'TorBrowser.app'
-
-  caveats <<-EOS.undent
-    If you already have a version of TorBrowser installed this will overwrite your local settings.
-    It is recommended to use TorBrowser's built-in update mechanism after the first install to keep your settings.
-  EOS
 end


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Since version 6 the Torbrowser is codesigned on MacOS. Due to the new folder layout necessary for this change the user profile is not stored in the application bundle anymore. This means that you will not lose your settings anymore when overwriting an existing Torbrowser. The caveat can thus be removed.