### PR TITLE
Update sketch-beta to 42,36679

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '42,36644'
-  sha256 'c95a364cb7cbd0f1390d456252feb66cfce756a7330ad242588340593c698414'
+  version '42,36679'
+  sha256 '10d31f2cadeb2577576b01c7a2fe3f0960abce3c2f910e4c03948775b8c14c36'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '230d2cf506cb9cab5a611507bca406d21555a2a7d3ee447e2c5d153e3fec2a18'
+          checkpoint: '76f17c27571614826c489d3bd8b1935dc85832813451f066f264717aa71f2f0d'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.