### PR TITLE
Update libreoffice-dev to 5.3.0.0,beta2

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,12 +1,12 @@
 cask 'libreoffice-dev' do
-  version '5.3.0.0,beta1'
-  sha256 '8dff22f381e754e32b5f57a605f0121592ae27056960f5613c4df713b58f7ecf'
+  version '5.3.0.0,beta2'
+  sha256 'de2b255d4e0aa4d2e6f95aaaaacefc58a3838708d24b7e95ba87d97681710685'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
 
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version.before_comma}.#{version.after_comma}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'c670b48ca9a4352e2ec995b28745bed6f4bb6cb446e18cbc15b8b77a24bab665'
+          checkpoint: 'ebb247994de5d9151a1158d384568e0a230420ff9b8d6803c85fa8436ae8b17b'
   name 'LibreOfficeDev'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc",


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
