### PR TITLE
Update Android Studio Canary to 2.3.0.0,162.3454121

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.2.2.0,145.3360264'
-  sha256 'c882c96643860a20ff1c4ced0e11ca72e613c9c2b9450a312c56f7c2678730b9'
+  version '2.3.0.0,162.3454121'
+  sha256 '868e9ce175cf6cd0f2c5026699aff3f46dbfe1b8e61a8ff3e8ccc8873f13b08b'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.

