### PR TITLE
Update thunderbird-beta to 52.0b1

### DIFF
--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -1,18 +1,18 @@
 cask 'thunderbird-beta' do
-  version '51.0b2'
+  version '52.0b1'
 
   language 'en', default: true do
-    sha256 '3f8ffaa52e6e71006c829cf4a5cb24465c3f020670edd5771036165f6d35147d'
+    sha256 'e4418679343661b92d6bc605b92fca16ae22e533f483325516b4799e4c94c7ed'
     'en-US'
   end
 
   language 'ru' do
-    sha256 'a3b0c14f20697b46765652ffce0ba842151dc87cd32c95e5a79a164d9fd1359f'
+    sha256 '52d897483d0c71fca63b00d94457d5c5ee8f5b695628ebe084b668d4bcc0ba1a'
     'ru'
   end
 
   language 'uk' do
-    sha256 '76b2276ec26c9f7965531d7925346b11509e812b5be2dd0a77ad16b9b70b4682'
+    sha256 'c764ee8158beef24e2c811283701e30c6eef590da9905c98ef072a9940fbd71a'
     'uk'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.