### PR TITLE
Update tower-beta to 2.5.2-334,334-bc7e6fb8

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.5.2-332,332-130b99da'
-  sha256 'd6ca91a8f11480030399125bb73b0adb377f63cb77ac446784387362ed34ea74'
+  version '2.5.2-334,334-bc7e6fb8'
+  sha256 '16f84397d3d323c1e810bf7421d429bde37c04e261aeaf6a35d1037c17d5607f'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: '86f69c590427520360a8fdad35e152e1c937f9c62676d180444d1ee8eac5a4b9'
+          checkpoint: '5f1c3eef0bd157a6af4de6618158012a6a981893952ce421acfd94ce55c04941'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
   license :commercial


### PR DESCRIPTION
#### Checklist

- [x] The commit message includes the cask’s name and version.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.