### PR TITLE
Update airmail-beta to 3.2.396,273

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.1.394,272'
-  sha256 'aef297ca33f941c13aa8a19708a8a447507018760a3cb7817ace0015161d1865'
+  version '3.2.396,273'
+  sha256 '6457a328a8b666b9288b08c8d950a4fb21577803bac81dadac8896c93ecb6ec2'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '5ab2929bcb84b68a612440f17c1296dc9c6891952a5cbaf3bc1574306cc5abbc'
+          checkpoint: 'b8a2cc20f3d5340471a2d37db6bd3b70b001ef58a46688a16d28f44de5b849ce'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.