### PR TITLE
Add Ableton Live Lite v9.7.1

### DIFF
--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,0 +1,10 @@
+cask 'ableton-live-lite' do
+  version '9.7.1'
+  sha256 '8cc2779b3888a74aa481ef6729564ad7938180b5fd9e1c07c79bad32708d26b1'
+
+  url "http://cdn2-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
+  name 'Ableton Live Lite'
+  homepage 'https://www.ableton.com/en/products/live-lite/'
+
+  app "Ableton Live #{version.major} Lite.app"
+end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

As discussed in https://github.com/caskroom/homebrew-cask/pull/20589 and https://github.com/caskroom/homebrew-cask/pull/16064, the Ableton Live Lite "Edition" is supposed to go in caskroom/versions tap.
PS: It's my first attempt to create a cask and contribute - I appreciate any advice.
