### PR TITLE
Add GPG Suite Beta (2016.12b1)

### DIFF
--- a/Casks/gpgtools-beta.rb
+++ b/Casks/gpgtools-beta.rb
@@ -1,0 +1,85 @@
+cask 'gpgtools-beta' do
+  version '2016.12b1'
+  sha256 '2bb29067e7f2705a51b22f23080ca767bba4735ce16711a7d950e582737e8aaf'
+
+  url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
+  appcast 'https://gpgtools.org/releases/gpgsuite/pre-appcast.xml',
+          checkpoint: 'b0e18b27c8464ec73f909ad47ac60cf66dc65ba8a1d534d4a3258d2ce399bb1f'
+  name 'GPG Suite Beta'
+  homepage 'https://gpgtools.org/'
+  gpg "#{url}.sig",
+      key_url: 'https://gpgtools.org/GPGTools%2000D026C4.asc'
+
+  auto_updates true
+  conflicts_with cask: 'gpgtools'
+
+  pkg 'Install.pkg'
+
+  # TODO: remove all ENV variables
+  postflight do
+    system_command '/usr/local/MacGPG2/libexec/fixGpgHome',
+                   args: [
+                           Etc.getpwuid(Process.euid).name,
+                           ENV['GNUPGHOME'] ? ENV['GNUPGHOME'] : Pathname.new(File.expand_path('~')).join('.gnupg'),
+                         ],
+                   sudo: true
+  end
+
+  uninstall_postflight do
+    %w[gpg gpg2 gpg-agent].map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
+      File.rm(exec) if File.exist?(exec) && File.readlink(exec).include?('MacGPG2')
+    end
+  end
+
+  uninstall script:    {
+                         executable: "#{staged_path}/Uninstall.app/Contents/Resources/GPG Suite Uninstaller.app/Contents/Resources/uninstall.sh",
+                         sudo:       true,
+                       },
+            pkgutil:   'org.gpgtools.*',
+            quit:      [
+                         'com.apple.mail',
+                         'org.gpgtools.gpgkeychainaccess',
+                         'org.gpgtools.gpgkeychain',
+                         'org.gpgtools.gpgservices',
+                         # TODO: add "killall -kill gpg-agent"
+                       ],
+            launchctl: [
+                         'org.gpgtools.Libmacgpg.xpc',
+                         'org.gpgtools.gpgmail.patch-uuid-user',
+                         'org.gpgtools.macgpg2.fix',
+                         'org.gpgtools.macgpg2.shutdown-gpg-agent',
+                         'org.gpgtools.macgpg2.updater',
+                         'org.gpgtools.macgpg2.gpg-agent',
+                       ],
+            delete:    [
+                         '/Library/Services/GPGServices.service',
+                         '/Library/Mail/Bundles/GPGMail.mailbundle',
+                         '/Network/Library/Mail/Bundles/GPGMail.mailbundle',
+                         '/usr/local/MacGPG2',
+                         '/private/etc/paths.d/MacGPG2',
+                         '/private/etc/manpaths.d/MacGPG2',
+                         '/private/tmp/gpg-agent',
+                         '/Library/PreferencePanes/GPGPreferences.prefPane',
+                         '/Applications/GPG Keychain Access.app',
+                         '/Applications/GPG Keychain.app',
+                         '/Library/Application Support/GPGTools',
+                         '/Library/Frameworks/Libmacgpg.framework',
+                       ]
+
+  zap delete: [
+                '~/Library/Services/GPGServices.service',
+                '~/Library/Mail/Bundles/GPGMail.mailbundle',
+                '~/Library/PreferencePanes/GPGPreferences.prefPane',
+                '~/Library/LaunchAgents/org.gpgtools.*',
+                '~/Library/Preferences/org.gpgtools.*',
+                '~/Library/Containers/com.apple.mail/Data/Library/Preferences/org.gpgtools.*',
+                '~/Library/Application Support/GPGTools',
+                '~/Library/Frameworks/Libmacgpg.framework',
+                '~/Containers/com.apple.mail/Data/Library/Frameworks/Libmacgpg.framework',
+                # TODO: expand/glob for ~/Library/Caches/org.gpgtools.gpg*
+              ]
+
+  caveats do
+    files_in_usr_local
+  end
+end


### PR DESCRIPTION
This release fixes the compatibility problems with MacOS 10.12 Sierra.
The announcement which includes known issues is available at
https://gpgtools.tenderapp.com/discussions/problems/49449-will-not-work-on-macosx-sierra

This Cask is a copy of the gpgtools cask from the main repo. The only
changes are the name and the appcast url. The appcast does not
currently have the beta listed. I assume that future betas will appear
correctly. I found the url by enabling the check beta versions option in
preferences.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
  - This Cask should be named gpgsuite-beta, but the main repo cask is named incorrectly. Left name as is for consistency
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
