### PR TITLE
Update Android Studio Canary to 2.2.0.8,145.3200535

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.2.0.7,145.3128856'
-  sha256 '746107da4155e605c1a18d120fb7504f0cba80bd347ec4892150591a9f1887c5'
+  version '2.2.0.8,145.3200535'
+  sha256 '1631dc57dbb71be819049438a80793e99548bde68de417e112337f006ac039d2'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
#### Editing an existing cask

- [X] Commit message includes cask’s name (and new version, if applicable).
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` left no offenses.
