### PR TITLE
Update airmail-beta to 3.2.406,282

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.405,281'
-  sha256 '9562119464a8f94fa354c1ce29806ec2f095810072a858601401131bb071f4a2'
+  version '3.2.406,282'
+  sha256 'b6868d1f342f370bcb7b42fa01b0b91c21aef334e0d36bd2afbce32ee21d070a'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '7da3efab6bc20520a8697d1d521b66ef127a7cacf78faa5c196bdd16748221a7'
+          checkpoint: '2e93f5eb8de5cf1ff0ca2c9036aec30335d2ddeddb1205617fb92586a8ecc833'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.