### PR TITLE
Update virtualbox-beta to 5.1.9,111660

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -3,8 +3,8 @@ cask 'virtualbox-beta' do
     version '4.3.32-103443'
     sha256 '08defbf310b7ba5852fa8dd951438bb9b1528bb1544211568861986110e807f7'
   else
-    version '5.1.7,111038'
-    sha256 '8c018c9af1656abf5c2c868c8010734c9d3e48e868cd85190089e35fb4e5ca37'
+    version '5.1.9,111660'
+    sha256 '4cd819f9dfcdbe3dfe1b02299af42f940e2ad91d2423880a31ece0d760e1441f'
   end
 
   url "http://www.virtualbox.org/download/testcase/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.