### PR TITLE
Update pycharm-ce-eap to 2017.1,171.2455.3

### DIFF
--- a/Casks/pycharm-ce-eap.rb
+++ b/Casks/pycharm-ce-eap.rb
@@ -1,6 +1,6 @@
 cask 'pycharm-ce-eap' do
-  version '2017.1,171.2272.11'
-  sha256 'cce4fbd4b655fcd9e65292812eb41a089a3603c0328500ab8504bd5ace27183e'
+  version '2017.1,171.2455.3'
+  sha256 '5413d3a47e17a1d8ae696d99e782bd5459a16ce80bd63bc93bb9aea7eedc8319'
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version.after_comma}.dmg"
   name 'Jetbrains PyCharm Community Edition EAP'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.