### PR TITLE
updated vivaldi-snapshot (1.3.551.28)

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.3.551.21'
-  sha256 '387399a48f9d38640f54b177f2632254e62a7e757658165cbc3d9bb27ca7ab26'
+  version '1.3.551.28'
+  sha256 '7892c135210b7fb246d75d7825e6a3c8a63076a9afb971e6903007c606906b8f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'b6ab1aa1216263ff273d7bc7600b169996deeca1e55f2370417055c0428a16cc'
+          checkpoint: '0453ef97754fe377e800eb9ca93c920c52a7b2e364cd1733f51dba75e06091c0'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
   license :gratis


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
