### PR TITLE
Add Docker for Mac Beta (1.12.1.11525)

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,0 +1,25 @@
+cask 'docker-beta' do
+  version '1.12.1.11525'
+  sha256 '95cdef690943272b00f701c06f1ef4954c0cae7a3a454e91f1d5cad407252e1f'
+
+  url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
+  appcast 'https://download.docker.com/mac/beta/appcast.xml',
+          checkpoint: 'fcfc6aa7674b26ff0ee1131fcda26dd1be14be88e666fabe88a631ba591bf231'
+  name 'Docker for Mac Beta'
+  homepage 'https://www.docker.com/products/docker'
+  license :gratis
+
+  auto_updates true
+
+  app 'Docker.app'
+
+  uninstall quit: 'com.docker.docker'
+
+  zap delete: [
+                '~/.docker',
+                '~/Library/Caches/com.docker.docker',
+                '~/Library/Containers/com.docker.docker',
+                '~/Library/Preferences/com.docker.docker.plist',
+                '~/Library/Group Containers/group.com.docker',
+              ]
+end


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [ ] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

---

Docker for Mac now provides a public beta channel. #2148