### PR TITLE
Update thebrain9 cask to version 9.0.107.0

### DIFF
--- a/Casks/thebrain9.rb
+++ b/Casks/thebrain9.rb
@@ -1,6 +1,6 @@
 cask 'thebrain9' do
-  version '9.0.101.0'
-  sha256 '01c35e65b24e0de65b11a55148d68c3e1eb7fbec66934f49eae6bb6da30e88dc'
+  version '9.0.107.0'
+  sha256 '15011129e764b8637b9846c59b4d921b44bb0fe0eba06d988fa8ef7a6b279f1f'
 
   url "http://updater.thebrain.com/files/TheBrain#{version}.dmg"
   name 'TheBrain 9'


### PR DESCRIPTION
### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download thebrain9` is error-free.
- [x] `brew cask style --fix thebrain9.rb` left no offenses.