### PR TITLE
Update iterm2-beta to 3.0.12

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,6 +1,6 @@
 cask 'iterm2-beta' do
-  version '3.0.11'
-  sha256 'c7760ad2cd4c8749e3e38b4dd1ee1ed854e0dea3f058e5508dffcf99fcf9620c'
+  version '3.0.12'
+  sha256 'd500c5e376a05df6896f92504961142b7721efb9e235232d39545c7a3c5b7507'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.