### PR TITLE
Update sketch-beta to 42,36764

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '42,36679'
-  sha256 '10d31f2cadeb2577576b01c7a2fe3f0960abce3c2f910e4c03948775b8c14c36'
+  version '42,36764'
+  sha256 '9e2b61f5c68ae4ed0c125f78051ed3a8f9400e427b8d1aa1a8959552500eccf4'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '76f17c27571614826c489d3bd8b1935dc85832813451f066f264717aa71f2f0d'
+          checkpoint: 'a4b21774325d1aab0c0872b358e6ad0f95102bb6ea3ed523b3200e6f995a277b'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.