### PR TITLE
Update vivaldi-snapshot to 1.7.735.29

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.735.27'
-  sha256 '1c7c0d6a77fda348594c3d218b7fe64bf6a0f6b15cf0e5c5dac4f9fabd9e5c76'
+  version '1.7.735.29'
+  sha256 'c9b9a88607f714a65f1a6ceb8807505f14a1997e92c89fdacce387b85f196c5a'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c30a8b8f35c9eede87498e7257f32d7dca731de0408b247806347b7753400f6d'
+          checkpoint: '59a623664db54bd62eacf866752be25bcf832bd829f2fc2e05b8dba25ee46c52'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.