### PR TITLE
Update xquartz-beta to 2.7.11_rc1

### DIFF
--- a/Casks/xquartz-beta.rb
+++ b/Casks/xquartz-beta.rb
@@ -1,11 +1,11 @@
 cask 'xquartz-beta' do
-  version '2.7.10'
-  sha256 'd5cd043ed0e22f6da81cb1f36241d812ecef34ce80f92c928626284c7f93b0ac'
+  version '2.7.11_rc1'
+  sha256 'e2e11013b4ec5f43616448a39c9b0e2ec945ecb95ccb4f1f7654d1a736054ed6'
 
   # bintray.com/xquartz was verified as official when first introduced to the cask
   url "https://dl.bintray.com/xquartz/downloads/XQuartz-#{version}.dmg"
   appcast 'https://www.xquartz.org/releases/sparkle/beta.xml',
-          checkpoint: 'e1c84792b714a135732f8fb1e8f3c8a147089fa6a245c5a027094afa22ac714d'
+          checkpoint: 'de608add5bbb6ee3af4eaecce37ea8c534e06b4fd5f990d21ded53a3d17636d5'
   name 'XQuartz'
   homepage 'http://www.xquartz.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.