### PR TITLE
Add British English version of Adobe Photoshop

### DIFF
--- a/Casks/adobe-photoshop-cc-gb.rb
+++ b/Casks/adobe-photoshop-cc-gb.rb
@@ -1,0 +1,40 @@
+cask 'adobe-photoshop-cc-gb' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://trials3.adobe.com/AdobeProducts/PHSP/16/osx10/Photoshop_16_LS20.dmg',
+      user_agent: :fake,
+      cookies:    { 'MM_TRIALS' => '1234' }
+  name 'Adobe Photoshop CC 2015'
+  homepage 'https://adobe.com/products/photoshop'
+  license :commercial
+
+  conflicts_with cask: 'adobe-photoshop-cc'
+
+  preflight do
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe Photoshop CC 2015/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe\ Photoshop\ CC\ 2015/Deployment/en_GB_Deployment.xml"
+  end
+
+  uninstall_preflight do
+    uninstall_xml = "#{staged_path}/uninstall.xml"
+
+    IO.write uninstall_xml, <<-EOF.undent
+      <?xml version="1.0" encoding="utf-8"?>
+      <Deployment>
+        <Properties>
+          <Property name="removeUserPrefs">0</Property>
+          <Property name="mediaSignature">{2614BC86-757D-4293-9E25-E4E16F370A9E}</Property>
+        </Properties>
+        <Payloads>
+          <Payload adobeCode="{2614BC86-757D-4293-9E25-E4E16F370A9E}">
+            <Action>remove</Action>
+          </Payload>
+        </Payloads>
+      </Deployment>
+    EOF
+
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe Photoshop CC 2015/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{uninstall_xml}"
+  end
+
+  uninstall rmdir: '/Applications/Utilities/Adobe Installers'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download adobe-photoshop-cc-gb` is error-free.
- [x] `brew cask style --fix adobe-photoshop-cc-gb` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install adobe-photoshop-cc-gb` worked successfully.
- [x] `brew cask uninstall adobe-photoshop-cc-gb` worked successfully.