### PR TITLE
Update airmail-beta to 3.1.394,272

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.1.313,271'
-  sha256 '217f5d302450f53eaa965b8170c908b967dde41410e1270a789f8db91e528241'
+  version '3.1.394,272'
+  sha256 'aef297ca33f941c13aa8a19708a8a447507018760a3cb7817ace0015161d1865'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'c004239af5894f946a7e4393bc5080c1b7bcc600b7fcb7f152bdb1fad05223d3'
+          checkpoint: '5ab2929bcb84b68a612440f17c1296dc9c6891952a5cbaf3bc1574306cc5abbc'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.