### PR TITLE
Update datagrip-eap to 2017.1,171.2455.7

### DIFF
--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -1,19 +1,19 @@
 cask 'datagrip-eap' do
-  version '162.1121.36'
-  sha256 'a88ef7b6b8e42a58e9ef38ebac663e1e5c2a10e6a1d56f63a2e9474e41d1764e'
+  version '2017.1,171.2455.7'
+  sha256 '62f0ecac1518b9b1b7f2ed57c88afd9e21d89aeafae3ec6f80cfbef152c660f6'
 
-  url "https://download.jetbrains.com/datagrip/datagrip-#{version}.dmg"
+  url "https://download.jetbrains.com/datagrip/datagrip-#{version.after_comma}.dmg"
   name 'DataGrip'
-  homepage 'https://confluence.jetbrains.com/display/DBE/DataGrip+2016.2+EAP'
+  homepage 'https://www.jetbrains.com/datagrip/nextversion/'
 
   conflicts_with cask: 'datagrip'
 
-  app 'DataGrip.app'
+  app "DataGrip #{version.before_comma} EAP.app"
 
   zap delete: [
-                '~/Library/Preferences/DataGrip2016.2',
-                '~/Library/Application Support/DataGrip2016.2',
-                '~/Library/Caches/DataGrip2016.2',
-                '~/Library/Logs/DataGrip2016.2',
+                "~/Library/Application Support/DataGrip#{version.before_comma}",
+                "~/Library/Caches/DataGrip#{version.before_comma}",
+                "~/Library/Logs/DataGrip#{version.before_comma}",
+                "~/Library/Preferences/DataGrip#{version.before_comma}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.