### PR TITLE
Update sketch-beta to 41,35299

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '41,35231'
-  sha256 '6a13bed1349d2dd2f384cf49793824224c927da03d05e828ba93ffe8063f0c9f'
+  version '41,35299'
+  sha256 '22be06ee43bd4d60bc2e39d6753b3d20381cccda26ac4161b18e9b3cc21a75e1'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '54c7b159c1f2968fcdb8253b3520e282a6b97962e18a308023e9277d43361909'
+          checkpoint: '518bbc6a64d8ca9271f0fe49769185875746b713cc379c843b396d286c3358b0'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.