### PR TITLE
Add Pale Moon Version 27.0.0

### DIFF
--- a/Casks/palemoon-tycho.rb
+++ b/Casks/palemoon-tycho.rb
@@ -1,0 +1,10 @@
+cask 'palemoon-tycho' do
+  version '27.0.0'
+  sha256 '59504762c6935b35ca33b06f31cb799cb5dedfb9ca04a527dd83dab0991b01c1'
+
+  url 'https://mac.palemoon.org/dist/palemoon-27.0.0.mac64.dmg'
+  name 'Pale Moon Tycho'
+  homepage 'https://www.palemoon.org/'
+
+  app 'PaleMoon.app'
+end

--- a/Casks/palemoon-tycho.rb
+++ b/Casks/palemoon-tycho.rb
@@ -2,7 +2,7 @@ cask 'palemoon-tycho' do
   version '27.0.0'
   sha256 '59504762c6935b35ca33b06f31cb799cb5dedfb9ca04a527dd83dab0991b01c1'
 
-  url 'https://mac.palemoon.org/dist/palemoon-27.0.0.mac64.dmg'
+  url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Pale Moon Tycho'
   homepage 'https://www.palemoon.org/'
 

--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,9 +1,9 @@
-cask 'palemoon-tycho' do
+cask 'palemoon' do
   version '27.0.0'
   sha256 '59504762c6935b35ca33b06f31cb799cb5dedfb9ca04a527dd83dab0991b01c1'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
-  name 'Pale Moon Tycho'
+  name 'Pale Moon'
   homepage 'https://www.palemoon.org/'
 
   app 'PaleMoon.app'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed

Adds Pale Moon version 27.0.0, codename Tycho. Putting in versions as version 26.5.0 is stable before Tycho rebase which breaks functionality.