### PR TITLE
Update flash-player-debugger-npapi to 23.0.0.207

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,11 +1,11 @@
 cask 'flash-player-debugger-npapi' do
-  version '23.0.0.205'
-  sha256 'b42622d0ba37b39a7d2ca82388a09ff750b07498730c491f8f03e8a3dffe0e0f'
+  version '23.0.0.207'
+  sha256 '6ad4ced374e7f7c26ea777cbd09958672567f4319e10245a3631175f6323302a'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"
   appcast 'http://fpdownload2.macromedia.com/get/flashplayer/update/current/xml/version_en_mac_pl.xml',
-          checkpoint: '26a40ba2c668486155b9a3bce042a5105d158ddc8a0266f13614e264727ec5c3'
+          checkpoint: '50c4e19caa48710cf812e1549e5179124552b4bf760dc9aa719e09dd86d10fbe'
   name 'Adobe Flash Player NPAPI (plugin for Safari and Firefox) content debugger'
   homepage 'https://www.adobe.com/support/flashplayer/debug_downloads.html'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.