### PR TITLE
Fix sha256 value for Webkit Nightly r208420

### DIFF
--- a/Casks/webkit-nightly.rb
+++ b/Casks/webkit-nightly.rb
@@ -1,6 +1,6 @@
 cask 'webkit-nightly' do
   version 'r208420'
-  sha256 '80926485ab5f0c4731f811a7955338c166c72549817826cf60bb6fd75a36d274'
+  sha256 'a7341ff5af993b15ac9f1cab0a91c77a74ac98ba83877439738dc90a2deefebd'
 
   url "https://builds-nightly.webkit.org/files/trunk/mac/WebKit-SVN-#{version}.dmg"
   name 'WebKit Nightly'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

**Didn't complete the above because currently just making the change via GitHub Web UI and I am assuming (big assumption) making such a minor change shouldn't break anything**

~~Additionally, **if adding a new cask**:~~

~~- [ ] Named the cask according to the [token reference].~~
~~- [ ] `brew cask install {{cask_file}}` worked successfully.~~
~~- [ ] `brew cask uninstall {{cask_file}}` worked successfully.~~
~~- [ ] Checked there are no [open pull requests] for the same cask.~~
~~- [ ] Checked that the cask was not already refused in [closed issues].~~

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed

Trying to install via brew cask I got a sha256 mismatch error

Downloaded the file from https://builds-nightly.webkit.org/files/trunk/mac/WebKit-SVN-r208420.dmg
and ran

`openssl dgst -sha256 WebKit-SVN-r208420.dmg`

This confirmed the sha256 value