### PR TITLE
Add Slack.app v2.2.6-beta1

### DIFF
--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -1,0 +1,27 @@
+cask 'slack-beta' do
+  version '2.2.6-beta1'
+  sha256 '7166abdf83772bcfc4ada304499dd6b1de0aafb4d9fdde0980a3a665e1d7c1d4'
+
+  # slack-ssb-updates.global.ssl.fastly.net was verified as official when first introduced to the cask
+  url "https://slack-ssb-updates.global.ssl.fastly.net/mac_external_beta/Slack-#{version}-macOS.zip"
+  name 'Slack'
+  homepage 'https://slack.com/beta/osx'
+  license :gratis
+
+  auto_updates true
+
+  app 'Slack.app'
+
+  uninstall quit: 'com.tinyspeck.slackmacgap'
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.tinyspeck.slackmacgap.sfl',
+                '~/Library/Application Support/Slack',
+                '~/Library/Caches/com.tinyspeck.slackmacgap',
+                '~/Library/Containers/com.tinyspeck.slackmacgap',
+                '~/Library/Containers/com.tinyspeck.slackmacgap.SlackCallsService',
+                '~/Library/Cookies/com.tinyspeck.slackmacgap.binarycookies',
+                '~/Library/Preferences/com.tinyspeck.slackmacgap.plist',
+                '~/Library/Saved Application State/com.tinyspeck.slackmacgap.savedState',
+              ]
+end


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Additionally, when **adding a new cask**:

- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-versions/pulls) for the same cask. <ins>There is currently an open PR, #2577, but it looks like the author is open to it being superseded by this on</ins>
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-versions/issues) where that cask was already refused. <ins>Slack Beta was removed in #548, but it looks like the beta served a different purpose at that time.</ins>
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).

  <p><ins>I didn't follow this point, because other beta casks in this repository seem to include "beta" at the end of their names.</ins></p>

  > <ins>Remove from the end: version numbers or incremental release designations such as “alpha”, “beta”, or “release candidate”.</ins>
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.