### PR TITLE
Update xbox360-controller-driver-beta to 0.16.4

### DIFF
--- a/Casks/xbox360-controller-driver-beta.rb
+++ b/Casks/xbox360-controller-driver-beta.rb
@@ -1,10 +1,10 @@
 cask 'xbox360-controller-driver-beta' do
-  version '0.15_beta5'
-  sha256 '05103e1a45b1e22199ac1699d5eca1838e797395f74d07f0c771d60d03f5debe'
+  version '0.16.4'
+  sha256 'e72232947be69b9483349ffa9bc4d8fe7e74c5ea453f3df14a6d86489489f4c3'
 
-  url "https://github.com/360Controller/360Controller/releases/download/v#{version}_unofficial/360ControllerInstall_#{version}_unofficial.dmg"
+  url "https://github.com/360Controller/360Controller/releases/download/v#{version}/360ControllerInstall_#{version}.dmg"
   appcast 'https://github.com/360Controller/360Controller/releases.atom',
-          checkpoint: 'b3f93a26f2cfc8c5f3987967c01392ca95ec71d4c062425b2b317c40e12f4ca7'
+          checkpoint: 'ea89ea749b89a985b663d1bee677a06acc0b1afebbd58258d62ea5d92c5f4f7f'
   name 'TattieBogle Xbox 360 Controller Driver (with improvements)'
   homepage 'https://github.com/360Controller/360Controller'
   license :gpl


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.