### PR TITLE
Update Firefox ESR to 45.4.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,6 +1,6 @@
 cask 'firefox-esr' do
-  version '45.3.0'
-  sha256 '553bb7f6a07e938d2fcb3ce08e4ad04b8448ed7a38048b680103a08c5000cf3d'
+  version '45.4.0'
+  sha256 '4e40d588b838709822bd3ccc1edbd13f055df8daf73d1024bcc6c9cbe07ef1e9'
 
   # mozilla.net was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}esr/mac/en-US/Firefox%20#{version}esr.dmg"


### PR DESCRIPTION
see https://www.mozilla.org/en-US/firefox/45.4.0/releasenotes/

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
