### PR TITLE
Update firefox-beta to 51.0b8

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '51.0b7'
+  version '51.0b8'
 
   language 'de' do
-    sha256 '14ac0db570ab3e130ebf1fba16faa55494195ef50b2a61704ffbbf6037c12c0f'
+    sha256 '508e526ae205d6be10aaaa04d539a178da3f37d9bf35d7dc02acb8570cbf3048'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'c17c05e3b3fe95e3eaad3642b8a599f5dcf28e1b68fbe6e255f1e73f7036395c'
+    sha256 '32ec6b9c1a622dd9f62fa5a9963bbd51722995c34d707f566fb09f69c8d2f094'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'bf87c8caafd39135888294bb31ddac12e4c1403991e762fdbb5af93f322f805f'
+    sha256 '07912a18d4791cc281431453e9587849b24c899232eba0194a5fc2ba78b3840b'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '891df6e5e9a4bd28fe27879c3f2c990c704a406fdb1c783a052840f41d4035c7'
+    sha256 'e8221b75c4eaf36d268219f0cc88e3b80a55046203d4e6055cd9f96cf74a59da'
     'fr'
   end
 
   language 'gl' do
-    sha256 'cd14d0b957eee7e8601856b6b75403477b622cd2e3a4977285fdc1e39a329211'
+    sha256 '0c05df672a5caecc3bf7067a7efb7aff15cdff945bb9a4a581493607df97bb3d'
     'gl'
   end
 
   language 'it' do
-    sha256 'ce0c95cd0adffb3fe3e283c4920c3c3ed02b53f4a0651b642168a8fcb6be6c68'
+    sha256 '1df50cf6cad7aac906bf6fea4c74b0397393ce782241bcfbd2d7bbfbc5e23352'
     'it'
   end
 
   language 'ja' do
-    sha256 '8edba9c498911ebab8f3931834e0a11fba14274614dc7e75e91a304ebcfa72e5'
+    sha256 '25eae3bcced62fc80488663d15a3c02b5583f12814b18aa6c57d2d8f19638d51'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'c35afc8a7eece480a4cc0d1995b5e465b21ad716901a4dee6c002cdfb90aab60'
+    sha256 '84d1084d53a666595878a36d34dc88b83fd15731374aac2fbbf983626ae26c48'
     'nl'
   end
 
   language 'pl' do
-    sha256 '688220db45d6ea9ad282ea595f6426ee2472de42c81c57e1d29f17ae1d0a23c6'
+    sha256 '07bb52b551b0cb044193013e70c7c6264a9ff8d642e79172d4de29c3aa91b40b'
     'pl'
   end
 
   language 'pt' do
-    sha256 '991926dd3612dac3fb1df1638fc0f8cde405b0d1b559ea12c3b777dfbf434937'
+    sha256 'b86f77317c4336a7b21bca5d4bcca4900427d20a74f05937e59d37aa21b8a0ac'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '926b9cb50d97a1f4f80afb9f224fd565bb6abc71d6214edd8199d584e2f72cfd'
+    sha256 '558adcdbb698add34f0b75067d8013d103e0e7a1755d42410ef0f9abd4c72ff3'
     'ru'
   end
 
   language 'uk' do
-    sha256 '54d4b962260f621ba002d131c25b55fab6af7bd67a59013e469278ef63e83d1d'
+    sha256 'bef16f21b6ad5240f5e14b1e96590a7533a99305b28eadbe6887c5c36ce5552d'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'e1f8618fd5c46dabc05b779f26d1c6b1ea8e15ce9a2f171d8f057ebb9211800a'
+    sha256 '6290eeca40ec58e66938539ef566cbb569f07c2c9261baaad8ec4b176a135f13'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'c185b48798239482f842085d21b90c07fe45d337c9450d752b158068bd23f4ec'
+    sha256 '5e3f5cd9d4a91e660cf7d6c57c38f0d926887a7cf8a0abd2ea502daacc315a92'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.