### PR TITLE
Fix kinematic-beta sha256 not matching current v0.12.0 download

### DIFF
--- a/Casks/kinematic-beta.rb
+++ b/Casks/kinematic-beta.rb
@@ -1,6 +1,6 @@
 cask 'kinematic-beta' do
   version '0.12.0'
-  sha256 '161d702e25cfda4337c5f9b1315ad1487b287cd581e8951caee7ff529595370c'
+  sha256 '0d6770197ed1db1c9a653c78bc51bb0d1483882233cf2d2bf688609b1a5251ef'
 
   # github.com/docker/kitematic was verified as official when first introduced to the cask
   url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

---

I don't know if this change is the best route, but right now when I try to install the kinematic-beta I'm told the checksum doesn't match:

```
❯ brew cask install kinematic-beta
==> Downloading https://github.com/docker/kitematic/releases/download/v0.12.0/Kitematic-0
==> Verifying checksum for Cask kinematic-beta
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 161d702e25cfda4337c5f9b1315ad1487b287cd581e8951caee7ff529595370c
Actual: 0d6770197ed1db1c9a653c78bc51bb0d1483882233cf2d2bf688609b1a5251ef
File: /Users/andrew/Library/Caches/Homebrew/Cask/kinematic-beta--0.12.0.zip
To retry an incomplete download, remove the file above.
```

I snagged the value via a direct download of kitematic from GitHub:

```bash
curl -sL https://github.com/docker/kitematic/releases/download/v0.12.0/Kitematic-0.12.0-Mac.zip \
    | shasum -a 256
```

So, I just updated the `sha256` value.