### PR TITLE
Update safari-technology-preview to r23

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -5,7 +5,7 @@ cask 'safari-technology-preview' do
   if MacOS.version <= :el_capitan
     url 'http://appldnld.apple.com/STP/031-81900-20160926-E7046BDA-8434-11E6-83C5-ADC333D2D062/SafariTechnologyPreview.dmg'
   else
-    url 'https://secure-appldnld.apple.com/STP/031-95977-20170111-2BE113BA-E6C0-11E6-8F82-EDF6D45B5B9D/SafariTechnologyPreview.dmg'
+    url 'https://secure-appldnld.apple.com/STP/031-98194-20170208-718B1142-D9F2-11E6-9947-B4F4B59B175E/SafariTechnologyPreview.dmg'
   end
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
