### PR TITLE
fix SHA256 for dbeaver-ce 3.8.2

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,6 +1,6 @@
 cask 'dbeaver-community' do
   version '3.8.2'
-  sha256 '5e169b4fee723f8a31515eb2ad03b79e57bf0a499c686745e54e08cde51231db'
+  sha256 'c265f3ed323b1da91ffa7cf2b78e01930fa1c11623b63f60045e148d87fb949e'
 
   url "http://dbeaver.jkiss.org/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
   name 'DBeaver Community Edition'


### PR DESCRIPTION
- [Y] `brew cask audit --download {{cask_file}}` is error-free.
- [Y] `brew cask style --fix {{cask_file}}` reports no offenses.
- [Sort of] The commit message includes the cask’s name and version.
   (I am fixing the SHA of an existing version)