### PR TITLE
Update docker-beta to 1.13.0,15140

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '1.13.0.15084'
-  sha256 'cd6bc97f4d3b1b70c8202a2921b06f02f9edbdc7d4badba92285f9bacd5ea965'
+  version '1.13.0,15140'
+  sha256 '966faa3505f0ad04005e15ef6cee40de175a0044b4e9d02736713719701871dc'
 
-  url "https://download.docker.com/mac/beta/#{version}/Docker.dmg"
+  url "https://download.docker.com/mac/beta/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'd1df9b75158b5125ef8ceee0a9cbfbb2e5c1868d7a4172361336579b74263c45'
+          checkpoint: '219193c2d2400fb15baead71720ec9deceb97180bdca01bf7e4cfb35d1c5d7fa'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.