### PR TITLE
Update IntelliJ IDEA 2016.2.3 EAP platform to build 162.1812.17

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-ce-eap' do
-  version '2016.2.3,162.1812.8'
-  sha256 '19f2cda851b3a97541de965091de76d36901cd667bec192cb16462ad70de9054'
+  version '2016.2.3,162.1812.17'
+  sha256 '3a180ff30a8c9b7bf8bf38f6297fcd9ec6d8994e2b0489b97bfbeead362fb3b8'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Community Edition EAP'
@@ -10,7 +10,7 @@ cask 'intellij-idea-ce-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
+  app 'IntelliJ IDEA CE.app'
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-eap' do
-  version '2016.3,163.3094.26'
-  sha256 '781c04045250bd694e1d75803c983b8a9d39d6c355ed84770e0b813e8efdabb8'
+  version '2016.2.3,162.1812.8'
+  sha256 'e62a328308b8ea05c2acc5f8a53ec1b5ff6f87d72352a332ee218a05d7afcd4b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA EAP'

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-eap' do
-  version '2016.2.3,162.1812.8'
-  sha256 'e62a328308b8ea05c2acc5f8a53ec1b5ff6f87d72352a332ee218a05d7afcd4b'
+  version '2016.2.3,162.1812.17'
+  sha256 '19955c3a22afed0471eeecea0b8fd173939e3d51a87d2d98264303f9638b99b0'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA EAP'
@@ -9,7 +9,7 @@ cask 'intellij-idea-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} EAP.app"
+  app 'IntelliJ IDEA.app'
 
   uninstall delete: '/usr/local/bin/idea'
 


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

I've also reverted #2523 since next release of IntelliJ IDEA has it's own dedicated cask, see #2508.