### PR TITLE
Update pdfpenpro to 831.0,1483740107

### DIFF
--- a/Casks/pdfpenpro.rb
+++ b/Casks/pdfpenpro.rb
@@ -1,10 +1,10 @@
 cask 'pdfpenpro' do
-  version '830.1,1481079889'
-  sha256 'eed9bb19ac40d3c9dd1d23691105c6df7fd3563cbd7fbf2fc4a0cff998b0336a'
+  version '831.0,1483740107'
+  sha256 '8edce0a326127243e93c7dd9029c15352b3d4e8ac07ca6817798ce41a448f042'
 
   url "https://dl.smilesoftware.com/com.smileonmymac.PDFpenPro/#{version.before_comma}/#{version.after_comma}/PDFpenPro-#{version.before_comma}.zip"
   appcast 'https://updates.smilesoftware.com/com.smileonmymac.PDFpenPro.xml',
-          checkpoint: 'b9d35c5c6c5c3313f3fa545d584be71fd00600f13df780bbd76bc89b703ca6ea'
+          checkpoint: '70d0e591bb0f201c5bf1f2202392c003da77272ae913b1a05d7e581649246097'
   name 'PDFpenPro'
   homepage 'https://smilesoftware.com/PDFpenPro'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.