### PR TITLE
Update emacs-nightly to 2016-12-20_01-45-32-35aaa6b6aa9a2e7b42465603fb32355a009c510f

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2016-12-18_01-45-40-1a15d14e143ed84d8116c6510f9619d936ea43a1'
-  sha256 '6ca4018bcda81eb90611d40e0ebf9587d3245f78300f974c845c35b0a3453939'
+  version '2016-12-20_01-45-32-35aaa6b6aa9a2e7b42465603fb32355a009c510f'
+  sha256 'afbb6cb1ced39445aa3ce191944e726e6f9efbd8293784723b05beb2a915370b'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: 'f64360ab32acf7623024ca94b1c5c3c30d81eb764d06834111a21b65f5c99548'
+          checkpoint: '37f1b3399d9ea8aac68644993eca061dca78e37370fbd6e5d8818300e10c6161'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.