### PR TITLE
Update airmail-beta to 3.1.313,271

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.1.392,270'
-  sha256 'fa83d2382e63524d423a50681dca8238c412bd553ca692fcb422aabccd1838c3'
+  version '3.1.313,271'
+  sha256 '217f5d302450f53eaa965b8170c908b967dde41410e1270a789f8db91e528241'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'e11c14384c0cef47a980981b1bbbb2a8e4063d70097f1e47051e15dae11d75d5'
+          checkpoint: 'c004239af5894f946a7e4393bc5080c1b7bcc600b7fcb7f152bdb1fad05223d3'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.