### PR TITLE
Update firefox-beta to 52.0b5

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '52.0b4'
+  version '52.0b5'
 
   language 'de' do
-    sha256 'ac3717ab487e485919cceb2ecdcb80cd6f160c0c07d069ffa32fda43d76cd932'
+    sha256 'f324a6fff728ffee415fb3b4c788f32ed7ee12a161e6736da3a738e560e21f00'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '9b789e8252ad5a7a9a444513f04d4ae68aec65765e193438d190c6ee86f86d78'
+    sha256 'bb6e598df22417a6f414b025ec72b537c0fceacfe1ef34367cf9673050007915'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '89240d3205026b0390764a6f601a5591835ac5d6faada3ecd4a0b392b83a8715'
+    sha256 'd64efec94d3165e449fe9d5d2a146a84fba7f502e75fa93314bd30ef304ecc98'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '8e568ca74aea57b42c0edde6f0a1da9dd542991627cb19ce4b55c3c667e10e1e'
+    sha256 'c7ac00270fe38223ec19c0113ca96a785c2cbd44dea5feb0ca8b5f34c48e8574'
     'fr'
   end
 
   language 'gl' do
-    sha256 'bc5c87525e5d08479369b03bba366977d6646a3ed68f0053b8a8592218fb3471'
+    sha256 'f1de2da0eeaf026d50434f4f65c53e50a41ca9da93bdb90b971b2435c1c223ae'
     'gl'
   end
 
   language 'it' do
-    sha256 '30412cbb77a39ec1dd4e2660758eb7b0870c5797128841a1131c6a0bccbe8748'
+    sha256 '4b815bd50976e1ad1141bfedf446407a11265f35f2994b060a9a5dfc2d0425b1'
     'it'
   end
 
   language 'ja' do
-    sha256 'ff08153fa0492574cff4b856754b127918513733cffb130073960dd7970713c2'
+    sha256 'a9538d4b664abf2e5ac92eb095993bc69cfceecabe441ca1cc808c32844d6e12'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '6006d05361fc22d9f2e96e1b510a8f54d21766b1e399e8197dbcf949cb510e27'
+    sha256 'efe353559e486a53b6082b51101d06ecf513fc3ba84846ebad739b99e848baf3'
     'nl'
   end
 
   language 'pl' do
-    sha256 '61c4c3050d9f8e4b8afc84ed83f04a8d1916d24872d495007704e70a0444b992'
+    sha256 'ef6f0a5d2fc94ccc7864e1c822872f301242d78b4828d2b0a2d7f800c2e36960'
     'pl'
   end
 
   language 'pt' do
-    sha256 'cfe6d59a8960fce1ff079318e089584b16c9dc5281e567d7796e209c65198bf0'
+    sha256 'b70a89248d5843fe748ffc1ec2e605f99c674d52624ed6815e581f77bccd8afb'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'e43748d5059261711e677cc692a77e0a3e6628941db177ec6fe8a26ee3f35fd0'
+    sha256 'd597562c933a5bfa6841967e182d5f7222534787e079f68ad41b4cd36468d9d7'
     'ru'
   end
 
   language 'uk' do
-    sha256 '5d517ba67e8ef923a846a68f9bc8434f1c8c0823466a3fff239a6072ea64629d'
+    sha256 '0acb6139019f9b878ccc91c681d50ae8f330a89da7de4018d9448ba451d941e9'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '353664ce15def9a6acc378e830e13d50f8e6b9a25df5870b88ec79d452ae8318'
+    sha256 'b5f1a96fced4ac462232228e13c70a0f2f2fbf62c45dfa5ba064d0e7201441b6'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'e00468bfc1943bc2e720793c1ee8a5b57859b807b1b2565528921b83a62efa5c'
+    sha256 '22464bb02ddf1255cd703a566c361e5a09c09a6de9704c5429aadaa19e20f44b'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free. _- skipped: leaving this to Travis since DL are slow right now._
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.