### PR TITLE
Unity (5.2.3f)

### DIFF
--- a/Casks/unity523.rb
+++ b/Casks/unity523.rb
@@ -9,6 +9,6 @@ cask 'unity523' do
 
   pkg "Unity-#{version}.pkg"
 
-  uninstall :quit => 'com.unity3d.UnityEditor5.x',
-            :pkgutil => 'com.unity3d.UnityEditor5.x'
+  uninstall quit:    'com.unity3d.UnityEditor5.x',
+            pkgutil: 'com.unity3d.UnityEditor5.x'
 end

--- a/Casks/unity523.rb
+++ b/Casks/unity523.rb
@@ -1,0 +1,14 @@
+cask 'unity523' do
+  version '5.2.3f1'
+  sha256 'a2cf141409078a8e1934a0dede357578580e318c21275696b57346acbcbd284c'
+
+  url 'http://download.unity3d.com/download_unity/f3d16a1fa2dd/MacEditorInstaller/Unity-5.2.3f1.pkg'
+  name 'Unity Editor'
+  homepage 'https://unity3d.com/unity/'
+  license :commercial
+
+  pkg "Unity-#{version}.pkg"
+
+  uninstall :quit => 'com.unity3d.UnityEditor5.x',
+            :pkgutil => 'com.unity3d.UnityEditor5.x'
+end


### PR DESCRIPTION
Added Version `5.2.3f` for Unity. We have a continuous-integration requirement to peg the version to this older one, and are actively working on moving to the later `5.4`. 

For context, [our product](https://improbable.io/docs/7.0) integrates to Unity, so we're happy to support this long-term.

### Changes to a cask

#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download unity523` is error-free.
- [x] `brew cask style --fix unity523` left no offenses.
- [x] `brew cask install unity523` worked successfully.
- [x] `brew cask uninstall unity523` worked successfully.

