### PR TITLE
Update airmail-beta to 3.2.407,283

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.406,282'
-  sha256 'b6868d1f342f370bcb7b42fa01b0b91c21aef334e0d36bd2afbce32ee21d070a'
+  version '3.2.407,283'
+  sha256 '9582c1aeeb157e746d3ba86a700e64fe1c51abeccb648334665d9466de2313bc'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '2e93f5eb8de5cf1ff0ca2c9036aec30335d2ddeddb1205617fb92586a8ecc833'
+          checkpoint: 'ac1c64901488165a98f2fa2f6944f873d2b76507bf83bbb30aecc5f0bc1d905c'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.