### PR TITLE
Update vivaldi-snapshot to 1.7.705.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.704.3'
-  sha256 'd7bedd2abeb04f5af83e95d3e2226ca4671525961dfc84a760721530c985c59b'
+  version '1.7.705.3'
+  sha256 'dcd1c5a429ee467ba3def0a11650d0fcd25f9f05af81359280659899c453596d'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '64d40d90878a8313f880e13fbc53984e0603d15de5e822375622fcb24ae5cbe1'
+          checkpoint: 'f252d7d33fe9f677eb60d66deaf229b007b9bc192e6e729799f5ed9283ecd428'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.