### PR TITLE
Adding minishift-unstable for minishift 1.0.0-beta.1

### DIFF
--- a/Casks/minishift-beta.rb
+++ b/Casks/minishift-beta.rb
@@ -1,4 +1,4 @@
-cask 'minishift-unstable' do
+cask 'minishift-beta' do
   version '1.0.0-beta.1'
   sha256 '2d4020615bd86b814c678fedbf6072488101c26298a90fb081904c6913d88497'
 

--- a/Casks/minishift-unstable.rb
+++ b/Casks/minishift-unstable.rb
@@ -7,10 +7,6 @@ cask 'minishift-unstable' do
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 
-  depends_on arch: :x86_64
-  depends_on formula: 'unar'
-  container type: :tar
-
   binary 'minishift', target: 'minishift'
 
   postflight do

--- a/Casks/minishift-unstable.rb
+++ b/Casks/minishift-unstable.rb
@@ -8,9 +8,10 @@ cask 'minishift-unstable' do
   homepage 'https://github.com/minishift/minishift'
 
   depends_on arch: :x86_64
-  container type: :naked
+  depends_on formula: 'unar'
+  container type: :tar
 
-  binary 'minishift-#{version}-darwin-amd64/minishift', target: 'minishift'
+  binary 'minishift', target: 'minishift'
 
   postflight do
     set_permissions "#{staged_path}/minishift", '0755'

--- a/Casks/minishift-unstable.rb
+++ b/Casks/minishift-unstable.rb
@@ -3,8 +3,7 @@ cask 'minishift-unstable' do
   sha256 '2d4020615bd86b814c678fedbf6072488101c26298a90fb081904c6913d88497'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
-  appcast 'https://github.com/minishift/minishift/releases.atom',
-    checkpoint: 'f78e6fe63a0e0f8f3cae4f97daebe8528e8a38a7d023c6630598b128ee6c8fed'
+  appcast 'https://github.com/minishift/minishift/releases.atom', checkpoint: 'f78e6fe63a0e0f8f3cae4f97daebe8528e8a38a7d023c6630598b128ee6c8fed'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 
@@ -12,7 +11,6 @@ cask 'minishift-unstable' do
   container type: :naked
 
   binary 'minishift-#{version}-darwin-amd64/minishift', target: 'minishift'
-
 
   postflight do
     set_permissions "#{staged_path}/minishift", '0755'

--- a/Casks/minishift-unstable.rb
+++ b/Casks/minishift-unstable.rb
@@ -3,7 +3,8 @@ cask 'minishift-unstable' do
   sha256 '2d4020615bd86b814c678fedbf6072488101c26298a90fb081904c6913d88497'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
-  appcast 'https://github.com/minishift/minishift/releases.atom', checkpoint: 'f78e6fe63a0e0f8f3cae4f97daebe8528e8a38a7d023c6630598b128ee6c8fed'
+  appcast 'https://github.com/minishift/minishift/releases.atom',
+          checkpoint: 'f78e6fe63a0e0f8f3cae4f97daebe8528e8a38a7d023c6630598b128ee6c8fed'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 

--- a/Casks/minishift-unstable.rb
+++ b/Casks/minishift-unstable.rb
@@ -1,0 +1,20 @@
+cask 'minishift-unstable' do
+  version '1.0.0-beta.1'
+  sha256 '2d4020615bd86b814c678fedbf6072488101c26298a90fb081904c6913d88497'
+
+  url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
+  appcast 'https://github.com/minishift/minishift/releases.atom',
+    checkpoint: 'f78e6fe63a0e0f8f3cae4f97daebe8528e8a38a7d023c6630598b128ee6c8fed'
+  name 'Minishift'
+  homepage 'https://github.com/minishift/minishift'
+
+  depends_on arch: :x86_64
+  container type: :naked
+
+  binary 'minishift-#{version}-darwin-amd64/minishift', target: 'minishift'
+
+
+  postflight do
+    set_permissions "#{staged_path}/minishift", '0755'
+  end
+end


### PR DESCRIPTION
A homebrew cask already exists for `minishift` however we also needed a version for the latest unstable version, hence this pull request to add `minishift-unstable` to homebrew cask versions.

After making all changes to the cask:

- [x] `brew cask audit --download minishift-unstable` is error-free.
- [x] `brew cask style --fix minishift-unstable` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
