### PR TITLE
Update opera-beta to 42.0.2393.78

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '42.0.2393.38'
-  sha256 '430f1a628a8a8e965fde39a17337a2251b3608bdeba683f7e4f6da8627e413a1'
+  version '42.0.2393.78'
+  sha256 'fac07ed47ba366f2cbfc12171eb69a94af5b0d4dd188bf2b166f634d4536abcc'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.