### PR TITLE
Update vivaldi-snapshot to 1.5.627.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.5.626.8'
-  sha256 '8896eef6538149bfaac1964a691457306a5472a6743361c12d89140ea3dbca2e'
+  version '1.5.627.3'
+  sha256 '9fbb4e30d8f002cf5e841ab7cb6825b6ba34e695775f41a59541982882c24bf2'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '4342dc87e20b41c7b97d394b4f9e055f5bcc7ccd6fa4a38b3af5af4cc87bc3c1'
+          checkpoint: 'b12bd860f160dea522d137e0a6307c5d25456e8afcac384e5c39025adc3e4531'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.