### PR TITLE
Update wmail-prerelease to 2.1.1

### DIFF
--- a/Casks/wmail-prerelease.rb
+++ b/Casks/wmail-prerelease.rb
@@ -1,11 +1,11 @@
 cask 'wmail-prerelease' do
-  version '2.0.9'
-  sha256 '4978e60a7b92686d88c500aeda758893185183a5454c09d048801a487cac2a7a'
+  version '2.1.1'
+  sha256 '87ba6695be4ed5d6664d411cb4f09639d49fe9c8c89f08c5d03d1895f8c95a32'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
   url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_prerelease_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: '08566cf44721cce0db76e13e3e101dbb827334d23222ae26d2145619ecf9ab39'
+          checkpoint: '3f8d154cc47118f8070fb1a92f76b2c12928e5ad3a5d4019c788653209cedeec'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.