### PR TITLE
Update vivaldi-snapshot to 1.7.704.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.6.689.32'
-  sha256 '979120b0c09f085490269a7b5715421ae57bfef9d819599a222d7ee095283936'
+  version '1.7.704.3'
+  sha256 'd7bedd2abeb04f5af83e95d3e2226ca4671525961dfc84a760721530c985c59b'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '6ed839ec17f8facb6b6b3e0e01df0ee6bcede9e3fed255f59a6e9dfac3f26163'
+          checkpoint: '64d40d90878a8313f880e13fbc53984e0603d15de5e822375622fcb24ae5cbe1'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.