### PR TITLE
Update sketch-beta to 41,35091

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '40.3,33838'
-  sha256 'ba172b8cbf8e5156b640f6ac8447cf3e9f49e997d75199c55fd0162e4f6326c5'
+  version '41,35091'
+  sha256 '789aeed0691d587f31dacbaff3eba905a7d5672485b055a9e89737eab8a4c5b1'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '197e2bef075ba264a8cecf9df173a36953ed099663fad19d46a7dfbf2b07c12c'
+          checkpoint: 'df5d2d3796391aab9df47e74b967ddeb707f7df81d7b6235ebb4be1f6a6c9dfb'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.