### PR TITLE
Update sketch-beta to 40.2,33825

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '40.1,33801'
-  sha256 '210f61fc1b6e5122311927353a5ad06a31a954fe84bceaa395d8e47625e1a619'
+  version '40.2,33825'
+  sha256 '790d92cf8ad07f079a60b0c011476b82768615c695994bac8154b57dbfedfd67'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '8333fdba3869479cfcf03807f836de92ce20d9c97a95e5dd2d4ff7c216988c82'
+          checkpoint: '5de61e3ed92e4cf25571cbe7a2c2c7650473ddd11f5284b5b173aea7027469c1'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
   license :commercial


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.