### PR TITLE
Fix homepages in 22 casks

### DIFF
--- a/Casks/ableton-live-beta.rb
+++ b/Casks/ableton-live-beta.rb
@@ -4,7 +4,7 @@ cask 'ableton-live-beta' do
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_beta_#{version.no_dots}_64.dmg"
   name 'Ableton Live Beta'
-  homepage 'https://ableton.com/en/live'
+  homepage 'https://www.ableton.com/en/live/'
 
   app "Ableton Live #{version.major_minor} Beta.app"
 

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -4,7 +4,7 @@ cask 'ableton-live-standard' do
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   name 'Ableton Live Standard'
-  homepage 'https://ableton.com/en/live'
+  homepage 'https://www.ableton.com/en/live/'
 
   app "Ableton Live #{version.major} Standard.app"
 

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -4,7 +4,7 @@ cask 'ableton-live-suite' do
 
   url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name 'Ableton Live Suite'
-  homepage 'https://ableton.com/en/live'
+  homepage 'https://www.ableton.com/en/live/'
 
   app "Ableton Live #{version[0]} Suite.app"
 

--- a/Casks/cura-beta.rb
+++ b/Casks/cura-beta.rb
@@ -4,7 +4,7 @@ cask 'cura-beta' do
 
   url "https://software.ultimaker.com/Cura_open_beta/Cura-#{version}-BETA-Darwin.dmg"
   name 'Cura'
-  homepage 'https://ultimaker.com/en/products/software'
+  homepage 'https://ultimaker.com/en/products/cura-software'
 
   app 'Cura.app'
 

--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -4,7 +4,7 @@ cask 'kicad-nightly' do
 
   url "http://downloads.kicad-pcb.org/osx/nightly/kicad-#{version}-c4osx.dmg"
   name 'KiCad'
-  homepage 'http://www.kicad-pcb.org/'
+  homepage 'http://kicad-pcb.org/'
 
   suite 'Kicad-apps', target: 'Kicad'
   artifact 'kicad', target: "#{ENV['HOME']}/Library/Application Support/kicad"

--- a/Casks/mono-mdk-preview.rb
+++ b/Casks/mono-mdk-preview.rb
@@ -5,7 +5,7 @@ cask 'mono-mdk-preview' do
   # download.xamarin.com was verified as official when first introduced to the cask
   url "http://download.xamarin.com/roslyn-preview/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
-  homepage 'http://mono-project.com'
+  homepage 'http://www.mono-project.com/'
 
   pkg "MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
 

--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -6,7 +6,7 @@ cask 'pdfpenpro' do
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
           checkpoint: '2d618379f9d3155f61363b811cda6d2eafec89b95c67b6d37139b66261988ac5'
   name 'PDFpenPro'
-  homepage 'https://www.smilesoftware.com/PDFpenPro/'
+  homepage 'https://smilesoftware.com/PDFpenPro'
 
   app 'PDFpenPro.app'
 end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -5,7 +5,7 @@ cask 'pycharm-ce' do
   url "https://download.jetbrains.com/python/pycharm-community-#{version}.dmg"
   name 'Jetbrains PyCharm Community Edition'
   name 'PyCharm CE'
-  homepage 'https://www.jetbrains.com/pycharm'
+  homepage 'https://www.jetbrains.com/pycharm/'
 
   conflicts_with cask: 'pycharm-ce-eap'
 

--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -5,7 +5,7 @@ cask 'rstudio-preview' do
   # amazonaws.com/rstudio-dailybuilds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-dailybuilds/RStudio-#{version}.dmg"
   name 'RStudio'
-  homepage 'http://www.rstudio.com/ide/download/preview'
+  homepage 'https://www.rstudio.com/products/rstudio/download/preview/'
 
   app 'RStudio.app'
 

--- a/Casks/scansnap-manager-s1300.rb
+++ b/Casks/scansnap-manager-s1300.rb
@@ -4,7 +4,7 @@ cask 'scansnap-manager-s1300' do
 
   url 'http://www.fujitsu.com/downloads/IMAGE/driver/ss/mgr/m-s1300/ScanSnap.dmg'
   name 'ScanSnap Manager for Fujitsu ScanSnap S1300'
-  homepage 'https://www.fujitsu.com/global/support/computing/peripheral/scanners/software/s1300m-setup.html'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/'
 
   depends_on macos: '>= :tiger'
 

--- a/Casks/scansnap-manager-s300m-s500m-s510m-fi-5110eoxm-legacy.rb
+++ b/Casks/scansnap-manager-s300m-s500m-s510m-fi-5110eoxm-legacy.rb
@@ -4,7 +4,7 @@ cask 'scansnap-manager-s300m-s500m-s510m-fi-5110eoxm-legacy' do
 
   url 'http://www.fujitsu.com/downloads/IMAGE/driver/ss/ScanSnap_V22L11.dmg'
   name 'ScanSnap Manager for Fujitsu ScanSnap fi-5110EOXM, S300M, S500M, s501M'
-  homepage 'https://www.fujitsu.com/global/support/computing/peripheral/scanners/software/mac.html'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/'
 
   depends_on macos: [:tiger, :leopard]
 

--- a/Casks/scansnap-manager-s300m-s510m.rb
+++ b/Casks/scansnap-manager-s300m-s510m.rb
@@ -4,7 +4,7 @@ cask 'scansnap-manager-s300m-s510m' do
 
   url 'http://www.fujitsu.com/downloads/IMAGE/driver/ss/ScanSnap_V22L16.dmg'
   name 'ScanSnap Manager for Fujitsu ScanSnap S300M, S501M'
