### PR TITLE
Update minishift-beta to 1.0.0-beta.3

### DIFF
--- a/Casks/minishift-beta.rb
+++ b/Casks/minishift-beta.rb
@@ -1,10 +1,10 @@
 cask 'minishift-beta' do
-  version '1.0.0-beta.2'
-  sha256 'de238fd78d2d1463fba831ecb338fb600d37b22a2ac97496d58dd39bbc4928ca'
+  version '1.0.0-beta.3'
+  sha256 '9b3be4c205aab7e6d562060e1b39ca0ccd5c5fe033d997c1a77b2a1b0109171e'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '6767956789af0782f42c860fa99bfd4d27be20a9c5457910007303661a235a48'
+          checkpoint: '3cae2c14bce9583c25ae8b0537faac2176631688fd8e05bc938c4df6e7caf722'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.