### PR TITLE
Update firefox-esr to 45.5.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,73 +1,73 @@
 cask 'firefox-esr' do
-  version '45.5.0'
+  version '45.5.1'
 
   language 'de' do
-    sha256 '0b6e8ae029cca6acb7e1bdb1e99aa32eaca3e1190311a4dfefff307075d19d28'
+    sha256 '729e7dd96337930b8b12b1403b78e112d95092a6a48c81d5a6ba549adf7c6688'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '2ce228e4c51c4f35f302c53b2070abf3b762750a4c7eafd16f081910e4ced125'
+    sha256 '671a7c5e1c31c299060a239f671e2dc0feda90fb400919b9f91b32655cabb334'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'd6b9f8c0a722b2ddb2138b13c5964d77cf29052f0553024e16ff391d2f5328ef'
+    sha256 '3a263c1871287ca73bdcd981921e44798512880fb9fcee0d6889481a93acb613'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '90a787f04945907b9ca747786f427ce32c0c069aab5e10642bdb4fb486e7aa90'
+    sha256 'c41cabe616deed4cb7eceaf41f1d3c66fda01800e8a754fce0116ec788b28659'
     'fr'
   end
 
   language 'gl' do
-    sha256 '03b97cd2df722b59484434aa6ce6e73bcb120040800770755b769afdbeadf891'
+    sha256 '13fa18ff6a79c68daee6a8403626fcfd8ef7a76dca53895b358a97f025a2a83d'
     'gl'
   end
 
   language 'it' do
-    sha256 '7f8aba5867b1d74c4d3fde2734bf4d53ddbb3b1920cd626e7cabaeffd5871922'
+    sha256 '2537311943ff98d73af1c41aa31477e7f994d70981fb7e0a3ee2b72f8457552f'
     'it'
   end
 
   language 'ja' do
-    sha256 '9d89aa108ff794e9b6b304ee9df6e14cd9609a76c56d0127a35099673d909157'
+    sha256 '44b975fac41c84f11a73ef383141bee4c34120c40536b85d42be7ebacf159d63'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '6fb0a9ef2ef544e276881a3a31329fc87264e5d5f957095d4a311e84ef121b53'
+    sha256 'd3e595d78af11e27bf7bc0da84801a245bed33d3865d1da9b45f6111aaada1f1'
     'nl'
   end
 
   language 'pl' do
-    sha256 'cd3f89577198e13403ac06639740c37f4e54f6d3dfcddc365f9a2da87836c11b'
+    sha256 '40e2a31606d8a5a0d057d9cd6ce4691b9778f8e798625ce893adc82220ce4417'
     'pl'
   end
 
   language 'pt' do
-    sha256 '838b08418fad9290f0751245e4c5726a81c972b654db508db7a854d14f531ff5'
+    sha256 'fe6fe999d696f6d759cb34f4c4b6ce643f727c6be3f4da6b174f583a65cdd19b'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'c9593c0be1daea67a38129c581d1291b8f4bc3b6be76b8cfd8afbf977debfc5f'
+    sha256 'd4e83857bf704478d5eb1741aaf9439f003b74b2bb39eec1bdf7e9af252a282d'
     'ru'
   end
 
   language 'uk' do
-    sha256 '4da9ce5af1dc1d971aaa82135737013adec51e11be4736db0df6c1d14823d39a'
+    sha256 '3204853a6a02b02fc23209f9fd021bc29867b1f21fe557dfbbe7e42b268664fd'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'd4457f695ed43eeafd9ff4cf14dca9c2e7dbafa3de4ff4e3fba60826d05fe848'
+    sha256 '704718d4ab7bb6db848162dd834ceeeafde819ded6bd116dea6d596b69fe6bc7'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ad0f9cc7e6d7908e6e9785c1a60178af554118c543f311f4061dd58783096df2'
+    sha256 'a312d2ad3ffcf0557cad7435bc65373c5626400d25ea655a014b0f1ea19040e0'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
