### PR TITLE
Fix homepages in 12 casks to include a bare domain slash

### DIFF
--- a/Casks/boot2docker-status-beta.rb
+++ b/Casks/boot2docker-status-beta.rb
@@ -7,7 +7,7 @@ cask 'boot2docker-status-beta' do
   appcast 'https://github.com/nickgartmann/boot2docker-status/releases.atom',
           checkpoint: 'e399bad2bf54114275f4dbce07312b54338baca54d8489326405130501a02a0e'
   name 'Boot2Docker Status'
-  homepage 'http://boot2docker-status.nickgartmann.com'
+  homepage 'http://boot2docker-status.nickgartmann.com/'
 
   app 'Boot2Docker Status.app'
 

--- a/Casks/cuda-z-beta.rb
+++ b/Casks/cuda-z-beta.rb
@@ -6,7 +6,7 @@ cask 'cuda-z-beta' do
   appcast 'https://sourceforge.net/projects/cuda-z/rss?path=/cuda-z/Beta',
           checkpoint: '64c18ee82db789664bc5aefe2981c8f5672bf656a4ca8d6497a91d7c36ad5f1c'
   name 'CUDA-Z'
-  homepage 'http://cuda-z.sourceforge.net'
+  homepage 'http://cuda-z.sourceforge.net/'
 
   app 'Cuda-Z.app'
 end

--- a/Casks/discord-ptb.rb
+++ b/Casks/discord-ptb.rb
@@ -4,7 +4,7 @@ cask 'discord-ptb' do
 
   url "https://cdn-ptb.discordapp.com/apps/osx/#{version}/DiscordPTB.dmg"
   name 'Discord PTB'
-  homepage 'https://discordapp.com'
+  homepage 'https://discordapp.com/'
 
   app 'Discord PTB.app'
 

--- a/Casks/foldingtext-dev.rb
+++ b/Casks/foldingtext-dev.rb
@@ -5,7 +5,7 @@ cask 'foldingtext-dev' do
   # foldingtext.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://foldingtext.s3.amazonaws.com/FoldingText-Dev.dmg'
   name 'FoldingText'
-  homepage 'http://www.foldingtext.com'
+  homepage 'http://www.foldingtext.com/'
 
   app 'FoldingText.app'
 end

--- a/Casks/handbrakecli-nightly.rb
+++ b/Casks/handbrakecli-nightly.rb
@@ -4,7 +4,7 @@ cask 'handbrakecli-nightly' do
 
   url "http://download.handbrake.fr/nightly/HandBrakeCLI-#{version}-master-osx.dmg"
   name 'HandBrake'
-  homepage 'https://handbrake.fr'
+  homepage 'https://handbrake.fr/'
 
   depends_on macos: '>= :lion'
 

--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -5,7 +5,7 @@ cask 'julia-nightly' do
   # amazonaws.com/julianightlies was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/julianightlies/bin/osx/x64/#{version.sub(%r{(\d+\.\d+).*}, '\1')}/julia-#{version}-osx.dmg"
   name 'Julia'
-  homepage 'http://julialang.org'
+  homepage 'http://julialang.org/'
 
   depends_on macos: '>= :lion'
 

--- a/Casks/totalfinder-beta.rb
+++ b/Casks/totalfinder-beta.rb
@@ -4,7 +4,7 @@ cask 'totalfinder-beta' do
 
   url "http://downloads.binaryage.com/TotalFinder-#{version}.dmg"
   name 'TotalFinder'
-  homepage 'http://totalfinder.binaryage.com'
+  homepage 'http://totalfinder.binaryage.com/'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/trillian-beta.rb
+++ b/Casks/trillian-beta.rb
@@ -4,7 +4,7 @@ cask 'trillian-beta' do
 
   url 'https://www.trillian.im/get/mac/beta/'
   name 'Trillian'
-  homepage 'https://www.trillian.im'
+  homepage 'https://www.trillian.im/'
 
   app 'Trillian.app'
 end

--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -4,7 +4,7 @@ cask 'tunnelblick-beta' do
 
   url "https://tunnelblick.net/release/Tunnelblick_#{version}.dmg"
   name 'Tunnelblick'
-  homepage 'https://tunnelblick.net'
+  homepage 'https://tunnelblick.net/'
 
   depends_on macos: '>= :tiger'
 

--- a/Casks/umsatz-mini.rb
+++ b/Casks/umsatz-mini.rb
@@ -4,7 +4,7 @@ cask 'umsatz-mini' do
 
   url 'http://umsatz-programm.de/ladungen/UmsatzMini2015.zip'
   name 'Umsatz Mini 2015'
-  homepage 'https://umsatz-programm.de'
+  homepage 'https://umsatz-programm.de/'
 
   app 'Umsatz Mini 2015.app'
 end

--- a/Casks/umsatz-pro.rb
+++ b/Casks/umsatz-pro.rb
@@ -4,7 +4,7 @@ cask 'umsatz-pro' do
 
   url 'http://umsatz-programm.de/ladungen/UmsatzPro2015.zip'
   name 'Umsatz Pro 2015'
-  homepage 'https://umsatz-programm.de'
+  homepage 'https://umsatz-programm.de/'
 
   app 'Umsatz Pro 2015.app'
 end

--- a/Casks/virtualbox-extension-pack-beta.rb
+++ b/Casks/virtualbox-extension-pack-beta.rb
@@ -4,7 +4,7 @@ cask 'virtualbox-extension-pack-beta' do
 
   url "http://www.virtualbox.org/download/testcase/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   name 'Oracle VirtualBox Extension Pack'
-  homepage 'https://www.virtualbox.org'
+  homepage 'https://www.virtualbox.org/'
 
   depends_on cask: 'virtualbox-beta'
   container type: :naked


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
