### PR TITLE
Update emacs-nightly to 2016-12-14_01-45-52-51b2669ad51441b3bd318c749e67b267defe4882

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2016-12-13_01-45-21-dc833039179ee11dae9aeb15b7d75e7435f7f1c9'
-  sha256 '85950b2b3a44c897f25d20b9781eb00c5a4616226015dde680e5de8e827be856'
+  version '2016-12-14_01-45-52-51b2669ad51441b3bd318c749e67b267defe4882'
+  sha256 '74af0bfa2a78901922f15316bccea89de8197a1bb53fd3b13d0507b13d877340'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '884fba7a2a4fdd4d69668cf941b6c7ec778496d85088ec4c1538d7243f79c100'
+          checkpoint: 'fb4384cdb44512185fdcd5f116d8497a216df4752b2f6fbe0ed376679251e5ea'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.