### PR TITLE
Update ableton-live-suite to 9.6.1

### DIFF
--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,14 +1,8 @@
 cask 'ableton-live-suite' do
   version '9.6.1'
+  sha256 '2951e547feae13c9f415c39c6045ebf0f2edf1f278bdf7bc40fd1d8a769e184b'
 
-  if Hardware::CPU.is_32_bit?
-    sha256 '83c5615ba0a2f9155e929c65c258979d30aff1f2208d7f737d0b1e5aa929ea92'
-    url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_32.dmg"
-  else
-    sha256 '2951e547feae13c9f415c39c6045ebf0f2edf1f278bdf7bc40fd1d8a769e184b'
-    url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
-  end
-
+  url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name 'Ableton Live Suite'
   homepage 'https://ableton.com/en/live'
   license :commercial


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.