### PR TITLE
Update sketch-beta to 40.3,33838

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '40.2,33825'
-  sha256 '790d92cf8ad07f079a60b0c011476b82768615c695994bac8154b57dbfedfd67'
+  version '40.3,33838'
+  sha256 'ba172b8cbf8e5156b640f6ac8447cf3e9f49e997d75199c55fd0162e4f6326c5'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '5de61e3ed92e4cf25571cbe7a2c2c7650473ddd11f5284b5b173aea7027469c1'
+          checkpoint: '197e2bef075ba264a8cecf9df173a36953ed099663fad19d46a7dfbf2b07c12c'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.