### PR TITLE
updated tower-beta (2.5.0-327,327-cedf62ec)

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.5.0-323,323-7f74ce35'
-  sha256 '1a774f55edf144ee0cddb6b1b650cde2777a5b560539021157d86a9b731b584d'
+  version '2.5.0-327,327-cedf62ec'
+  sha256 '3b7803420ef379b07db09566aa3a2d20f2eb3423427802be6a6efd6d076ff4c8'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: 'cd1529de4d56eb1cd99033d770c4d584441b4a816c97869e288a00275a40d5b7'
+          checkpoint: 'be6041bd4e7fe51adf7a44d2db7c69d6c49e3404a97f1170ebc372e9cf03a84a'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
   license :commercial


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
