### PR TITLE
Update airmail-beta to 3.2.404,280

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.403,279'
-  sha256 'bb7a8d5efc87af8e560d3eef13ff63aa6c2fae9bfcd44ce72d3bfc1ab6ba49e0'
+  version '3.2.404,280'
+  sha256 '8f337a77e5a1ee42f1643991f23e1328deb3e49218db14767b3f3f141c09e183'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'e526a19f0f99ff5f43b3f2663c29116c8ca5cf167ce1fe77fd2aeac16289eac8'
+          checkpoint: '85e6824d64638fc31877c8204dbcda4b221c2cfaa9abb04dc5b808de92f51208'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.