### PR TITLE
updated sequel-pro-nightly download url

### DIFF
--- a/Casks/sequel-pro-nightly.rb
+++ b/Casks/sequel-pro-nightly.rb
@@ -2,7 +2,7 @@ cask 'sequel-pro-nightly' do
   version 'r50a0f18540'
   sha256 '9edb2e6c023088175d1a136e1ad6647819e6315eb4f48dbcec353ec150edac15'
 
-  url "http://nightly.sequelpro.com/builds/Sequel_Pro_#{version}.dmg"
+  url "https://sequelpro.com/Sequel_Pro_#{version}.dmg"
   name 'Sequel Pro'
   homepage 'http://nightly.sequelpro.com/'
   license :mit


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.*
- [x] `brew cask audit --download sequel-pro-nightly` is error-free.
- [x] `brew cask style --fix sequel-pro-nightly` left no offenses.

*minus the version.

At the moment nightly builds are unavailable at the original url, but they've hosted the last version on their main url. 

See: https://sequelpro.com/nightly/

This simply updates this cask to work and not fail.