### PR TITLE
Update vivaldi-snapshot to 1.5.626.8

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.5.618.8'
-  sha256 'efa144846cc87d844b92041b22e77cf23c94d588257d90f8419df0e3eeec24a8'
+  version '1.5.626.8'
+  sha256 '8896eef6538149bfaac1964a691457306a5472a6743361c12d89140ea3dbca2e'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'cf246103f9d7482b080542b0b2279563bcc766b3a94886dc1ee87ac90af5417a'
+          checkpoint: '4342dc87e20b41c7b97d394b4f9e055f5bcc7ccd6fa4a38b3af5af4cc87bc3c1'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
   license :gratis


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.