### PR TITLE
Update airmail-beta to 3.2.403,279

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.402,278'
-  sha256 'b022a6bbea4cbdf61fde8beda3903dd32fed17b2c47331d809c63bd5ae655962'
+  version '3.2.403,279'
+  sha256 'bb7a8d5efc87af8e560d3eef13ff63aa6c2fae9bfcd44ce72d3bfc1ab6ba49e0'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'aa622b499bd2eb0e0c5a881fbdd42d0c1a5f8b26d1e883c05964fbcc27059f13'
+          checkpoint: 'e526a19f0f99ff5f43b3f2663c29116c8ca5cf167ce1fe77fd2aeac16289eac8'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.