### PR TITLE
Update webstorm-eap to 2017.1,171.2272.15

### DIFF
--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'webstorm-eap' do
-  version '2017.1,171.2014.24'
-  sha256 'a3fbd88f14908e536ab58f1ec24db1cb63a10580f858e1b13dc886ae23559d41'
+  version '2017.1,171.2272.15'
+  sha256 'c9743d1616fb018aacc82c14ede3bc24391d228d23bca68d1a3226c6c434ddaf'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-EAP-#{version.after_comma}.dmg"
   name 'WebStorm EAP'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.