### PR TITLE
Update atom-beta to 1.14.0-beta3

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.14.0-beta2'
-  sha256 '37c509e2fd49c01dfa2e0da251ac2540e810b0836bde894938db29c7eaac3cc4'
+  version '1.14.0-beta3'
+  sha256 '9ff885e56a4ad4fd067a858a66818eaddbd3f8ccb0c004652515b0c0cf882192'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: 'ed0ef9a4064e6e4365f0fca09645caaee1583a814ba7a8e859aa69cfb0accb7c'
+          checkpoint: 'dc97bf4b26a8ee3d628e697b0dd9071b2c6a6546a749f4f2552c57dc164f37f8'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.