### PR TITLE
updated airmail-beta (3.0.2.384,264)

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0.2.383,262'
-  sha256 '5d8e723f0911b7a53f40f5af684ac5fec36b37daf5fa12d15008f841191ad508'
+  version '3.0.2.384,264'
+  sha256 '50731107293cc21187a08324173c8cfd35e3a9f17a0f155b2217a4ef37dad793'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'a5791408e88971fbf35003f33d30170b16bb2b263eb21f89c460c2c3e4e0c537'
+          checkpoint: '73b7a2c760e26c9c20092beb8d01c094dc5c47fb8664a4ea6a43bad73a49f56d'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION

### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.

```console
$ brew cask audit --download ./airmail-beta.rb
==> Downloading https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/264?format=zip&
######################################################################## 100.0%
==> Verifying checksum for Cask airmail-beta
audit for airmail-beta: passed
```

- [x] `brew cask style --fix {{cask_file}}` left no offenses.

```console
$  brew cask style --fix ./airmail-beta.rb

1 file inspected, no offenses detected
```
