### PR TITLE
Update rhinoceroswip to 5D143w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5C249w'
-  sha256 'bb58586441ff7c6c122178189dcb7668478f61df36f39287fc62975b52953c23'
+  version '5D143w'
+  sha256 'd3a479f12682afcbf512314a2fe4d8e558bc784d6fa0057a5b08f984f6cd1f0a'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '03da618fc2af5b2357da7b0160ddce9816e1b4a1b4729bdb576a8959c758fd60'
+          checkpoint: 'f3c3a707d11053ffaa90f138d6a2dede7262038a386e434c5626f0b90ae822a4'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.