### PR TITLE
Update airmail-beta to 3.1.392,270

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.1.391,269'
-  sha256 '3aab04a0664eecfc01e3f89f20f77659c230275199d0d4920de3b3dfa2bdf197'
+  version '3.1.392,270'
+  sha256 'fa83d2382e63524d423a50681dca8238c412bd553ca692fcb422aabccd1838c3'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '462a02ccee368dae5324495bf3f5cb7ce9d9146b0c9ef4744638878e16beef73'
+          checkpoint: 'e11c14384c0cef47a980981b1bbbb2a8e4063d70097f1e47051e15dae11d75d5'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.