### PR TITLE
Update Earlybird v52.0a2

### DIFF
--- a/Casks/earlybird.rb
+++ b/Casks/earlybird.rb
@@ -1,8 +1,8 @@
 cask 'earlybird' do
-  version '51.0a2'
+  version '52.0a2'
   sha256 :no_check # required as upstream package is updated in-placea
 
-  url "https://ftp.mozilla.org/pub/mozilla.org/thunderbird/nightly/latest-comm-aurora/thunderbird-#{version}.en-US.mac.dmg"
+  url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-aurora/thunderbird-#{version}.en-US.mac.dmg"
   name 'Earlybird'
   name 'Thunderbird Nightly'
   homepage 'https://www.mozilla.org/en-US/thunderbird/channel/'


### PR DESCRIPTION
Hello,

Mozilla has changed URL to download ealybird (beta channel of thunderbird)

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [*] `brew cask audit --download {{cask_file}}` is error-free.
- [*] `brew cask style --fix {{cask_file}}` reports no offenses.
- [*] The commit message includes the cask’s name and version.
