### PR TITLE
scansnap-manager-s1300 caveat not 10.12 compat

### DIFF
--- a/Casks/scansnap-manager-s1300.rb
+++ b/Casks/scansnap-manager-s1300.rb
@@ -11,4 +11,10 @@ cask 'scansnap-manager-s1300' do
   pkg 'Scansnap Manager.pkg'
 
   uninstall pkgutil: 'jp.co.pfu.ScanSnap.V10L10'
+
+  caveats <<-EOS.undent
+    This version of ScanSnap Manager (v3.2L31) is not compatible with
+    macOS Sierra 10.12. Once installed launch ScanSnap Manager and click
+    Help->Online Update... to upgrade to a compatible version.
+  EOS
 end


### PR DESCRIPTION
Adding caveat. I can't find a URL to download 3.2 L91 directly.

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.