### PR TITLE
Update firefox-beta to 51.0b7

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '51.0b6'
+  version '51.0b7'
 
   language 'de' do
-    sha256 '176496655affd7126cd47a09d4bad8e3916465caac57742a9cc11c23dd30e857'
+    sha256 '14ac0db570ab3e130ebf1fba16faa55494195ef50b2a61704ffbbf6037c12c0f'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'dddc2c8a5d49554f8b610c528926f61b3df794c0f0a269b1e3b39c2c37860c69'
+    sha256 'c17c05e3b3fe95e3eaad3642b8a599f5dcf28e1b68fbe6e255f1e73f7036395c'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'a525f29927a2fbe2af7f342f67a4ed1dd69543133a6016a7163bc68513ffc916'
+    sha256 'bf87c8caafd39135888294bb31ddac12e4c1403991e762fdbb5af93f322f805f'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '691f1dacadb63700ee70123dfbbccbae8de8c1ec4c68dca572ebd2a4129b8a1d'
+    sha256 '891df6e5e9a4bd28fe27879c3f2c990c704a406fdb1c783a052840f41d4035c7'
     'fr'
   end
 
   language 'gl' do
-    sha256 '2cef98f3e26d2626118e31db99840ff6d91958bd93ac5ad4bece482cbe6e13d9'
+    sha256 'cd14d0b957eee7e8601856b6b75403477b622cd2e3a4977285fdc1e39a329211'
     'gl'
   end
 
   language 'it' do
-    sha256 '3dd016a4dff0f482398daac3f0a98704e143d350ad072674f71a0d275c314653'
+    sha256 'ce0c95cd0adffb3fe3e283c4920c3c3ed02b53f4a0651b642168a8fcb6be6c68'
     'it'
   end
 
   language 'ja' do
-    sha256 'd275913ce16288f53ce8ec2e6deafc85bb11f5b7bc0b2c58a901567e7087b384'
+    sha256 '8edba9c498911ebab8f3931834e0a11fba14274614dc7e75e91a304ebcfa72e5'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'f2e6a41ec2e4ecec51a207f26f299fa8abc4a6d96f5857e792d30c0686ce3e89'
+    sha256 'c35afc8a7eece480a4cc0d1995b5e465b21ad716901a4dee6c002cdfb90aab60'
     'nl'
   end
 
   language 'pl' do
-    sha256 '1fbda910e1a66c1fdb182f26db8f99f20a979d3b4bbee8520672de9bec5ab3cb'
+    sha256 '688220db45d6ea9ad282ea595f6426ee2472de42c81c57e1d29f17ae1d0a23c6'
     'pl'
   end
 
   language 'pt' do
-    sha256 '78b8f460c91b486e9c40f7036ac39d6e7526dd0e2202784052b2697c0232a00e'
+    sha256 '991926dd3612dac3fb1df1638fc0f8cde405b0d1b559ea12c3b777dfbf434937'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '382238d9fbcd5f8d1f58d36717cb37e36b48d43994b0226b07aff9477716d04c'
+    sha256 '926b9cb50d97a1f4f80afb9f224fd565bb6abc71d6214edd8199d584e2f72cfd'
     'ru'
   end
 
   language 'uk' do
-    sha256 'ca87c180aa748ab457d7d399732cdf3b36d91c15c8c11abae0905e50808b4eb2'
+    sha256 '54d4b962260f621ba002d131c25b55fab6af7bd67a59013e469278ef63e83d1d'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '6ecd757db3a5d0f12e39417ffd1d0488056a9a6469033bcf6a50cd0f0804f84a'
+    sha256 'e1f8618fd5c46dabc05b779f26d1c6b1ea8e15ce9a2f171d8f057ebb9211800a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '978ef39d7ddbedf0c5ba7fdb955d81cb3cafe7bee195127bbb3a7a13d662fcaa'
+    sha256 'c185b48798239482f842085d21b90c07fe45d337c9450d752b158068bd23f4ec'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.