### PR TITLE
Update vivaldi-snapshot to 1.7.735.39

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.735.36'
-  sha256 '49d9bd5b9efd67bfb6c71c1096f7183e14cbcd700a121b72f8a31ad468e92391'
+  version '1.7.735.39'
+  sha256 'a20cc088a502ca6fc829c3c9218c5ce85096284583d6502ec129e08febe97119'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '74d6a00ed2eab939b15ff011f1b69fb0fe379fc21d8eb6046c95942393c3cd21'
+          checkpoint: '7f322b89efcdd172882b514cfc1b0674877a1181d61cfd7a215fd4d78ea3d6ec'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.