### PR TITLE
Update opera-developer to 44.0.2475.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '44.0.2463.0'
-  sha256 '4fd9dcec399160abdb1a4529fd9f3bd47b5e643bc293de8f41ffe61579c22543'
+  version '44.0.2475.0'
+  sha256 'b13d4e2f1ffaaf33a7becb1980722900a66e4ca648ff44555fa3592b8b78b7e4'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.