### PR TITLE
Update firefox-beta to 50.0b5

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,8 +1,77 @@
 cask 'firefox-beta' do
-  version '49.0b10'
-  sha256 '37b21bbeb29fd6304b183d28214f402012a6b734d0d88f2bf4cfc953094e0e2c'
+  version '50.0b5'
 
-  url "https://download.mozilla.org/?product=firefox-#{version}-SSL&os=osx&lang=en-US"
+  language 'de' do
+    sha256 'b22f7e7524eb999637cc83d9828e65bbe63460a66761502e25b56a636168905b'
+    'de'
+  end
+
+  language 'en-GB' do
+    sha256 'bff170bdb8be4dd669bbab199a74929266cfc2207cd5234503a2d44e28aeb99d'
+    'en-GB'
+  end
+
+  language 'en', default: true do
+    sha256 '9f68324008c268cc45a972c8c5760ebf89ba49f95eb83a97d276a8b9ff93bf5a'
+    'en-US'
+  end
+
+  language 'fr' do
+    sha256 'ecb2a7b11f4612b5f0e74067127668afd41593fd518d5cc8e8422ce2fa5cd03d'
+    'fr'
+  end
+
+  language 'gl' do
+    sha256 '09edd1b9976a9e40eaf62b1ea86c8df968c5a02c15d69177753f57172d8d47dd'
+    'gl'
+  end
+
+  language 'it' do
+    sha256 '5f0f0a01cc36adcdb2d392c37b2b8c2362e614397c6a64c924b7e3d02615c13d'
+    'it'
+  end
+
+  language 'ja' do
+    sha256 '62a822aa77d82770acdf8dbc35245d8039e9e8724e7654b6e8f8b653ea8c7224'
+    'ja-JP-mac'
+  end
+
+  language 'nl' do
+    sha256 '25306bcb327c2370ebe7f8652da0b9c84c878b6991600472deb20ab156600b2a'
+    'nl'
+  end
+
+  language 'pl' do
+    sha256 'd1d5c8ae449ceee91fe4ee683da0e082d053c10256af44a945db70b09432f8f0'
+    'pl'
+  end
+
+  language 'pt' do
+    sha256 'bd1392c056747e5e66b450979a815803e9ad5f9862bb2912537e76bb2253dcbe'
+    'pt-PT'
+  end
+
+  language 'ru' do
+    sha256 '7766c6a39a2d2b0a0ebf8f1c138275dc2e5b308765c2c0f96d286c96fad24068'
+    'ru'
+  end
+
+  language 'uk' do
+    sha256 'd654f8be4e0de57f2902f6d56988ddd9a548b23ebb9eea9a46b4fa5b3b3c5732'
+    'uk'
+  end
+
+  language 'zh-TW' do
+    sha256 '31bf770c94b5c4ac4df6c1da96c821ca0bafd4edaada9900e32abc86179e9efb'
+    'zh-TW'
+  end
+
+  language 'zh' do
+    sha256 'd654f8be4e0de57f2902f6d56988ddd9a548b23ebb9eea9a46b4fa5b3b3c5732'
+    'zh-CN'
+  end
+
+  url "https://download.mozilla.org/?product=firefox-#{version}-SSL&os=osx&lang=#{language}"
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/en-US/firefox/channel/#beta'
   license :mpl

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,14 +1,14 @@
 cask 'java-beta' do
-  version '1.8.0_112-b04'
-  sha256 'dc14ae0b55ab4306dc3bd0547dc6fcc23b7565831fbaa4b71ccb2ac989aafdad'
+  version '1.8.0_122-b01'
+  sha256 '49438ee031674612f074da1cecf6718c7c6f2ed1fe951f24faf3dc7c92355cf5'
 
-  url 'http://download.java.net/java/jdk8u112/archive/b04/binaries/jdk-8u112-ea-bin-b04-macosx-x86_64-25_jul_2016.dmg',
+  url 'http://www.java.net/download/java/jdk8u122/archive/b01/binaries/jdk-8u122-ea-bin-b01-macosx-x86_64-20_sep_2016.dmg',
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }
   name 'Java Standard Edition Development Kit'
   homepage 'https://jdk8.java.net/download.html'
   license :gratis
 
-  pkg 'JDK 8 Update 112.pkg'
+  pkg 'JDK 8 Update 122.pkg'
 
   postflight do
     system '/usr/bin/sudo', '-E', '--',
@@ -31,7 +31,7 @@ cask 'java-beta' do
     end
   end
 
-  uninstall pkgutil: 'com.oracle.jdk8u112',
+  uninstall pkgutil: 'com.oracle.jdk8u122',
             delete:  [
                        MacOS.version <= :mavericks ? '/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK' : '',
                      ].keep_if { |v| !v.empty? }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.