### PR TITLE
Update macvim-kaoriya to 20161209

### DIFF
--- a/Casks/macvim-kaoriya.rb
+++ b/Casks/macvim-kaoriya.rb
@@ -3,13 +3,13 @@ cask 'macvim-kaoriya' do
     version '7.4:20130911'
     sha256 'd9fc6e38de1852e4ef79e9ea78afa60e606bf45066cff031e349d65748cbfbce'
   else
-    version '8.0:20161207'
-    sha256 '257d91dc3be2af69f7438130e3d67e051ff3f65f5bc55f8687a3bcf39706e2c6'
+    version '8.0:20161209'
+    sha256 '4957e90bc5f74badea4ebf39f61f0857fa3f4fa649c3c0033fe4c243bf5f4abc'
   end
 
   url "https://github.com/splhack/macvim-kaoriya/releases/download/#{version.after_colon}/MacVim-KaoriYa-#{version.after_colon}.dmg"
   appcast 'https://github.com/splhack/macvim-kaoriya/releases.atom',
-          checkpoint: '0ff8c6db7f4ca428fc2359c2854d4c983e842c1935c22669616212d3f3ebd5a2'
+          checkpoint: '38fc9e67bd2eb5ec0f5b1a7efd1729f92930b60d9d49aff6463936def701bf63'
   name 'MacVim KaoriYa'
   homepage 'https://github.com/splhack/macvim-kaoriya'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
