### PR TITLE
Update vivaldi-snapshot to 1.6.689.32

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.6.689.29'
-  sha256 '13c1c166b9c6ec4edba22a83e8fbc52fc7b0fa9a5e426f973ba6035726056166'
+  version '1.6.689.32'
+  sha256 '979120b0c09f085490269a7b5715421ae57bfef9d819599a222d7ee095283936'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'a91886da0c6261467883dfd0afca3a1d7c30d30e27d30e4f05b4213c8633d795'
+          checkpoint: '6ed839ec17f8facb6b6b3e0e01df0ee6bcede9e3fed255f59a6e9dfac3f26163'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.