### PR TITLE
Fix binary name in sourcetree-beta 2.4b6

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -12,8 +12,8 @@ cask 'sourcetree-beta' do
   auto_updates true
   depends_on macos: '>= 10.10'
 
-  app 'SourceTree Beta.app'
-  binary "#{appdir}/SourceTree Beta.app/Contents/Resources/stree"
+  app 'SourceTree-Beta.app'
+  binary "#{appdir}/SourceTree-Beta.app/Contents/Resources/stree"
 
   postflight do
     suppress_move_to_applications


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.


