### PR TITLE
Update 1password-beta to 6.6.BETA-11

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.6.BETA-8'
-  sha256 '55c150acab1e69793bf19cfc5fd4564851641f8731315d5d2a30cabcf6f058e0'
+  version '6.6.BETA-11'
+  sha256 '047d4f1f5964129b929c017c72ae19cff02b5ab7965aa464a3b93e439e27b294'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.