### PR TITLE
Upgrade phpstorm-eap to 163.6512.15

### DIFF
--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'phpstorm-eap' do
-  version '163.5644.4'
-  sha256 '0900a4750889df0523ff76181aa5b514d0eeff5872c3c9cde91cf0e2b1dd6938'
+  version '163.6512.15'
+  sha256 '8795d9c220aa13a9006f15ee85a5eda8efe69ec4ba627bbc68ec34b3acf56845'
 
   url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version}.dmg"
   name 'PhpStorm EAP'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.



