### PR TITLE
Update Docker for Mac Beta to 1.12.1.11807

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '1.12.1.11525'
-  sha256 '95cdef690943272b00f701c06f1ef4954c0cae7a3a454e91f1d5cad407252e1f'
+  version '1.12.1.11807'
+  sha256 'e1ef592d7aa9d6bb66ac6bff94c4f5b9cbe8da088984cae0f2ab6a505b514b50'
 
   url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'fcfc6aa7674b26ff0ee1131fcda26dd1be14be88e666fabe88a631ba591bf231'
+          checkpoint: '4e009f0ef12ef38f3dfc9cc5fb2352d74c28659aebaaf439929dccfeaf2d64c7'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/products/docker'
   license :gratis


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
