### PR TITLE
firefoxnightly: Update firefoxnightly to 53.0a1

### DIFF
--- a/Casks/firefoxnightly.rb
+++ b/Casks/firefoxnightly.rb
@@ -1,5 +1,5 @@
 cask 'firefoxnightly' do
-  version '52.0a1'
+  version '53.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 
   language 'en', default: true do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.