### PR TITLE
Update webstorm-eap to 2017.1,171.2455.4

### DIFF
--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'webstorm-eap' do
-  version '2017.1,171.2272.15'
-  sha256 'c9743d1616fb018aacc82c14ede3bc24391d228d23bca68d1a3226c6c434ddaf'
+  version '2017.1,171.2455.4'
+  sha256 '6ab5a70abe581e57d89653c003918a8684a7430066cc0e78fe8cbd71367a017b'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-EAP-#{version.after_comma}.dmg"
   name 'WebStorm EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.