### PR TITLE
Update vivaldi-snapshot to 1.7.735.11

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.725.3'
-  sha256 '7ead9c4b7200997e0ad1023d10f296fe7142976b2105ad42cc4279c9a93b7fc4'
+  version '1.7.735.11'
+  sha256 'b30266129ea7496111bafb06ed6408ca50cff404e65a28340c8aee1cca0d1605'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '25526ba7efb660399ffc79eab492f3de281b23581254ee2d54cab7a81fbc201b'
+          checkpoint: '0f6b53a01a65af7b2349ab4096f4e8ed9a7acc5a6704816b49b5a9acebf6112a'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.