### PR TITLE
Update ableton-live-beta to 9.7.1b3

### DIFF
--- a/Casks/ableton-live-beta.rb
+++ b/Casks/ableton-live-beta.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-beta' do
-  version '9.7b4'
-  sha256 '5bc6d02891df5702af956f29efab70223fd5ca92a3746b96d84bc1abd8cd8ac0'
+  version '9.7.1b3'
+  sha256 '8d5744c93b7d1f0346427a8bf945bdc7343b6f707eb4d9450365552557d54f80'
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_beta_#{version.no_dots}_64.dmg"
   name 'Ableton Live Beta'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
