### PR TITLE
Update vivaldi-snapshot to 1.7.715.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.705.3'
-  sha256 'dcd1c5a429ee467ba3def0a11650d0fcd25f9f05af81359280659899c453596d'
+  version '1.7.715.3'
+  sha256 'a9a8c480de817d6d2d9d64d31c993a9f6e7940ab42d6328e4f6045d3d756f626'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'f252d7d33fe9f677eb60d66deaf229b007b9bc192e6e729799f5ed9283ecd428'
+          checkpoint: '2443494f5fc9c11d086ad125e88305f1439ed74c33bed3e808ad9174a787e4ba'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.