### PR TITLE
Update opera-developer to 43.0.2420.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '43.0.2412.0'
-  sha256 '1e8ca5030b86304b1e4004f269c01632523c372da09930cac229cf6ca51a6d50'
+  version '43.0.2420.0'
+  sha256 'cca2d505fc0f18669e438d6dc3fba53cdcc081b4b5357d9fdff176ecef8f6102'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.