### PR TITLE
Update clion-eap to RC,2016.3.2

### DIFF
--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -1,19 +1,19 @@
 cask 'clion-eap' do
-  version '2016.3.2,163.10154.14'
-  sha256 '0f1f473b75848b204a21b411703dba91695052678a6c9db0ac4b592f4f59c7a3'
+  version 'RC,2016.3.2'
+  sha256 '5042c0064fdc7bed39bc0720cca8c823df5d66805c09f05632859a90e4fb44df'
 
-  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}-#{version.before_comma}.dmg"
   name 'CLion EAP'
   homepage 'https://confluence.jetbrains.com/display/CLION/Early+Access+Program'
 
   conflicts_with cask: 'clion'
 
-  app "CLion #{version.before_comma} EAP.app"
+  app 'CLion.app'
 
   zap delete: [
-                "~/Library/Application Support/CLion#{version.major_minor}",
-                "~/Library/Caches/CLion#{version.major_minor}",
-                "~/Library/Logs/CLion#{version.major_minor}",
-                "~/Library/Preferences/CLion#{version.major_minor}",
+                "~/Library/Application Support/CLion#{version.after_comma.major_minor}",
+                "~/Library/Caches/CLion#{version.after_comma.major_minor}",
+                "~/Library/Logs/CLion#{version.after_comma.major_minor}",
+                "~/Library/Preferences/CLion#{version.after_comma.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.