### PR TITLE
Update opera-beta to 41.0.2353.30

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '41.0.2353.23'
-  sha256 '41881d7039d98b577c855fdec2635b9a5a205be307e4277d0f1e8b8bdfe344c4'
+  version '41.0.2353.30'
+  sha256 'b28adc0cc7e67179cf79c7d19c1cc4bc695cb20f59ceadcf25036a064f621f08'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.