### PR TITLE
Update intellij-idea-next-*-eap (2016.3 EAP) to build 163.6957.12

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2016.3,163.6512.17'
-  sha256 '3200510012a08ff0813100012e09a649b7695fa4f0d16c6c30bd86da76e4d66d'
+  version '2016.3,163.6957.12'
+  sha256 '95b3553661209da03fd18ea5f0cd5067d382bb6c0ff3fc61f7cee6e828fcc489'
 
-  url "https://download.jetbrains.com/idea/ideaIC-#{version.before_comma}-PublicPreview.dmg"
+  url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"
   name "IntelliJ IDEA #{version.major_minor} CE EAP"
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea-next-eap' do
-  version '2016.3,163.6512.17'
-  sha256 '58404b598830fdb6b2979572327fafa17ea6160dcd99f88d576536172987ef3b'
+  version '2016.3,163.6957.12'
+  sha256 '281def00ca0d888461296ac785db5004cc7702b46ec81178e7c6633c07d79858'
 
-  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}-PublicPreview.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} EAP"
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
