### PR TITLE
Unison 2.40.69

### DIFF
--- a/Casks/unison240.rb
+++ b/Casks/unison240.rb
@@ -1,0 +1,13 @@
+cask 'unison240' do
+  version '2.40.69'
+  sha256 '2bcc460511f2b43fa1613cc5f9ba4dd59bb12d40b5b9fb2e9f21adaf854bcf3b'
+
+  # unison-binaries.inria.fr was verified as official when first introduced to the cask
+  url "http://unison-binaries.inria.fr/files/Unison-#{version}_x64.dmg"
+  name 'Panic Unison'
+  homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
+
+  depends_on arch: :x86_64
+
+  app 'Unison.app'
+end

--- a/Casks/unison240.rb
+++ b/Casks/unison240.rb
@@ -7,7 +7,5 @@ cask 'unison240' do
   name 'Unison'
   homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
 
-  depends_on arch: :x86_64
-
   app 'Unison.app'
 end

--- a/Casks/unison240.rb
+++ b/Casks/unison240.rb
@@ -4,7 +4,7 @@ cask 'unison240' do
 
   # unison-binaries.inria.fr was verified as official when first introduced to the cask
   url "http://unison-binaries.inria.fr/files/Unison-#{version}_x64.dmg"
-  name 'Panic Unison'
+  name 'Unison'
   homepage 'https://www.cis.upenn.edu/~bcpierce/unison/'
 
   depends_on arch: :x86_64


### PR DESCRIPTION
## Rationale

(also see discussion in caskroom/homebrew-cask#26206)

Unison is both a client and a server. Unfortunately, the choice of client is dictated by the server *minor version* -- client and server minor versions *have* to match on both sides. Luckily, there have been only so many "official" minor versions in the past 8 years -- 2.27, 2.32, 2.40, and 2.48.

Right now the official [unison cask](https://github.com/caskroom/homebrew-cask/blob/master/Casks/unison.rb) provides 2.48 (unless you have an old OSX). e.g.:

```
 if MacOS.version <= :mountain_lion
    version '2.40.69'
    sha256 '2bcc460511f2b43fa1613cc5f9ba4dd59bb12d40b5b9fb2e9f21adaf854bcf3b'
    url "http://unison-binaries.inria.fr/files/Unison-#{version}_x64.dmg"
  else
    version '2.48.15'
    sha256 '89894d14c9ff3c4d6195cb6a8065a2849e6ad55951799eedf8879e1a257d3e11'
    url "http://unison-binaries.inria.fr/files/Unison-OS-X-#{version}.zip"
```

But I need to install 2.40 on an new/recent OSX, because I talk to a server that runs 2.40. This `unison240` cask strips 2.48 from the official cast and only provides the latest stable 2.40.69 version, circa 2014 (see official [Unison Binaries](http://unison-binaries.inria.fr/)).

Thank you

## Boilerplate

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed

