### PR TITLE
Update airmail-beta to 3.2.405,281

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.404,280'
-  sha256 '8f337a77e5a1ee42f1643991f23e1328deb3e49218db14767b3f3f141c09e183'
+  version '3.2.405,281'
+  sha256 '9562119464a8f94fa354c1ce29806ec2f095810072a858601401131bb071f4a2'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '85e6824d64638fc31877c8204dbcda4b221c2cfaa9abb04dc5b808de92f51208'
+          checkpoint: '7da3efab6bc20520a8697d1d521b66ef127a7cacf78faa5c196bdd16748221a7'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.