### PR TITLE
Update docker-beta to 1.12.3.13798

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '1.12.3.13640'
-  sha256 'dbce453e68ccfa671a4e43f92b7bb1f3dfbad4538935b579c86bf7f203af2dce'
+  version '1.12.3.13798'
+  sha256 'a316d0c36cd497d56e4ed4a11333e988c32a07ea7cc1e8d222c41bbbcdffa9d2'
 
   url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: '85d49f039e375a62d59771aeefee4f24b7c6da0de73aa7745b963686042398c7'
+          checkpoint: '99a42dea1a7deaf654e500758bf5344c9cc5fd506cd79de7daa8289df2077f36'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.