### PR TITLE
Update atom-beta to 1.14.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.14.0-beta1'
-  sha256 '822e9dc3ccd0da633762c35671f89e4e718437c8a01582e312748b9697c109b8'
+  version '1.14.0-beta2'
+  sha256 '37c509e2fd49c01dfa2e0da251ac2540e810b0836bde894938db29c7eaac3cc4'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '31efcf0a8dbc4d9d61d681e4ddcbceb00a256b8277e51df10beba90a21715c12'
+          checkpoint: 'ed0ef9a4064e6e4365f0fca09645caaee1583a814ba7a8e859aa69cfb0accb7c'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.