### PR TITLE
Update opera-beta to 43.0.2442.686

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '43.0.2442.52'
-  sha256 '7d6cf4b1cd49a926df87930b750fa1052eec0818a7ef70584511e68e1dd5124f'
+  version '43.0.2442.686'
+  sha256 'd55fba4e196639e1c87aee179fcc8f036089f3b003fad0f807ce04b73bb22214'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.