### PR TITLE
Update emacs-nightly to 2016-12-16_01-45-26-cdf5340f51d4346c276102331e3ed29561753b26

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2016-12-15_01-45-24-09a66ceb5e906e704be58d5f40c45096307f0b9e'
-  sha256 '7f2bebff7c199e90e813d92fdb5baff06943b8a62e1f402f1a5c6dc478246d7f'
+  version '2016-12-16_01-45-26-cdf5340f51d4346c276102331e3ed29561753b26'
+  sha256 '0febada7447086031ad548fda20dcbed164f3f017c0d79dc7e6b1ec6df468c78'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: 'e9c256e34d8a83184879f528599bbfb4a2881dfd83f8072e11852bb581b2d4f7'
+          checkpoint: '55e20b694a54233f7b297dc231db25fb3b2dee56dfc1ac000403496451ba8ca6'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.