### PR TITLE
Update emacs-nightly to 2016-12-10_01-45-35-fc0fd24c105bde4c001ebebe4b8b7e1f96cd2871

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2016-10-21_01-44-43-56f8384bb3f20d55693a3a1db8aa2cf490e6d18e'
-  sha256 'afe81b37ebf741db92ee1f2e603a21df2b67cb6ec09d7f70d99f4b9bb6b20b7d'
+  version '2016-12-10_01-45-35-fc0fd24c105bde4c001ebebe4b8b7e1f96cd2871'
+  sha256 '2fb57d188e4de86ba75f123a4e41162705ffa7c1cb2df65208097557bca89d4d'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: 'e852c334334af7d6d2368ae86162f98df15c479abdc9064361580172dfed4ae1'
+          checkpoint: '3636bbf0be9aaf5baf019b84048e2662613449d54714cb5272b1e9cc5202ee13'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.