### PR TITLE
Update intellij-idea-next-*-eap (2016.3 EAP) to RC2 build 163.7743.37

### DIFF
--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2016.3,163.7743.17'
-  sha256 'b3bb048d00c4a1f8a4e1e2d2f601be30f4a031752be4048fc71d07d802970440'
+  version '2016.3,163.7743.37'
+  sha256 'd62f720d6688e2a4a83cde458eefff0a0e610694dcd7e2252f04d513352f38c7'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Next Community Edition EAP'
@@ -8,7 +8,7 @@ cask 'intellij-idea-next-ce-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
+  app 'IntelliJ IDEA CE.app'
 
   uninstall delete: '/usr/local/bin/idea'
 

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2016.3,163.7743.17'
-  sha256 '22be5d50db217140f2200461080c69438f273de0c7a64b3e08b6552236a9b16b'
+  version '2016.3,163.7743.37'
+  sha256 '3c6bf2777a84c3ba1826a839103ea3e829829d507930cd7b6ffdad17d8b67efc'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Next EAP'
@@ -8,7 +8,7 @@ cask 'intellij-idea-next-eap' do
 
   auto_updates true
 
-  app "IntelliJ IDEA #{version.before_comma} EAP.app"
+  app 'IntelliJ IDEA.app'
 
   uninstall delete: '/usr/local/bin/idea'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
