### PR TITLE
Update mono-mdk-preview 4.8.0.371

### DIFF
--- a/Casks/mono-mdk-preview.rb
+++ b/Casks/mono-mdk-preview.rb
@@ -1,9 +1,8 @@
 cask 'mono-mdk-preview' do
-  version '4.3.0.2114'
-  sha256 :no_check # required as upstream package is updated in-place
+  version '4.8.0.371'
+  sha256 '2313fa4574e5f37c9c7fc6db0aaf0f2124ff37404571cf988b8c89cfbba06ddc'
 
-  # download.xamarin.com was verified as official when first introduced to the cask
-  url "http://download.xamarin.com/roslyn-preview/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
+  url "https://download.mono-project.com/archive/#{version.sub(%r{\.[^.]*$}, '')}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name 'Mono'
   homepage 'http://www.mono-project.com/'
 


### PR DESCRIPTION
Update mono-mdk-preview to latest Alpha Mono release: 4.8 Alpha 2 (4.8.0.371)

After making all changes to the cask:

- [ x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.