### PR TITLE
Update osxfuse-beta to 3.5.2

### DIFF
--- a/Casks/osxfuse-beta.rb
+++ b/Casks/osxfuse-beta.rb
@@ -1,11 +1,11 @@
 cask 'osxfuse-beta' do
-  version '3.5.1'
-  sha256 '51703d866d675f66b62eb18ffd861bdaceaa7f4f2f306276bb03c2abda94ce8f'
+  version '3.5.2'
+  sha256 '49ed3b3cf015cd9ca113de901a57cbd2cd8f4b5afe93259c10b5fddc7256f947'
 
   # github.com/osxfuse/osxfuse was verified as official when first introduced to the cask
   url "https://github.com/osxfuse/osxfuse/releases/download/osxfuse-#{version}/osxfuse-#{version}.dmg"
   appcast 'https://github.com/osxfuse/osxfuse/releases.atom',
-          checkpoint: '38615b9de3643e971af31a17b9a6318be8f5f98a19027b47f42b134584e94e3e'
+          checkpoint: 'c03f1a0c1c927f221f97ecee08b1fe6d957f3c81e1a75167654a14f7f54c7262'
   name 'OSXFUSE'
   homepage 'https://osxfuse.github.io/'
   license :bsd


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.