### PR TITLE
Update intellij-idea-next-*-eap (2016.3 EAP) to build 163.7743.17

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -3,7 +3,7 @@ cask 'intellij-idea-next-ce-eap' do
   sha256 'b3bb048d00c4a1f8a4e1e2d2f601be30f4a031752be4048fc71d07d802970440'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
-  name 'IntelliJ IDEA Community Edition EAP'
+  name 'IntelliJ IDEA Next Community Edition EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -3,7 +3,7 @@ cask 'intellij-idea-next-ce-eap' do
   sha256 'b3bb048d00c4a1f8a4e1e2d2f601be30f4a031752be4048fc71d07d802970440'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
-  name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"
+  name 'IntelliJ IDEA Community Edition EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -9,7 +9,7 @@ cask 'intellij-idea-next-ce-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.major_minor} CE EAP.app"
+  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2016.3,163.7342.3'
-  sha256 '0af9192f5b72a199173337746eeeb5e3373bcc506579125f3fbd227f5ef1e41d'
+  version '2016.3,163.7743.17'
+  sha256 'b3bb048d00c4a1f8a4e1e2d2f601be30f4a031752be4048fc71d07d802970440'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"
@@ -9,7 +9,7 @@ cask 'intellij-idea-next-ce-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
+  app "IntelliJ IDEA #{version.major_minor} CE EAP.app"
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -4,7 +4,6 @@ cask 'intellij-idea-next-ce-eap' do
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} Community Edition EAP"
-  name "IntelliJ IDEA #{version.major_minor} CE EAP"
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2016.3,163.7342.3'
-  sha256 '48cfe739b5ea8dbd38cc504eb8f6c40b6f9399853a565409bdbae9f3c36b4bd0'
+  version '2016.3,163.7743.17'
+  sha256 '22be5d50db217140f2200461080c69438f273de0c7a64b3e08b6552236a9b16b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name "IntelliJ IDEA #{version.major_minor} EAP"
@@ -8,7 +8,7 @@ cask 'intellij-idea-next-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} EAP.app"
+  app "IntelliJ IDEA #{version.major_minor} EAP.app"
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -8,7 +8,7 @@ cask 'intellij-idea-next-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.major_minor} EAP.app"
+  app "IntelliJ IDEA #{version.before_comma} EAP.app"
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -3,7 +3,7 @@ cask 'intellij-idea-next-eap' do
   sha256 '22be5d50db217140f2200461080c69438f273de0c7a64b3e08b6552236a9b16b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
-  name "IntelliJ IDEA #{version.major_minor} EAP"
+  name 'IntelliJ IDEA EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -3,7 +3,7 @@ cask 'intellij-idea-next-eap' do
   sha256 '22be5d50db217140f2200461080c69438f273de0c7a64b3e08b6552236a9b16b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
-  name 'IntelliJ IDEA EAP'
+  name 'IntelliJ IDEA Next EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
