### PR TITLE
Update firefox-beta to 51.0b3

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '50.0b5'
+  version '51.0b3'
 
   language 'de' do
-    sha256 'b22f7e7524eb999637cc83d9828e65bbe63460a66761502e25b56a636168905b'
+    sha256 '88a5aa4772dae4d67ad5e14efdf6a95f3d1a75cd497d52a098433a1e1a341959'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'bff170bdb8be4dd669bbab199a74929266cfc2207cd5234503a2d44e28aeb99d'
+    sha256 '8aa154e55a562bc9f7f6c079ef830efa33da201579077aca691fc2599ab446f3'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '9f68324008c268cc45a972c8c5760ebf89ba49f95eb83a97d276a8b9ff93bf5a'
+    sha256 '538d36efc7ef05de2b4de3e3e4dc3bf51227ff3863b7d9a220d37bed57f6ad52'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'ecb2a7b11f4612b5f0e74067127668afd41593fd518d5cc8e8422ce2fa5cd03d'
+    sha256 '1e44b20b3a3dde77e813f4e6929f36c558297f5dcd81f2e177292368952911ea'
     'fr'
   end
 
   language 'gl' do
-    sha256 '09edd1b9976a9e40eaf62b1ea86c8df968c5a02c15d69177753f57172d8d47dd'
+    sha256 'c5233ba34d961c1ff97b835deded0fce6505421a95fe2083627dd2e94602ee26'
     'gl'
   end
 
   language 'it' do
-    sha256 '5f0f0a01cc36adcdb2d392c37b2b8c2362e614397c6a64c924b7e3d02615c13d'
+    sha256 '14e38982086b4860bb66dc444fb107d7433e6ba04798de0b04a4fbb1e76b0ae1'
     'it'
   end
 
   language 'ja' do
-    sha256 '62a822aa77d82770acdf8dbc35245d8039e9e8724e7654b6e8f8b653ea8c7224'
+    sha256 '417ffcbca4bb4ef674fe024561cd376c81b7f2baec2a53e425d8eda763d48c93'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '25306bcb327c2370ebe7f8652da0b9c84c878b6991600472deb20ab156600b2a'
+    sha256 'd2516c91eb8f8f5561181400dffddd6f1e5cb9ccb20fe83ac2808fb18a434da7'
     'nl'
   end
 
   language 'pl' do
-    sha256 'd1d5c8ae449ceee91fe4ee683da0e082d053c10256af44a945db70b09432f8f0'
+    sha256 'a86de420af5cc5775c69e5b4af75b28e83900e4b32a366f93e773df80cb892e6'
     'pl'
   end
 
   language 'pt' do
-    sha256 'bd1392c056747e5e66b450979a815803e9ad5f9862bb2912537e76bb2253dcbe'
+    sha256 '06beb171f859e0597ce7e26e8f3e46cbed9d4fbef166ec0c16ef11fbbd099612'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '7766c6a39a2d2b0a0ebf8f1c138275dc2e5b308765c2c0f96d286c96fad24068'
+    sha256 '45238cc2ab1b0c0c8b6f05c8a7e57161b46276eca243305117c85b55681688a9'
     'ru'
   end
 
   language 'uk' do
-    sha256 'd654f8be4e0de57f2902f6d56988ddd9a548b23ebb9eea9a46b4fa5b3b3c5732'
+    sha256 'e06d110f7cbb34546913d19ffc1079153ca308577adbccd45b468de3bd33eccf'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '31bf770c94b5c4ac4df6c1da96c821ca0bafd4edaada9900e32abc86179e9efb'
+    sha256 '07dd8855f105e5f0186c4c1fa656172078b031df6eb0832ee6920b05fb72494a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'aecdbdc48e970cf3c4c451fe6fd569781f1179566534014d0735196ecf3b8890'
+    sha256 '0c664eaeac824da62ff976bec9b62f6d2207f12098cb541c7b2316f5f31b7781'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.