### PR TITLE
Update webkit-nightly to r207387

### DIFF
--- a/Casks/webkit-nightly.rb
+++ b/Casks/webkit-nightly.rb
@@ -1,6 +1,6 @@
 cask 'webkit-nightly' do
-  version 'r207302'
-  sha256 'cc7f0e024238f917e72fa6a9411f5c848278ec60569cc7fb455116a758bebf23'
+  version 'r207387'
+  sha256 'f6b70b7803d2581aa29c43c2984d823d3ee4fcbc7d94c3775b67f8a20fa8030c'
 
   url "http://builds.nightly.webkit.org/files/trunk/mac/WebKit-SVN-#{version}.dmg"
   name 'WebKit Nightly'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.