### PR TITLE
Update firefox-beta to 52.0b1

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '51.0b14'
+  version '52.0b1'
 
   language 'de' do
-    sha256 '7a6ac5ed6e246b21a33b523e51507b00092d8e15015bfda640cb38dfafd7374b'
+    sha256 'cf5a90ba323300d41025f88ff31ab01549be7d808619d91d9a0a801c4e84d589'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a75f284baf0e673f0d8f27615923520bc6eaa86356b807558c3cba45ae1b7188'
+    sha256 'cf09e01a4db43434d385146ca2d743438d6c27d6590fc459e1848cf2e4611db3'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'f1cca1f34c075691c987e2eea2a47228b8d043d92931d8d2f9daf90a569eb05f'
+    sha256 '3f68a5c9273cc497084b7f69c012bb15bc60fc4b0dac9177cf321651f7658e3b'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'd587ce173edb898b022f8c07b69103e77169976ab179fe8c7c9e61bd04c06dca'
+    sha256 '9593ad76cd600657b5224a48c2d296fd55bddda227369a2d477c051804b710f5'
     'fr'
   end
 
   language 'gl' do
-    sha256 'b4f35e5b7f579cb619674450a02e24742dcb291cfeaa21184fa6e2eb5c50e290'
+    sha256 'c356b579f7cad451bb5020ae3c5af03b5ea9ce6bac2c279c57bd08124c31e2a8'
     'gl'
   end
 
   language 'it' do
-    sha256 'de0a6f5600d4326c8938a39d77168e1a88f73dfcb30dcaad589d1506cce1473d'
+    sha256 '0d5afb3ac9258b57c87f6891bb92d14793bc0720ade1ea56b291dde1ba15a1d6'
     'it'
   end
 
   language 'ja' do
-    sha256 '2eb8c642baa5c368f21415d81ebcafac259ec6772437ed22945cef57ac62fd07'
+    sha256 '9ddc04d7b080515ae1299b30aa4e6b112fc5b0d631af0bdce99a46e4159b0f85'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'd0d6270c8881d60600983aa60fa2b58200f9d1c38b49ecbd4ce777e2cf2645c4'
+    sha256 '98279beb2a6615450f6f6851400050dad1be5916d293b0bb4affd28cb820fceb'
     'nl'
   end
 
   language 'pl' do
-    sha256 'b20c5a69509d045d450392d6dca40abada7a6a21da0e869404962d1a6a54f363'
+    sha256 '9b69d4df4c471e0cdad2cd69efbd16acf4a7d29736e0d28e19f033a4657f8eb6'
     'pl'
   end
 
   language 'pt' do
-    sha256 '4aa35aea7ce1ec33cafd05b3ec454537fc83faa83e3964045e95ff338d4f897c'
+    sha256 '5e9e87e28894963b9046ca6dcfc27e29fb0f1aeb2c2aa71c3f9736b69a580325'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '2750d96e874e83713e98b2ec0a24802c7a6d872b582f6b1d8ea7a55ebabc2b76'
+    sha256 'b7446647042bfefd70084e6a416f721261d507d7ccb40a95d814b60b458cb92b'
     'ru'
   end
 
   language 'uk' do
-    sha256 'cc4ddf6c1f2fad122ce6dfd2383391f80728aff9f53b1c4e82da5fa8650f76a0'
+    sha256 '94b17e1a75455756eaf23695d848ce6c415358547868b7d84d5ea33b2a76e0f1'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'e1ca9a0dbc1caa1b6f2ecdc62837be4d4019fe7ae62cdca9b9b31f3c6ddd5ab6'
+    sha256 'd1afd0cbc91f801e1cd00e370017ffafbd1d46854c710b272dc50c99c587755f'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '4a77768f01632bdafcecd969be3009fe7dfa035a5277d05549eceeb77f7970b8'
+    sha256 'cd9bad749b23db844418d27b503f5a0fe89147f3bfa2486252c70a84db06e706'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.