### PR TITLE
Update airmail-beta to 3.2.399,275

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.398,274'
-  sha256 'a93412d21fbfd41c7168ad6984d1d80bd032bf1f8e19b9c3b11e8bf25177b64e'
+  version '3.2.399,275'
+  sha256 '740c787a5a153d453e809890a779a255b6051ad3f95270c358b233625f92d27e'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'fae7508d1a1865f72ff1e670bce199ed792a27b78cb88e5390cf5b27c21139d7'
+          checkpoint: '36590d52fba0ae97958d80d69a684d898541f2432021b21bce75cadede1af431'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.