### PR TITLE
Update firefox-beta to 52.0b2

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '52.0b1'
+  version '52.0b2'
 
   language 'de' do
-    sha256 'cf5a90ba323300d41025f88ff31ab01549be7d808619d91d9a0a801c4e84d589'
+    sha256 'db34cf04016a7455caa067020891697f3d40acaa2fd7d4b2d17a7f1c16731992'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'cf09e01a4db43434d385146ca2d743438d6c27d6590fc459e1848cf2e4611db3'
+    sha256 '50f7a186040f429d21efaa1cefd82da48f7b1db4a2eb1fa3314e8cf321cb34f1'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '3f68a5c9273cc497084b7f69c012bb15bc60fc4b0dac9177cf321651f7658e3b'
+    sha256 '6016b32e70ce773a114cce714ece369f88bb6db77a3a076a846b7121037ae42a'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '9593ad76cd600657b5224a48c2d296fd55bddda227369a2d477c051804b710f5'
+    sha256 'cab590d71a53eb9c1f1c0ee434d625bcf28e96f013dcd91ecd9bad5bcd65e8bb'
     'fr'
   end
 
   language 'gl' do
-    sha256 'c356b579f7cad451bb5020ae3c5af03b5ea9ce6bac2c279c57bd08124c31e2a8'
+    sha256 '28c1c06a06179c8efd304a16a67c7e4888251071299c7e76eb82b17c7b768ba1'
     'gl'
   end
 
   language 'it' do
-    sha256 '0d5afb3ac9258b57c87f6891bb92d14793bc0720ade1ea56b291dde1ba15a1d6'
+    sha256 'fc06f094ba794286e4816a946f710686e1b3f53c0809235b28a80015208f07f5'
     'it'
   end
 
   language 'ja' do
-    sha256 '9ddc04d7b080515ae1299b30aa4e6b112fc5b0d631af0bdce99a46e4159b0f85'
+    sha256 '430a0a6a9630cd54747bed66d6b7dbe2b114857765cc94ae67c22d0229a3fc8b'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '98279beb2a6615450f6f6851400050dad1be5916d293b0bb4affd28cb820fceb'
+    sha256 '7d360b69077c7044c25dd754092e399463e63124ac95ad2b123e2ab73179363a'
     'nl'
   end
 
   language 'pl' do
-    sha256 '9b69d4df4c471e0cdad2cd69efbd16acf4a7d29736e0d28e19f033a4657f8eb6'
+    sha256 '8eefd7ec301718d6da71f74f9fb4284de03548da875da5ae8e443283f05a0b08'
     'pl'
   end
 
   language 'pt' do
-    sha256 '5e9e87e28894963b9046ca6dcfc27e29fb0f1aeb2c2aa71c3f9736b69a580325'
+    sha256 '3ebf0329da174946fa25321735d6361dab7c436051cc67a93a3abc69b57cf60b'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'b7446647042bfefd70084e6a416f721261d507d7ccb40a95d814b60b458cb92b'
+    sha256 '1a41f7783b2a2493836bb87c369f8d8e22b4cf1e7262b976fe730b9e5afdd32e'
     'ru'
   end
 
   language 'uk' do
-    sha256 '94b17e1a75455756eaf23695d848ce6c415358547868b7d84d5ea33b2a76e0f1'
+    sha256 'f553d0c42bc3cbd60e908019637b6fd04fc14f142a37b4079b6723bfe4e344fc'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'd1afd0cbc91f801e1cd00e370017ffafbd1d46854c710b272dc50c99c587755f'
+    sha256 'edc01cbb10386c713902e54e59a713e67449f8a70c797a0edf2ef081fa31b5e6'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'cd9bad749b23db844418d27b503f5a0fe89147f3bfa2486252c70a84db06e706'
+    sha256 '1e014b72aff962695ef7a49c394801ab1de91081dc944e82bd3e097a2fc8e9b6'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.