### PR TITLE
Update Android Studio Canary to 2.2.0.11,145.3253452

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.2.0.10,145.3240973'
-  sha256 'a1b46236107e6119aa45912b72e433d4599fe2a82089c6c3a2c5c3054750fa12'
+  version '2.2.0.11,145.3253452'
+  sha256 'd173bcb01a8c2eabf7c1ac4f65c817dbed2d244f71e80262c6c12afda8b83c45'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [X] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` left no offenses.
