### PR TITLE
Update vivaldi-snapshot to 1.7.725.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.721.3'
-  sha256 '7c07a3e684e0676132d19991908095e5b2a7b4ba227760966670f5066da47b0d'
+  version '1.7.725.3'
+  sha256 '7ead9c4b7200997e0ad1023d10f296fe7142976b2105ad42cc4279c9a93b7fc4'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c0ccddbd233f58355e1c9dc19982111163e8e96226d118cbc3efb1ff2fa43f5e'
+          checkpoint: '25526ba7efb660399ffc79eab492f3de281b23581254ee2d54cab7a81fbc201b'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.