### PR TITLE
flash-player-debugger.rb: fixed URL of version 23.0.0.185

### DIFF
--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,9 +1,9 @@
 cask 'flash-player-debugger' do
   version '23.0.0.185'
-  sha256 'f1a7b29230bee1a8125d005d69becc9d6a63e7192291c5478b1f1f5e68d3e9b0'
+  sha256 '2d0faacfa637eef76c9c78f2b250e01f5f3d29cb4d09ea3bd493c0f70e3b9102'
 
   # macromedia.com was verified as official when first introduced to the cask
-  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa.dmg"
+  url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"
   name 'Adobe Flash Player projector content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
Previously, the URL actually pointed to the release version of Flash Player.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed

