### PR TITLE
Update firefox-esr to 45.6.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,73 +1,73 @@
 cask 'firefox-esr' do
-  version '45.5.1'
+  version '45.6.0'
 
   language 'de' do
-    sha256 '729e7dd96337930b8b12b1403b78e112d95092a6a48c81d5a6ba549adf7c6688'
+    sha256 '71fde2a23acd00174808906b44514c5a96b9521ced23bb378c516b81837499d2'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '671a7c5e1c31c299060a239f671e2dc0feda90fb400919b9f91b32655cabb334'
+    sha256 '2f000f58b8c626ce070df3629559005ec31bd12f88372a28e1b82cb911a0465a'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '3a263c1871287ca73bdcd981921e44798512880fb9fcee0d6889481a93acb613'
+    sha256 'c5ab6a93fe7607a8ef1873335c3cc468a63d39df05f76e17421df87eda2d2f15'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'c41cabe616deed4cb7eceaf41f1d3c66fda01800e8a754fce0116ec788b28659'
+    sha256 'e0bdc5146fe45c7e611e17b90a2b309fb906a3a335febde91b14ef430aecc352'
     'fr'
   end
 
   language 'gl' do
-    sha256 '13fa18ff6a79c68daee6a8403626fcfd8ef7a76dca53895b358a97f025a2a83d'
+    sha256 '0af0f6fb94b0d233635a258d1f180fec3344ea297332dd8044ff00f8b92c7cb9'
     'gl'
   end
 
   language 'it' do
-    sha256 '2537311943ff98d73af1c41aa31477e7f994d70981fb7e0a3ee2b72f8457552f'
+    sha256 '58013e3657fc2c1e192b386215edf2b4fbc11f3d7da8e1c8ea0a3541bc127c7a'
     'it'
   end
 
   language 'ja' do
-    sha256 '44b975fac41c84f11a73ef383141bee4c34120c40536b85d42be7ebacf159d63'
+    sha256 'c25ff53081e25686b426d9d1e8c7e2621b433894f64b3bf476fc7a11ea501954'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'd3e595d78af11e27bf7bc0da84801a245bed33d3865d1da9b45f6111aaada1f1'
+    sha256 '8445a0b4efa20b6875da450e46e10f2dd3ebefb233669dbcc4bf555eb73f9b93'
     'nl'
   end
 
   language 'pl' do
-    sha256 '40e2a31606d8a5a0d057d9cd6ce4691b9778f8e798625ce893adc82220ce4417'
+    sha256 '78d700e7534e5d21dce618f52aa8c516280c35b33fd7c8da76c514b5b7cc96ec'
     'pl'
   end
 
   language 'pt' do
-    sha256 'fe6fe999d696f6d759cb34f4c4b6ce643f727c6be3f4da6b174f583a65cdd19b'
+    sha256 '01d3671bd3ce9e338caad2a7ac7edbaf46a42c19585b0f425f4353ed038e9d45'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'd4e83857bf704478d5eb1741aaf9439f003b74b2bb39eec1bdf7e9af252a282d'
+    sha256 '44ea920f98a8bde3d0018ca23135e0684c3928cbf782f4e4a60b411b33f4077e'
     'ru'
   end
 
   language 'uk' do
-    sha256 '3204853a6a02b02fc23209f9fd021bc29867b1f21fe557dfbbe7e42b268664fd'
+    sha256 'ba1a207afae24ca8426718d01728150430b00891f01416c754df0024dcc4a17e'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '704718d4ab7bb6db848162dd834ceeeafde819ded6bd116dea6d596b69fe6bc7'
+    sha256 '743627c0bca2493e552bb120340854d61c915ebd9e5659c90d22c690fa1bac8c'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'a312d2ad3ffcf0557cad7435bc65373c5626400d25ea655a014b0f1ea19040e0'
+    sha256 'c5ab6a93fe7607a8ef1873335c3cc468a63d39df05f76e17421df87eda2d2f15'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.