### PR TITLE
Update clion-eap to 2016.3.2,163.10154.14

### DIFF
--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -1,19 +1,19 @@
 cask 'clion-eap' do
-  version '163.9166.5'
-  sha256 'e59f30f8c06989fec5204f89d22ad3edbcbe5c34d71e87bbcd1a79802351c1dc'
+  version '2016.3.2,163.10154.14'
+  sha256 '0f1f473b75848b204a21b411703dba91695052678a6c9db0ac4b592f4f59c7a3'
 
-  url "https://download.jetbrains.com/cpp/CLion-#{version}.dmg"
+  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}.dmg"
   name 'CLion EAP'
   homepage 'https://confluence.jetbrains.com/display/CLION/Early+Access+Program'
 
   conflicts_with cask: 'clion'
 
-  app 'CLion 2016.3.1 EAP.app'
+  app "CLion #{version.before_comma} EAP.app"
 
   zap delete: [
-                '~/Library/Preferences/CLion2016.3',
-                '~/Library/Application Support/CLion2016.3',
-                '~/Library/Caches/CLion2016.3',
-                '~/Library/Logs/CLion2016.3',
+                "~/Library/Application Support/CLion#{version.major_minor}",
+                "~/Library/Caches/CLion#{version.major_minor}",
+                "~/Library/Logs/CLion#{version.major_minor}",
+                "~/Library/Preferences/CLion#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Version format was changed to be more in line with other JetBrains EAP casks and to make use of interpolation easier. Zaps were changed to be in alphabetical order.