### PR TITLE
Update 1password-beta to 6.5.BETA-35

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.5.BETA-32'
-  sha256 'a83dd7efdec4832b1880cbaa52211cfa92a9021dfebbcdf2bfac9ca425f0bfd9'
+  version '6.5.BETA-35'
+  sha256 'eefe6b698534befda1627339823ca0d606e96be9490e2722ae8e48f24d4cfe13'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.