### PR TITLE
Update vivaldi-snapshot to 1.7.721.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.715.3'
-  sha256 'a9a8c480de817d6d2d9d64d31c993a9f6e7940ab42d6328e4f6045d3d756f626'
+  version '1.7.721.3'
+  sha256 '7c07a3e684e0676132d19991908095e5b2a7b4ba227760966670f5066da47b0d'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '2443494f5fc9c11d086ad125e88305f1439ed74c33bed3e808ad9174a787e4ba'
+          checkpoint: 'c0ccddbd233f58355e1c9dc19982111163e8e96226d118cbc3efb1ff2fa43f5e'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.