### PR TITLE
Update IntelliJ IDEA 2017.1 EAP to build 171.2272.14

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-ce-eap' do
-  version '2017.1,171.2272.14'
-  sha256 'c46f70cae677391d48b0c74123e80de70424607b598aeed136fb24754524d636'
+  version '2016.3.3,163.11103.3'
+  sha256 'bb6db56aaf29d701f838a73632cd296e6330a4161df3beedddc7ff21ab0d34f5'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Community Edition EAP'
@@ -15,8 +15,8 @@ cask 'intellij-idea-ce-eap' do
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",
+                "~/Library/Preferences/IdeaIC#{version.major_minor}",
                 "~/Library/Caches/IdeaIC#{version.major_minor}",
                 "~/Library/Logs/IdeaIC#{version.major_minor}",
-                "~/Library/Preferences/IdeaIC#{version.major_minor}",
               ]
 end

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-eap' do
-  version '2017.1,171.2272.14'
-  sha256 'd21c531a5f9835c3785b3d5fbf8734686f6fbc8bfa2f3b5eccf929eb2d2d3d49'
+  version '2016.3.3,163.11103.3'
+  sha256 '09b82844f85df9295b7512a828d1e0b19d938a244e7eac52dc06f9ae3da6be4f'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA EAP'
@@ -13,9 +13,9 @@ cask 'intellij-idea-eap' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
-                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
+                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
               ]
 end

--- a/Casks/intellij-idea-next-ce-eap.rb
+++ b/Casks/intellij-idea-next-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-ce-eap' do
-  version '2017.1,171.2014.21'
-  sha256 '08992de88d65b4b21a546dd582a7bb0596d9bff9eff627b6c3b49b8c8b712f11'
+  version '2017.1,171.2272.14'
+  sha256 'c46f70cae677391d48b0c74123e80de70424607b598aeed136fb24754524d636'
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Next Community Edition EAP'

--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2017.1,171.2014.21'
-  sha256 '61eabc83c1a3315c3b33b5d1b4a773ef628540595f101285db63aea72c61c1fd'
+  version '2017.1,171.2272.14'
+  sha256 'd21c531a5f9835c3785b3d5fbf8734686f6fbc8bfa2f3b5eccf929eb2d2d3d49'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Next EAP'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

I've also reverted #3124 and #3125 because the changes were made in wrong cask files.
