### PR TITLE
Update intellij-idea-next-* (2016.3 EAP) to build 163.5644.15

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2016.3,163.5219.11'
-  sha256 'e1a62a3edbcac6017e96aaa99a392f29849bc5e76f322340dfff2cc4a8f9e7b6'
+  version '2016.3,163.5644.15'
+  sha256 '4871e3b466c162570a49d87d3e6a2dd59cbcb4f189baa66a5c543b4169b96485'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2016.3,163.5219.11'
-  sha256 '6e3d5072d8986c7dcb3a513f3d564ede684cf0b0b7fbbfd1896761e422ccc632'
+  version '2016.3,163.5644.15'
+  sha256 '947d86a1b766f2a1829ddaf960dcb5df5ee065c35df36387680a659851011d9b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} EAP"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
