### PR TITLE
Add IntelliJ IDEA 2016.3 EAP

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,0 +1,23 @@
+cask 'intellij-idea-next-ce-eap' do
+  version '2016.3,163.3094.26'
+  sha256 'fc5f83092ff30e2cdb723d8a70b49cd5603b22aebb176591090369bd568c72d9'
+
+  url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
+  name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"
+  name "IntelliJ IDEA #{version.major_minor} CE EAP"
+  homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
+  license :apache
+
+  auto_updates true
+
+  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
+
+  uninstall delete: '/usr/local/bin/idea'
+
+  zap delete: [
+                "~/Library/Application Support/IdeaIC#{version.major_minor}",
+                "~/Library/Preferences/IdeaIC#{version.major_minor}",
+                "~/Library/Caches/IdeaIC#{version.major_minor}",
+                "~/Library/Logs/IdeaIC#{version.major_minor}",
+              ]
+end

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,0 +1,22 @@
+cask 'intellij-idea-next-eap' do
+  version '2016.3,163.3094.26'
+  sha256 '781c04045250bd694e1d75803c983b8a9d39d6c355ed84770e0b813e8efdabb8'
+
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
+  name "IntelliJ IDEA #{version.major_minor} EAP"
+  homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
+  license :commercial
+
+  auto_updates true
+
+  app "IntelliJ IDEA #{version.before_comma} EAP.app"
+
+  uninstall delete: '/usr/local/bin/idea'
+
+  zap delete: [
+                "~/Library/Caches/IntelliJIdea#{version.major_minor}",
+                "~/Library/Logs/IntelliJIdea#{version.major_minor}",
+                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
+                "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
+              ]
+end


### PR DESCRIPTION
IntelliJ IDEA has three EAPs for: 
- previous release
- current release
- next release

with dedicated subpages for each one. Plesae review [EAP home page](https://confluence.jetbrains.com/display/IDEADEV/EAP).

My proposition is to keep track of each one individually and this is PR for **next** (2016.3) release.

### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:

- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

