### PR TITLE
Update opera-beta to 43.0.2442.21

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '43.0.2442.7'
-  sha256 'ffaa3cec33da0835d4ce1219bb67f09d5d4ecc56a30d431e933eb752abf5e006'
+  version '43.0.2442.21'
+  sha256 '3b61835f21b3eb18e765e98b9641416144199464480ac3eb93118635410d7399'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.