### PR TITLE
Update airmail-beta to 3.1.391,269

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.0.2.387,267'
-  sha256 '54075c15b1a91d2197655c79f00d08d2b45a47900a6c8af2beddf6c22e70b3b9'
+  version '3.1.391,269'
+  sha256 '3aab04a0664eecfc01e3f89f20f77659c230275199d0d4920de3b3dfa2bdf197'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '999d39f13813ccf68f59df00a134e13e133816d88862df104089eef814d7dbb0'
+          checkpoint: '462a02ccee368dae5324495bf3f5cb7ce9d9146b0c9ef4744638878e16beef73'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
   license :commercial


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.