### PR TITLE
Fix PHPStorm EAP cask & Upgrade to 2016.3,163.7342.9

### DIFF
--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -8,14 +8,14 @@ cask 'phpstorm-eap' do
 
   conflicts_with cask: 'phpstorm'
 
-  app 'PhpStorm #{version.major_minor} EAP.app'
+  app "PhpStorm #{version.major_minor} EAP.app"
 
   uninstall delete: '/usr/local/bin/pstorm'
 
   zap delete: [
-                '~/Library/Preferences/PhpStorm#{version.major_minor}',
-                '~/Library/Caches/PhpStorm#{version.major_minor}',
-                '~/Library/Logs/PhpStorm#{version.major_minor}',
-                '~/Library/Application Support/PhpStorm#{version.major_minor}',
+                "~/Library/Preferences/PhpStorm#{version.major_minor}",
+                "~/Library/Caches/PhpStorm#{version.major_minor}",
+                "~/Library/Logs/PhpStorm#{version.major_minor}",
+                "~/Library/Application Support/PhpStorm#{version.major_minor}",
               ]
 end

--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'phpstorm-eap' do
-  version '2016.3,163.6957.13'
-  sha256 '94ebdbe52bfb9fbf7fbd4e2b62cdb3c59d7aa0484aa13a44a3c4527a1d457604'
+  version '2016.3,163.7342.9'
+  sha256 'f42bce001f593926a32c40b262844f8934f01dfef74d260d3d66017c5e62225b'
 
   url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version.after_comma}.dmg"
   name 'PhpStorm EAP'


### PR DESCRIPTION
The PHPStorm EAP cask was using single quotes and therefore the file names were incorrect. This made it un-installable, which is why I don't think there needs to be a version bump of any sort.

I've also updated it to the latest EAP.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
