### PR TITLE
Add alfred-2 (2.8.4_437)

### DIFF
--- a/Casks/alfred-2.rb
+++ b/Casks/alfred-2.rb
@@ -1,0 +1,30 @@
+cask 'alfred-2' do
+  version '2.8.4_437'
+  sha256 'def068cc763213aba11c07c18cd432740c81026deb31711699f7545e757846b5'
+
+  url "https://cachefly.alfredapp.com/Alfred_#{version}.zip"
+  name 'Alfred'
+  homepage 'https://www.alfredapp.com/'
+  license :freemium
+
+  auto_updates true
+  accessibility_access true
+
+  app 'Alfred 2.app'
+
+  postflight do
+    suppress_move_to_applications key: 'suppressMoveToApplications'
+  end
+
+  uninstall quit:       'com.runningwithcrayons.Alfred-2',
+            login_item: 'Alfred 2'
+
+  zap delete: [
+                '~/Library/Application Support/Alfred 2',
+                '~/Library/Caches/com.runningwithcrayons.Alfred-2',
+                '~/Library/Caches/com.runningwithcrayons.Alfred-Preferences',
+                '~/Library/Preferences/com.runningwithcrayons.Alfred-2.plist',
+                '~/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.plist',
+                '~/Library/Saved Application State/com.runningwithcrayons.Alfred-Preferences.savedState',
+              ]
+end


### PR DESCRIPTION
Since Alfred 3 was released, someone requested that Alfred 2 remain installable via Cask (see caskroom/homebrew-cask#21390). It seemed simple enough to find the last Alfred 2 cask and add it to homebrew/versions here, so I thought I'd take the liberty of doing so.

### Checklist

- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:

- [X] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [X] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [X] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.