### PR TITLE
Update 1password-beta to 6.5.BETA-22

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.5.BETA-20'
-  sha256 'a103a0399745173727c636f9e1d46bd1236e6fb7c0be7830c1f7fe99bc580978'
+  version '6.5.BETA-22'
+  sha256 '4fcab360f2998a2252d0db97120560bdf340e9b6b51128fe01b3f7fd6178863a'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.