### PR TITLE
Remove files_in_usr_local from sublime-text-dev and sublime-text2.

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -21,8 +21,4 @@ cask 'sublime-text-dev' do
                 '~/Library/Preferences/com.sublimetext.3.plist',
                 '~/Library/Saved Application State/com.sublimetext.3.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sublime-text2.rb
+++ b/Casks/sublime-text2.rb
@@ -17,8 +17,4 @@ cask 'sublime-text2' do
                 '~/Library/Caches/com.sublimetext.2',
                 '~/Library/Saved Application State/com.sublimetext.2.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Fix for https://github.com/caskroom/homebrew-cask/issues/29593