### PR TITLE
Update libreoffice-dev to 5.3.0.1

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,16 +1,16 @@
 cask 'libreoffice-dev' do
-  version '5.3.0.0,beta2'
-  sha256 'de2b255d4e0aa4d2e6f95aaaaacefc58a3838708d24b7e95ba87d97681710685'
+  version '5.3.0.1'
+  sha256 '75c569333380ef6ff91dad72c5f58e493422c49a5bb608e3cbe1776bf9c5836a'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
-
-  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version.before_comma}.#{version.after_comma}_MacOS_x86-64.dmg"
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'ebb247994de5d9151a1158d384568e0a230420ff9b8d6803c85fa8436ae8b17b'
-  name 'LibreOfficeDev'
+          checkpoint: '1ea2c4052947e21bdd81872db608bb9ff1c09c0f6e9e5cea82bad1690c876122'
+  name 'LibreOffice Fresh Prerelease'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
-  gpg "#{url}.asc",
-      key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
+  gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  app 'LibreOfficeDev.app'
+  depends_on macos: '>= :mountain_lion'
+
+  app 'LibreOffice.app'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.