### PR TITLE
Update opera-developer to 44.0.2494.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '44.0.2487.0'
-  sha256 'b21e312a67cc0605f6ee2bb8f1ae1fafca1d2b11ec55e8dd0e81bf47565885ae'
+  version '44.0.2494.0'
+  sha256 '9e09d7292190dd38ac2b25b112b75f256cf234d92566f63e0d084c54319267fc'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.