### PR TITLE
Update xquartz-beta to 2.7.10

### DIFF
--- a/Casks/xquartz-beta.rb
+++ b/Casks/xquartz-beta.rb
@@ -1,11 +1,11 @@
 cask 'xquartz-beta' do
-  version '2.7.10_rc5'
-  sha256 '7401f60d13bde92f3371f6fc69e9649f26b3dacc725f35f4a6821bf80d583837'
+  version '2.7.10'
+  sha256 'd5cd043ed0e22f6da81cb1f36241d812ecef34ce80f92c928626284c7f93b0ac'
 
   # bintray.com/xquartz was verified as official when first introduced to the cask
   url "https://dl.bintray.com/xquartz/downloads/XQuartz-#{version}.dmg"
   appcast 'https://www.xquartz.org/releases/sparkle/beta.xml',
-          checkpoint: 'd1cf1d701f09e0c5bd7f1dbe2a7b03d289b11f1dc6f919f766659bd4fae0b5b5'
+          checkpoint: 'e1c84792b714a135732f8fb1e8f3c8a147089fa6a245c5a027094afa22ac714d'
   name 'XQuartz'
   homepage 'http://www.xquartz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.