### PR TITLE
Update sketch-beta to 41,35231

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '41,35091'
-  sha256 '789aeed0691d587f31dacbaff3eba905a7d5672485b055a9e89737eab8a4c5b1'
+  version '41,35231'
+  sha256 '6a13bed1349d2dd2f384cf49793824224c927da03d05e828ba93ffe8063f0c9f'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'df5d2d3796391aab9df47e74b967ddeb707f7df81d7b6235ebb4be1f6a6c9dfb'
+          checkpoint: '54c7b159c1f2968fcdb8253b3520e282a6b97962e18a308023e9277d43361909'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.