### PR TITLE
Add wmail-pre-released v2.0.9

### DIFF
--- a/Casks/wmail-pre-release.rb
+++ b/Casks/wmail-pre-release.rb
@@ -1,0 +1,15 @@
+cask 'wmail-pre-release' do
+  version '2.0.9'
+  sha256 '4978e60a7b92686d88c500aeda758893185183a5454c09d048801a487cac2a7a'
+
+  # github.com/Thomas101/wmail was verified as official when first introduced to the cask
+  url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_prerelease_osx.dmg"
+  appcast 'https://github.com/Thomas101/wmail/releases.atom',
+          checkpoint: '08566cf44721cce0db76e13e3e101dbb827334d23222ae26d2145619ecf9ab39'
+  name 'WMail'
+  homepage 'https://thomas101.github.io/wmail/'
+
+  conflicts_with cask: 'wmail'
+
+  app 'WMail pre-release.app'
+end


### PR DESCRIPTION
The existing wmail cask give access to the last stable version of WMail.
This new cask give access to the pre-release channel (see http://thomas101.github.io/wmail/download for a description of the 2 channels)

----

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask