### PR TITLE
Update docker-beta to 1.12.3.13397

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '1.12.2.12906'
-  sha256 '92f29aac98c7482fbebfc4534dea79950ea3f13fbbb9cebaed7d68de772bc692'
+  version '1.12.3.13397'
+  sha256 '4667ebf8bce72c8907025e5d125adc9f2362626bf2acef0d2a2973dd23b29416'
 
   url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: '38c3e1ce13e05f918cd05c9e8b5bf7ae7c2ed7ea6ef490864cfb4db9f34f4b76'
+          checkpoint: '6299f76aad8cad13ea2cc2b4c9bb4a8b71107967131c8761673b68af477c5592'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.