### PR TITLE
Remove uninstall delete directive from IntelliJ IDEA casks

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -12,8 +12,6 @@ cask 'intellij-idea-ce-eap' do
 
   app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
 
-  uninstall delete: '/usr/local/bin/idea'
-
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
                 "~/Library/Preferences/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -12,8 +12,6 @@ cask 'intellij-idea-ce' do
 
   app 'IntelliJ IDEA CE.app'
 
-  uninstall delete: '/usr/local/bin/idea'
-
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
                 "~/Library/Preferences/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -11,8 +11,6 @@ cask 'intellij-idea-eap' do
 
   app "IntelliJ IDEA #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/idea'
-
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -12,8 +12,6 @@ cask 'intellij-idea-next-ce-eap' do
 
   app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
 
-  uninstall delete: '/usr/local/bin/idea'
-
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
                 "~/Library/Preferences/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -11,8 +11,6 @@ cask 'intellij-idea-next-eap' do
 
   app "IntelliJ IDEA #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/idea'
-
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

None of Intellij IDEA product is linked into the `/usr/local/bin` during installation so they should be removed during uninstallation.