### PR TITLE
update multimarkdown-composer-beta & -pro to v3.0b47

### DIFF
--- a/Casks/multimarkdown-composer-beta.rb
+++ b/Casks/multimarkdown-composer-beta.rb
@@ -1,6 +1,6 @@
 cask 'multimarkdown-composer-beta' do
-  version '3.0b46'
-  sha256 '673570ff77487dddbe19751a1ab83a2c77eeaa9e3242ac88eefe7b755bf4d636'
+  version '3.0b47'
+  sha256 '44c9fec7f025e43634edd74cfd83599d1c8bbe160fb60abd7605226ccbd63aca'
 
   # files.fletcherpenney.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.fletcherpenney.net.s3.amazonaws.com/MultiMarkdown%20Composer%20%28Non-Sandboxed%29-#{version}.zip"

--- a/Casks/multimarkdown-composer-pro.rb
+++ b/Casks/multimarkdown-composer-pro.rb
@@ -1,6 +1,6 @@
 cask 'multimarkdown-composer-pro' do
-  version '3.0b46'
-  sha256 '9eee8954e42d705b8a3433ef07ff52394b7e910c02ad0df9b4fa1dbfadee4b96'
+  version '3.0b47'
+  sha256 '0c2d1e0e1ac380501076e54de138278492a83c9750e079c05faac07ca0e81461'
 
   # files.fletcherpenney.net.s3.amazonaws.com was verified as official when first introduced to the cask
   url "http://files.fletcherpenney.net.s3.amazonaws.com/MultiMarkdown%20Composer%20Pro%20%28Beta%29-#{version}.zip"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
