### PR TITLE
updated rubymine-eap (2016.2.2,162.1628.31)

### DIFF
--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -1,8 +1,8 @@
 cask 'rubymine-eap' do
-  version '162.1628.31,2016.2.2'
+  version '2016.2.2,162.1628.31'
   sha256 'cef6016ed186296ff9c872eb8e127faeea82f4f808f0082b71758f4d719890d1'
 
-  url "https://download.jetbrains.com/ruby/RubyMine-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/ruby/RubyMine-#{version.after_comma}.dmg"
   name 'RubyMine EAP'
   homepage 'https://confluence.jetbrains.com/display/RUBYDEV/Early+Access+Program'
   license :commercial
@@ -14,9 +14,9 @@ cask 'rubymine-eap' do
   uninstall delete: '/usr/local/bin/mine'
 
   zap delete: [
-                "~/Library/Preferences/RubyMine#{version.after_comma.major_minor}",
-                "~/Library/Application Support/RubyMine#{version.after_comma.major_minor}",
-                "~/Library/Caches/RubyMine#{version.after_comma.major_minor}",
-                "~/Library/Logs/RubyMine#{version.after_comma.major_minor}",
+                "~/Library/Preferences/RubyMine#{version.major_minor}",
+                "~/Library/Application Support/RubyMine#{version.major_minor}",
+                "~/Library/Caches/RubyMine#{version.major_minor}",
+                "~/Library/Logs/RubyMine#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask
I think that it's better to put end-user version before version of build.
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.