### PR TITLE
Update emacs-nightly to 2016-12-18_01-45-40-1a15d14e143ed84d8116c6510f9619d936ea43a1

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2016-12-16_01-45-26-cdf5340f51d4346c276102331e3ed29561753b26'
-  sha256 '0febada7447086031ad548fda20dcbed164f3f017c0d79dc7e6b1ec6df468c78'
+  version '2016-12-18_01-45-40-1a15d14e143ed84d8116c6510f9619d936ea43a1'
+  sha256 '6ca4018bcda81eb90611d40e0ebf9587d3245f78300f974c845c35b0a3453939'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '55e20b694a54233f7b297dc231db25fb3b2dee56dfc1ac000403496451ba8ca6'
+          checkpoint: 'f64360ab32acf7623024ca94b1c5c3c30d81eb764d06834111a21b65f5c99548'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.