### PR TITLE
Updating kodi-development from rc2 to rc3

### DIFF
--- a/Casks/kodi-development.rb
+++ b/Casks/kodi-development.rb
@@ -1,6 +1,6 @@
 cask 'kodi-development' do
-  version '17.0-Krypton_rc2'
-  sha256 'e7ad26409e822fe9c7514dadd98e5804e521ec3c195f38a926922663ee65a088'
+  version '17.0-Krypton_rc3'
+  sha256 '6f6ef8166ef2ad59c0e4bfd2d1396b9c293c6a029424eb577faf3b70b752a272'
 
   url "http://mirrors.kodi.tv/releases/osx/x86_64/kodi-#{version}-x86_64.dmg"
   name 'Kodi-Development'


### PR DESCRIPTION
Kodi v17 Krypton has updated from develpoment release rc2 to rc3. Updating the cask to point to the latest development release.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
