### PR TITLE
Mirror kicad.rb formula from homebrew-cask

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -4,9 +4,14 @@ cask 'kicad-nightly' do
 
   url "http://downloads.kicad-pcb.org/osx/nightly/kicad-#{version}.dmg"
   name 'KiCad'
-  homepage 'http://www.kicad-pcb.org'
+  homepage 'http://www.kicad-pcb.org/'
   license :gpl
 
-  suite 'Kicad'
-  artifact 'kicad', target: Pathname.new(File.expand_path('~')).join('Library/Application Support/kicad')
+  suite 'Kicad-apps', target: 'Kicad'
+  artifact 'kicad', target: "#{ENV['HOME']}/Library/Application Support/kicad"
+
+  preflight do
+    system_command '/bin/mkdir', args: ['--', "#{staged_path}/Kicad-apps"]
+    system_command '/bin/mv', args: ['--', *Dir["#{staged_path}/Kicad/*.app"], "#{staged_path}/Kicad-apps/"]
+  end
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download kicad-nightly` is error-free.
- [x] `brew cask style --fix kicad-nightly` left no offenses.

Contents of Kicad and kicad directories end up together on a case-insensitive filesystem. This hack installs the files to their intended location.