### PR TITLE
Update Android Studio Canary to 2.2.0.9,145.3225885

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.2.0.8,145.3200535'
-  sha256 '1631dc57dbb71be819049438a80793e99548bde68de417e112337f006ac039d2'
+  version '2.2.0.9,145.3225885'
+  sha256 'a63ef7c0145379ffd1df145907bb024e6e3ed460a012c7e731c3fedc1c8eba0c'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` left no offenses.
