### PR TITLE
Update 1password-beta to 6.6.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.5.2.BETA-1'
-  sha256 'b3e599270f78f120ed4be2a4e7e7a57fa9d9a902de257d6decac697989c418a9'
+  version '6.6.BETA-1'
+  sha256 'f19a61e5b159b9d594d9f2a4a22bffc68e68c20d58fc6a64032a6038af1fd137'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.