### PR TITLE
Update palemoon.rb to 27.0.1

### DIFF
--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,6 +1,6 @@
 cask 'palemoon' do
-  version '27.0.0'
-  sha256 '59504762c6935b35ca33b06f31cb799cb5dedfb9ca04a527dd83dab0991b01c1'
+  version '27.0.1'
+  sha256 'b004dabe39b79cbe9afe39d5c43c3ca6152c78b29a118e335426b1215e0aa94b'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Pale Moon'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

