### PR TITLE
Update screenflow5 to 5.0.7

### DIFF
--- a/Casks/screenflow5.rb
+++ b/Casks/screenflow5.rb
@@ -1,6 +1,6 @@
 cask 'screenflow5' do
-  version '5.0.6'
-  sha256 'b0e2ec943246a781acd0fc115d319e361bb37f9f8edc0fd514ac066de8eb6ca0'
+  version '5.0.7'
+  sha256 '2b5a3e8b4469dd69b78f9960edef3fa3fc6de9085a1718f76d2403fa2f52acfd'
 
   url "https://www.telestream.net/download-files/screenflow/#{version.major_minor.dots_to_hyphens}/ScreenFlow-#{version}.dmg"
   name 'ScreenFlow'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.