### PR TITLE
Update macvim-kaoriya to 20161013

### DIFF
--- a/Casks/macvim-kaoriya.rb
+++ b/Casks/macvim-kaoriya.rb
@@ -3,13 +3,13 @@ cask 'macvim-kaoriya' do
     version '7.4:20130911'
     sha256 'd9fc6e38de1852e4ef79e9ea78afa60e606bf45066cff031e349d65748cbfbce'
   else
-    version '8.0:20161009'
-    sha256 'd1bb12cf267e2e96c5f310f7e5d05b13c91ae951df064525506ecdf9d8dd84a1'
+    version '8.0:20161013'
+    sha256 'e0ad51a792168fc002f0cf6456d5e6ee46fb6ec8cb0a522ea814ec42a22dbe84'
   end
 
   url "https://github.com/splhack/macvim-kaoriya/releases/download/#{version.after_colon}/MacVim-KaoriYa-#{version.after_colon}.dmg"
   appcast 'https://github.com/splhack/macvim-kaoriya/releases.atom',
-          checkpoint: 'cfc7205894eb94d320661d0f023e2be4ef6b6ca8538d8fbd03014f4bef194f25'
+          checkpoint: '1c6cc3b83fddb170a4f64783d3f7ee526dc0369791031e04aa87eccf3394e7d7'
   name 'MacVim KaoriYa'
   homepage 'https://github.com/splhack/macvim-kaoriya'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.