### PR TITLE
Add British English version of Adobe Illustrator

### DIFF
--- a/Casks/adobe-illustrator-cc-gb.rb
+++ b/Casks/adobe-illustrator-cc-gb.rb
@@ -1,0 +1,27 @@
+cask 'adobe-illustrator-cc-gb' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://trials3.adobe.com/AdobeProducts/ILST/19/osx10-64/Illustrator_19_LS20.dmg',
+      user_agent: :fake,
+      cookies:    { 'MM_TRIALS' => '1234' }
+  name 'Adobe Illustrator CC 2015'
+  homepage 'https://adobe.com/products/illustrator'
+  license :commercial
+
+  conflicts_with cask: 'adobe-illustrator-cc'
+
+  preflight do
+    deployment_xml = "#{staged_path}/Adobe Illustrator CC 2015/Deployment/deployment.xml"
+
+    IO.write(deployment_xml, IO.read(deployment_xml).gsub('>en_US<', '>en_GB<'))
+
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe Illustrator CC 2015/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{deployment_xml}"
+  end
+
+  uninstall_preflight do
+    system '/usr/bin/sudo', '-E', '--', "#{staged_path}/Adobe Illustrator CC 2015/Install.app/Contents/MacOS/Install", '--mode=silent', "--deploymentFile=#{staged_path}/Adobe\ Illustrator\ CC\ 2015/Deployment/uninstall.xml"
+  end
+
+  uninstall rmdir: '/Applications/Utilities/Adobe Installers'
+end


### PR DESCRIPTION
### Checklist
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download adobe-illustrator-cc-gb` is error-free.
- [x] `brew cask style --fix adobe-illustrator-cc-gb` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install adobe-illustrator-cc-gb` worked successfully.
- [x] `brew cask uninstall adobe-illustrator-cc-gb` worked successfully.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>