### PR TITLE
Update vivaldi-snapshot to 1.8.755.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.7.735.39'
-  sha256 'a20cc088a502ca6fc829c3c9218c5ce85096284583d6502ec129e08febe97119'
+  version '1.8.755.3'
+  sha256 '9f9b222ac6f8c57a1dfe56df9a9508faa5953a3e45dab1073788f3f9ec5ae96a'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '7f322b89efcdd172882b514cfc1b0674877a1181d61cfd7a215fd4d78ea3d6ec'
+          checkpoint: '92496022be840269ec23b4a0c13276be1fda2ca5ec38eb89d62345f92dd80128'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.