### PR TITLE
Update phpstorm-eap to 2016.3.2,163.10154.2

### DIFF
--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'phpstorm-eap' do
-  version '2016.3.1,163.9166.11'
-  sha256 '2aa42446f5738dd4ad3d7acac02458b8cc7d72820670611edeb61b30161f3d86'
+  version '2016.3.2,163.10154.2'
+  sha256 '44835d034c2855d036822adf5b9f15bb74f2ba03d8ae0402559693541f92f78b'
 
   url "https://download.jetbrains.com/webide/PhpStorm-EAP-#{version.after_comma}.dmg"
   name 'PhpStorm EAP'
@@ -13,9 +13,9 @@ cask 'phpstorm-eap' do
   uninstall delete: '/usr/local/bin/pstorm'
 
   zap delete: [
-                "~/Library/Preferences/PhpStorm#{version.major_minor}",
+                "~/Library/Application Support/PhpStorm#{version.major_minor}",
                 "~/Library/Caches/PhpStorm#{version.major_minor}",
                 "~/Library/Logs/PhpStorm#{version.major_minor}",
-                "~/Library/Application Support/PhpStorm#{version.major_minor}",
+                "~/Library/Preferences/PhpStorm#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.