### PR TITLE
Update kicad-nightly to 20161219-032625.3ffa37c

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -1,6 +1,6 @@
 cask 'kicad-nightly' do
-  version '20161217-032736.f631ae2'
-  sha256 '6b5db7fd414e64ad8f1310d9d2451cf70ff08679fed22d6e2fbcce4963a8cec0'
+  version '20161219-032625.3ffa37c'
+  sha256 '58f89c0ed77f69ba63ea6fadc0b77166e3998de41d5388c33954f7fdffe15313'
 
   url "http://downloads.kicad-pcb.org/osx/nightly/kicad-#{version}-c4osx.dmg"
   name 'KiCad'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.