-  homepage 'https://www.fujitsu.com/global/support/computing/peripheral/scanners/software/mac-mg22-eol.html'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/'
 
   depends_on cask: 'scansnap-manager-s300m-s500m-s510m-fi-5110eoxm-legacy'
   depends_on macos: '>= :snow_leopard'

--- a/Casks/scansnap-manager-sv600.rb
+++ b/Casks/scansnap-manager-sv600.rb
@@ -4,7 +4,7 @@ cask 'scansnap-manager-sv600' do
 
   url "https://www.fujitsu.com/downloads/IMAGE/driver/ss/mgr/m-sv600/MacScanSnapV#{version.no_dots}WW.dmg"
   name 'ScanSnap Manager for Fujitsu ScanSnap SV600'
-  homepage 'https://www.fujitsu.com/global/support/computing/peripheral/scanners/software/'
+  homepage 'https://www.fujitsu.com/global/support/products/computing/peripheral/scanners/scansnap/software/'
 
   depends_on macos: '>= :lion'
 

--- a/Casks/sketchup-pro.rb
+++ b/Casks/sketchup-pro.rb
@@ -6,7 +6,7 @@ cask 'sketchup-pro' do
   # trimble.com/sketchup was verified as official when first introduced to the cask
   url 'https://dl.trimble.com/sketchup/SketchUpPro-en.dmg'
   name 'SketchUp'
-  homepage 'https://www.sketchup.com/intl/en/'
+  homepage 'http://www.sketchup.com/intl/en/'
 
   suite 'SketchUp 2016'
 

--- a/Casks/textual-beta.rb
+++ b/Casks/textual-beta.rb
@@ -4,7 +4,7 @@ cask 'textual-beta' do
 
   url 'https://www.codeux.com/textual/downloads/Textual-Beta.zip'
   name 'Textual'
-  homepage 'https://help.codeux.com/textual/Release-Notes:-Version-6.0.0.kb'
+  homepage 'https://help.codeux.com/textual/release-notes/Release-Notes:-Version-6.0.0.kb'
 
   app 'Textual.app'
 end

--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -18,7 +18,7 @@ cask 'thunderbird-beta' do
 
   url "https://ftp.mozilla.org/pub/thunderbird/releases/#{version}/mac/#{language}/Thunderbird%20#{version}.dmg"
   name 'Mozilla Thunderbird'
-  homepage 'https://www.mozilla.org/en-US/thunderbird/all-beta.html'
+  homepage 'https://www.mozilla.org/en-US/thunderbird/beta/all/'
 
   app 'Thunderbird.app'
 end

--- a/Casks/thunderbird-pt-br.rb
+++ b/Casks/thunderbird-pt-br.rb
@@ -4,7 +4,7 @@ cask 'thunderbird-pt-br' do
 
   url "https://download.mozilla.org/?product=thunderbird-#{version}&os=osx&lang=pt-BR"
   name 'Mozilla Thunderbird'
-  homepage 'https://www.mozilla.org/pt/thunderbird/'
+  homepage 'https://www.mozilla.org/pt-BR/thunderbird/'
 
   app 'Thunderbird.app'
 end

--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -4,7 +4,7 @@ cask 'transmission-nightly' do
 
   url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
   name 'Transmission'
-  homepage 'https://www.transmissionbt.com'
+  homepage 'https://transmissionbt.com/'
 
   app 'Transmission.app'
 

--- a/Casks/vmware-fusion6.rb
+++ b/Casks/vmware-fusion6.rb
@@ -4,7 +4,7 @@ cask 'vmware-fusion6' do
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}-light.dmg"
   name 'VMware Fusion'
-  homepage 'https://www.vmware.com/products/fusion/'
+  homepage 'https://www.vmware.com/products/fusion.html'
 
   app 'VMware Fusion.app'
   binary "#{appdir}/VMware Fusion.app/Contents/Library/vmrun"

--- a/Casks/vmware-fusion7.rb
+++ b/Casks/vmware-fusion7.rb
@@ -4,7 +4,7 @@ cask 'vmware-fusion7' do
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   name 'VMware Fusion'
-  homepage 'https://www.vmware.com/products/fusion/'
+  homepage 'https://www.vmware.com/products/fusion.html'
 
   app 'VMware Fusion.app'
   binary "#{appdir}/VMware Fusion.app/Contents/Library/vmnet-cfgcli"

--- a/Casks/vox0.rb
+++ b/Casks/vox0.rb
@@ -4,7 +4,7 @@ cask 'vox0' do
 
   url "http://cloud.coppertino.com/vox/Vox_#{version}.dmg"
   name 'VOX'
-  homepage 'http://coppertino.com/vox/'
+  homepage 'http://coppertino.com/'
 
   app 'Vox.app'
 end

--- a/Casks/xamarin-studio-preview.rb
+++ b/Casks/xamarin-studio-preview.rb
@@ -6,7 +6,7 @@ cask 'xamarin-studio-preview' do
   appcast 'https://static.xamarin.com/installer_assets/v3/Mac/Universal/InstallationManifest.xml',
           checkpoint: '14727c4cd976ca3d96a7a9c362bebd064a49c4f24d32296d33767e3a76b4a685'
   name 'Xamarin Studio Preview'
-  homepage 'https://xamarin.com/studio'
+  homepage 'https://www.xamarin.com/studio'
 
   app 'Xamarin Studio.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
---
Mostly done to avoid unnecessary redirects. HTTPS in some cases is removed since it's not available anymore.