### PR TITLE
Update webstorm-eap to 2017.1,171.1834.8

### DIFF
--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -1,21 +1,21 @@
 cask 'webstorm-eap' do
-  version 'RC,2016.3.2'
-  sha256 '0b9a84b355d24d799960ad356ae329afab678d36ba65498a983bc6813f6afc44'
+  version '2017.1,171.1834.8'
+  sha256 '6a6bff688b478fc0d9a22a713e90fdc2ac0116ad744b840fcf3dcd450f93201e'
 
-  url "https://download.jetbrains.com/webstorm/WebStorm-#{version.after_comma}-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/webstorm/WebStorm-EAP-#{version.after_comma}.dmg"
   name 'WebStorm EAP'
   homepage 'https://confluence.jetbrains.com/display/WI/WebStorm+EAP'
 
   conflicts_with cask: 'webstorm'
 
-  app 'WebStorm.app'
+  app "WebStorm #{version.before_comma} EAP.app"
 
   uninstall delete: '/usr/local/bin/wstorm'
 
   zap delete: [
-                "~/Library/Preferences/WebStorm#{version.after_comma.major_minor}",
-                "~/Library/Application Support/WebStorm#{version.after_comma.major_minor}",
-                "~/Library/Caches/WebStorm#{version.after_comma.major_minor}",
-                "~/Library/Logs/WebStorm#{version.after_comma.major_minor}",
+                "~/Library/Application Support/WebStorm#{version.major_minor}",
+                "~/Library/Caches/WebStorm#{version.major_minor}",
+                "~/Library/Logs/WebStorm#{version.major_minor}",
+                "~/Library/Preferences/WebStorm#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
