### PR TITLE
Update visual-studio-code-insiders to 1.8.0,e0871329738682651367be4e8…

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.3.0,5474147bb83618975409dad7d8aa96151d7d1ea1'
-  sha256 '05e55c2e130315358dd9ce3c1c039e4bb7e07b4c6edcebe0acf30bc639a81aef'
+  version '1.8.0,e0871329738682651367be4e8a618912ad693e03'
+  sha256 'bb51bcfb2dc8e44c3536144af021b023e703ffaf4ef7fb5c6ac9f7025adedd4e'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
@@ -16,5 +16,9 @@ cask 'visual-studio-code-insiders' do
   zap delete: [
                 '~/Library/Application Support/Code - Insiders',
                 '~/Library/Caches/Code - Insiders',
+                '~/Library/Caches/com.microsoft.VSCodeInsiders',
+                '~/Library/Caches/com.microsoft.VSCodeInsiders.ShipIt',
+                '~/Library/Preferences/com.microsoft.VSCodeInsiders.helper.plist',
+                '~/Library/Preferences/com.microsoft.VSCodeInsiders.plist',
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.