### PR TITLE
Update opera-developer to 41.0.2349.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '41.0.2340.0'
-  sha256 '15d0dec9ecaf3ab277633164a99410be079824b742e9d45ee57c14f69690b1ff'
+  version '41.0.2349.0'
+  sha256 '3c3268336b5fe7ca55d7d58e42c4a52d234c4ebec97bbca0b0d79871cc0a950f'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.