### PR TITLE
Update sketch-beta to 41.2,35396

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '41.1,35375'
-  sha256 '6adf599aa68f849bcea772ea84bef0cfcb9fadb7dd889c1a5708e8b15722534f'
+  version '41.2,35396'
+  sha256 '3ea7827266edc767408970e1d0ea602bf4b65446f3b0f75223bef67c17398403'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'db7d6e094e6ff5245999b5ceefa270e494c6fb027e81a318bf0aa7678bdd7eae'
+          checkpoint: '5df0081637828de3942ef26f305b110edd7a948bfcd83f0ffafeafd50c999898'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.