### PR TITLE
Update visual-studio-code-insiders to 1.10.0,723b20093d2f525e84cdf94a52f7695d1d539273

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.9.0,3af0e9d6b79145011a7be3970c1d4b83d69b0443'
-  sha256 'e02291b2015deb7126f047effe630068a9a0ab119735f7eb8cd32d441d7f81fd'
+  version '1.10.0,723b20093d2f525e84cdf94a52f7695d1d539273'
+  sha256 '1036cbb2f8fd4bcac880c61918cfed9a414651c85f40fc704260fb5e03fc1e67'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -9,6 +9,7 @@ cask 'visual-studio-code-insiders' do
   homepage 'https://code.visualstudio.com/insiders'
 
   auto_updates true
+  depends_on macos: '>= :mavericks'
 
   app 'Visual Studio Code - Insiders.app'
   binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.