### PR TITLE
Update airmail-beta to 3.2.401,277

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.400,276'
-  sha256 '0480c4291a006e244d73d9be474b20f110a642661fc9be53ca81fd8b86419247'
+  version '3.2.401,277'
+  sha256 'bc98f613f37a94c157ed0e83dc262b2fa772395d4604e969618e019a0508d9d8'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '49897693664d890ab27f4651115f9cc717105941d27ff376c2e28f58dae558f6'
+          checkpoint: 'd186dcb88c615fe158030c08d106e55ad684f78eae65e23647a08add12d84edc'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.