### PR TITLE
Update sketch-beta to 41.1,35375

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '41,35307'
-  sha256 'f767945f02a3f9f6102a086dae0d0e4a59ab39b7493309ef6373a06ac2e9283b'
+  version '41.1,35375'
+  sha256 '6adf599aa68f849bcea772ea84bef0cfcb9fadb7dd889c1a5708e8b15722534f'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '520827c797294d1a73502b728dfb37e9b1e2220ecac1d46dfd595904e4699271'
+          checkpoint: 'db7d6e094e6ff5245999b5ceefa270e494c6fb027e81a318bf0aa7678bdd7eae'
   name 'Sketch'
   homepage 'http://bohemiancoding.com/sketch/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.