### PR TITLE
Remove files_in_usr_local from casks that only have it due to `binary`

### DIFF
--- a/Casks/smartgit-rc.rb
+++ b/Casks/smartgit-rc.rb
@@ -8,8 +8,4 @@ cask 'smartgit-rc' do
 
   app 'SmartGit.app'
   binary "#{appdir}/SmartGit.app/Contents/MacOS/SmartGit"
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sourcetree-alpha.rb
+++ b/Casks/sourcetree-alpha.rb
@@ -29,8 +29,4 @@ cask 'sourcetree-alpha' do
                 '~/Library/Preferences/com.torusknot.SourceTreeNotMAS.LSSharedFileList.plist',
                 '~/Library/Saved Application State/com.torusknot.SourceTreeNotMAS.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -29,8 +29,4 @@ cask 'sourcetree-beta' do
                 '~/Library/Preferences/com.torusknot.SourceTreeNotMAS.LSSharedFileList.plist',
                 '~/Library/Saved Application State/com.torusknot.SourceTreeNotMAS.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -21,8 +21,4 @@ cask 'sublime-text-dev' do
                 '~/Library/Preferences/com.sublimetext.3.plist',
                 '~/Library/Saved Application State/com.sublimetext.3.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/sublime-text2.rb
+++ b/Casks/sublime-text2.rb
@@ -17,8 +17,4 @@ cask 'sublime-text2' do
                 '~/Library/Caches/com.sublimetext.2',
                 '~/Library/Saved Application State/com.sublimetext.2.savedState',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end

--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -5,7 +5,7 @@ cask 'tower-beta' do
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: 'fd480a4c5772693b4b6f6356ced981e991545356adc5c522870f73dc81b99b21'
+          checkpoint: '6904d7a8e7718508334418f6b5f3add8d8c2e56054eff41a38dbc554eb6fc250'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 

--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -17,8 +17,4 @@ cask 'tower-beta' do
                 '~/Library/Caches/com.fournova.Tower2',
                 '~/Library/Preferences/com.fournova.Tower2.plist',
               ]
-
-  caveats do
-    files_in_usr_local
-  end
 end


### PR DESCRIPTION
See https://github.com/caskroom/homebrew-cask/pull/29623.