### PR TITLE
flash 24.0.0.194

### DIFF
--- a/Casks/flash-player-debugger-npapi.rb
+++ b/Casks/flash-player-debugger-npapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-npapi' do
-  version '24.0.0.186'
-  sha256 '4c5f00d4cca72d23dd7506731c8678c54d008ae9855ee608a8e9c83fee240d57'
+  version '24.0.0.194'
+  sha256 '39d21af967b9fa4962b0af79e31278c880c97736d8ced3a4c72ff64a425fb32d'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_plugin_debug.dmg"

--- a/Casks/flash-player-debugger-ppapi.rb
+++ b/Casks/flash-player-debugger-ppapi.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger-ppapi' do
-  version '24.0.0.186'
-  sha256 '2907e49d4b0b50a83a2d77d419144499fa18cd78e0f2f2d322754c4fdbbb0ed8'
+  version '24.0.0.194'
+  sha256 '319c1499982939d84f28bded4d597eeef122b2141a8094420106cedab3d1986c'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_ppapi_debug.dmg"

--- a/Casks/flash-player-debugger.rb
+++ b/Casks/flash-player-debugger.rb
@@ -1,6 +1,6 @@
 cask 'flash-player-debugger' do
-  version '24.0.0.186'
-  sha256 'a2767c42db62f34afb35ec723f7d010055f8269a7bf438f4ea1e43ca1c3f8354'
+  version '24.0.0.194'
+  sha256 'd36a398deb1d0c44ba497ff0517bbf9ed7b02c6814cd8d3c8166282403166cea'
 
   # macromedia.com was verified as official when first introduced to the cask
   url "https://fpdownload.macromedia.com/pub/flashplayer/updaters/#{version.major}/flashplayer_#{version.major}_sa_debug.dmg"


### PR DESCRIPTION
flash-player-debugger, flash-player-debugger-npapi, and flash-player-debugger-ppapi 24.0.0.194

Note that the appcast checkpoints are left unchanged intensionally, because somehow the appcasts are still showing the previous version instead of 24.0.0.194...