### PR TITLE
Update libreoffice-dev to 5.3.0.0,beta1

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,16 +1,16 @@
 cask 'libreoffice-dev' do
-  version '5.2.3.2'
-  sha256 '899a0828f67dbe1d4feda438c43c40f036e265930b02498b2890fea22d3d7841'
+  version '5.3.0.0,beta1'
+  sha256 '8dff22f381e754e32b5f57a605f0121592ae27056960f5613c4df713b58f7ecf'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
 
-  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version.before_comma}.#{version.after_comma}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'fc3fbc118c7e3d0abf43a9442718b977412c09934bc9d4979cae44b9cab7b73b'
+          checkpoint: 'c670b48ca9a4352e2ec995b28745bed6f4bb6cb446e18cbc15b8b77a24bab665'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc",
       key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  app 'LibreOffice.app'
+  app 'LibreOfficeDev.app', target: 'LibreOffice.app'
 end

--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -12,5 +12,5 @@ cask 'libreoffice-dev' do
   gpg "#{url}.asc",
       key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  app 'LibreOfficeDev.app', target: 'LibreOffice.app'
+  app 'LibreOfficeDev.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.