### PR TITLE
Update intellij-idea-next-eap to 2017.1,171.2455.10

### DIFF
--- a/Casks/intellij-idea-next-eap.rb
+++ b/Casks/intellij-idea-next-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-next-eap' do
-  version '2017.1,171.2272.14'
-  sha256 'd21c531a5f9835c3785b3d5fbf8734686f6fbc8bfa2f3b5eccf929eb2d2d3d49'
+  version '2017.1,171.2455.10'
+  sha256 '61bed1761d155a6d3297323f2e5aba216389a6daac41702fdcf97b2050fbd1f4'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Next EAP'
@@ -13,9 +13,9 @@ cask 'intellij-idea-next-eap' do
   uninstall delete: '/usr/local/bin/idea'
 
   zap delete: [
+                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
-                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.