### PR TITLE
Adium Nightly 1.6hgr5946

### DIFF
--- a/Casks/adium-nightly16.rb
+++ b/Casks/adium-nightly16.rb
@@ -1,0 +1,16 @@
+cask 'adium-nightly16' do
+  version '1.6hgr5946'
+  sha256 'aa5f92647a256fff0b5098679bd4966db039769a0e8a094116fd06b0cb3dcfc2'
+
+  url "http://nightly.adium.im/adium-adium-1.6/Adium_#{version}.dmg"
+  name 'Adium'
+  homepage 'http://nightly.adium.im/?repo_branch=adium-adium-1.6'
+
+  app 'Adium.app'
+
+  zap delete: [
+                '~/Library/Caches/Adium',
+                '~/Library/Caches/com.adiumX.adiumX',
+                '~/Library/Preferences/com.adiumX.adiumX.plist',
+              ]
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download Casks/adium-nightly16.rb` is error-free.
- [x] `brew cask style --fix Casks/adium-nightly16.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install Casks/adium-nightly16.rb` worked successfully.
- [x] `brew cask uninstall Casks/adium-nightly16.rb` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed

---

This reverts 484a35ac874a8cf8d05361500e9fb6b84e43b4f6. While Adium development has not been very active lately, it sees some unfrequent updates (i.e. is not dead). And `1.6` branch includes both the latest protocol fixes/drops and some larger code tweaks.

