### PR TITLE
updated tower-beta (2.5.0-323,323-7f74ce35)

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.5.0-322,322-55d816d5'
-  sha256 'd1ef7ba334572ea7fee0075a88a83905a6fd931cc6b792823fdb428e20456ed3'
+  version '2.5.0-323,323-7f74ce35'
+  sha256 '1a774f55edf144ee0cddb6b1b650cde2777a5b560539021157d86a9b731b584d'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: 'b9b9c63dc0a5153aaf4feaa89b523f6fda1e561868de1bf56f91ba5f27b404a1'
+          checkpoint: 'cd1529de4d56eb1cd99033d770c4d584441b4a816c97869e288a00275a40d5b7'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
   license :commercial


### PR DESCRIPTION
### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
