### PR TITLE
Added "Vega.app" (32bit / latest) cask

### DIFF
--- a/Casks/vega-32bit.rb
+++ b/Casks/vega-32bit.rb
@@ -1,0 +1,12 @@
+cask 'vega-32bit' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://dist.subgraph.com/downloads/Vega.dmg'
+  name 'Vega'
+  name 'Vega (32bit)'
+  homepage 'https://subgraph.com/vega/index.en.html'
+  license :unknown
+
+  app 'Vega.app'
+end


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download vega-32bit` is error-free.
- [x] `brew cask style --fix vega-32bit` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install vega-32bit` worked successfully.
- [x] `brew cask uninstall vega-32bit` worked successfully.

Added 32bit version of the latest release of "Vega.app" as new cask
vega-32bit.rb