### PR TITLE
Update airmail-beta to 3.0.2.386,266

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0.2.384,264'
-  sha256 '50731107293cc21187a08324173c8cfd35e3a9f17a0f155b2217a4ef37dad793'
+  version '3.0.2.386,266'
+  sha256 'de585cd058bf9f00a208db51b91ffbf65450b86ce085b5ea4b783bbfb8e0aa32'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '73b7a2c760e26c9c20092beb8d01c094dc5c47fb8664a4ea6a43bad73a49f56d'
+          checkpoint: '5ecac942573de0e515764ff66406d9da148c65222ab7c31a7ff87f744cc37234'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.