### PR TITLE
Update intellij-idea-next-*-eap (2016.3 EAP) to build 163.7342.3

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2016.3,163.6957.12'
-  sha256 '95b3553661209da03fd18ea5f0cd5067d382bb6c0ff3fc61f7cee6e828fcc489'
+  version '2016.3,163.7342.3'
+  sha256 '0af9192f5b72a199173337746eeeb5e3373bcc506579125f3fbd227f5ef1e41d'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2016.3,163.6957.12'
-  sha256 '281def00ca0d888461296ac785db5004cc7702b46ec81178e7c6633c07d79858'
+  version '2016.3,163.7342.3'
+  sha256 '48cfe739b5ea8dbd38cc504eb8f6c40b6f9399853a565409bdbae9f3c36b4bd0'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} EAP"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
