### PR TITLE
Update libreoffice-dev to 5.2.3.2

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,12 +1,12 @@
 cask 'libreoffice-dev' do
-  version '5.2.3.1'
-  sha256 '44027aae1666d0f1dc774ae52ea2926da460f6e88d49434d554f5230a0b86cd5'
+  version '5.2.3.2'
+  sha256 '899a0828f67dbe1d4feda438c43c40f036e265930b02498b2890fea22d3d7841'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
 
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'b683b7a58396677620813b99c51fb4947e71109b49e6b78362fde27507b31587'
+          checkpoint: 'fc3fbc118c7e3d0abf43a9442718b977412c09934bc9d4979cae44b9cab7b73b'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc",


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.