### PR TITLE
Update vivaldi-snapshot to 1.6.682.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.5.676.6'
-  sha256 '721f782605dd75b1430db9e1d428e2174b9f9d53133c05cf3f27d2d9ded171ed'
+  version '1.6.682.3'
+  sha256 '11e1a1be5a499f94c98891f4f79232b944ff699a19119d49357e596703c54ae2'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '6139bcc7f64a7707daa8ff1a741f2375a877b91bd3b96acef564a1d4de5a78f2'
+          checkpoint: 'fbd46dd29a822f1d0bfb4f63ed38908286d8ccf4b1356f0a1741cf5f20f66090'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.