### PR TITLE
add parallels-desktop11 (11.2.1-32626)

### DIFF
--- a/Casks/parallels-desktop11.rb
+++ b/Casks/parallels-desktop11.rb
@@ -1,0 +1,43 @@
+cask 'parallels-desktop11' do
+  version '11.2.1-32626'
+  sha256 '4a275ad7a356fc2efba0a86ecbcf34eb5df5b216a02a700f03062e3a9cdde2ce'
+
+  url "https://download.parallels.com/desktop/v#{version[%r{^\w+}]}/#{version}/ParallelsDesktop-#{version}.dmg"
+  name 'Parallels Desktop'
+  homepage 'https://www.parallels.com/products/desktop/'
+  license :commercial
+
+  app 'Parallels Desktop.app'
+
+  postflight do
+    # Unhide the application
+    system '/usr/bin/sudo', '-E', '--', 'chflags', 'nohidden', "#{appdir}/Parallels Desktop.app"
+
+    # Run the initialization script
+    system '/usr/bin/sudo', '-E', '--',
+           "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
+           'init', '-b', "#{appdir}/Parallels Desktop.app"
+  end
+
+  uninstall_preflight do
+    set_ownership "#{appdir}/Parallels Desktop.app"
+  end
+
+  uninstall delete: [
+                      '/usr/bin/prl_convert',
+                      '/usr/bin/prl_disk_tool',
+                      '/usr/bin/prl_perf_ctl',
+                      '/usr/bin/prlctl',
+                      '/usr/bin/prlsrvctl',
+                    ]
+
+  zap       delete: [
+                      '~/.parallels_settings',
+                      '~/Library/Caches/com.parallels.desktop.console',
+                      '~/Library/Preferences/com.parallels.desktop.console.LSSharedFileList.plist',
+                      '~/Library/Preferences/com.parallels.desktop.console.plist',
+                      '~/Library/Preferences/com.parallels.Parallels Desktop Statistics.plist',
+                      '~/Library/Preferences/com.parallels.Parallels Desktop.plist',
+                      '~/Library/Preferences/com.parallels.Parallels.plist',
+                    ]
+end


### PR DESCRIPTION
add older version of Parallels Desktop

#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] Checked the cask follows the requirements of [acceptable casks](https://github.com/caskroom/homebrew-versions#acceptable-casks).
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
