### PR TITLE
Add sublime-text2 (2.0.2)

### DIFF
--- a/Casks/sublime-text2.rb
+++ b/Casks/sublime-text2.rb
@@ -1,0 +1,25 @@
+cask 'sublime-text2' do
+  version '2.0.2'
+  sha256 '906e71e19ae5321f80e7cf42eab8355146d8f2c3fd55be1f7fe5c62c57165add'
+
+  url "https://download.sublimetext.com/Sublime%20Text%20#{version}.dmg"
+  appcast 'https://www.sublimetext.com/updates/2/stable/appcast_osx.xml',
+          checkpoint: '1f88d22b2ed5ba5a9213accf500ca8f1a9723b391fbbbc45ffb23cd98c98519c'
+  name 'Sublime Text 2'
+  homepage 'https://www.sublimetext.com/2'
+  license :closed
+
+  app 'Sublime Text 2.app'
+  binary "#{appdir}/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+
+  zap delete: [
+                '~/Library/Application Support/Sublime Text 2',
+                '~/Library/Preferences/com.sublimetext.2.plist',
+                '~/Library/Caches/com.sublimetext.2',
+                '~/Library/Saved Application State/com.sublimetext.2.savedState',
+              ]
+
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
Adding Sublime Text 2 to the versions tap, as Sublime Text 3 is now the default. Some still use Sublime Text 2 as 3 still technically has the "beta" label"

Grabbed the [last version](https://github.com/caskroom/homebrew-cask/blob/eefe595fd3e8f39a0a03aabd27c7313fc6007c1a/Casks/sublime-text.rb) of the Sublime Text 2 cask from the git history.

-----
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
