### PR TITLE
Update vivaldi-snapshot to 1.5.633.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.5.627.3'
-  sha256 '9fbb4e30d8f002cf5e841ab7cb6825b6ba34e695775f41a59541982882c24bf2'
+  version '1.5.633.3'
+  sha256 '941457f73a9845408a6b3dd6fbfe8fe036956152c0ef25265715cef8deed2939'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'b12bd860f160dea522d137e0a6307c5d25456e8afcac384e5c39025adc3e4531'
+          checkpoint: 'c31fa0959825681f1022b2aa56dde2eaac7c6e766c76d2810ef294c1dcd00b46'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.