### PR TITLE
Update pdfpenpro to 830.1,1481079889

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '821.5,1476995246'
-  sha256 'fef903eb1bdc2d882a04e5e690999d6f121a9b56d86e833663be7975c256c076'
+  version '830.1,1481079889'
+  sha256 'eed9bb19ac40d3c9dd1d23691105c6df7fd3563cbd7fbf2fc4a0cff998b0336a'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: '2d618379f9d3155f61363b811cda6d2eafec89b95c67b6d37139b66261988ac5'
+          checkpoint: 'b9d35c5c6c5c3313f3fa545d584be71fd00600f13df780bbd76bc89b703ca6ea'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.