### PR TITLE
Update libreoffice-dev to 5.3.0.2

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-dev' do
-  version '5.3.0.1'
-  sha256 '75c569333380ef6ff91dad72c5f58e493422c49a5bb608e3cbe1776bf9c5836a'
+  version '5.3.0.2'
+  sha256 'bbacb51d6b4f60517ccad4bbd578a7597ce04d203b90ab05a2f7cad8ae73ff0b'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: '1ea2c4052947e21bdd81872db608bb9ff1c09c0f6e9e5cea82bad1690c876122'
+          checkpoint: '05d9fecc5be03090d5249c42ad921d3b1a2a8c1bec2de5d312063af7a595bcb5'
   name 'LibreOffice Fresh Prerelease'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.