### PR TITLE
Update webstorm-eap to 2016.3.2 EAP,163.9166.8

### DIFF
--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -1,14 +1,14 @@
 cask 'webstorm-eap' do
-  version 'RC,2016.3'
-  sha256 'a5ca297846ba9403e8db07c9c638890f81553719b8e075d8e15ec6743f662a11'
+  version '2016.3.2 EAP,163.9166.8'
+  sha256 'b22e658a8a8df9cbdeac77bd176f4f51e2ad3b48eb3d96a45fa49892ae520d91'
 
-  url "https://download.jetbrains.com/webstorm/WebStorm-#{version.after_comma}-#{version.before_comma}.dmg"
+  url "https://download-cf.jetbrains.com/webstorm/WebStorm-EAP-#{version.after_comma}.dmg"
   name 'WebStorm EAP'
   homepage 'https://confluence.jetbrains.com/display/WI/WebStorm+EAP'
 
   conflicts_with cask: 'webstorm'
 
-  app 'WebStorm.app'
+  app "WebStorm #{version.before_comma}.app"
 
   uninstall delete: '/usr/local/bin/wstorm'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.