### PR TITLE
Update Android Studio Canary to 2.3.0.6,162.3715353

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.3.0.1,162.3508619'
-  sha256 '39d621a7f5f9233a98edc94e82500f11e84e548c9366c466846fe4dccf0a1850'
+  version '2.3.0.6,162.3715353'
+  sha256 '1f1315ebefa67be5d5ab307e17f9a1da8dd4c8513182420ed8021521cf0147b7'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [X] `brew cask audit --download Casks/android-studio-canary.rb` is error-free.
- [X] `brew cask style --fix Casks/android-studio-canary.rb` reports no offenses.
- [X] The commit message includes the cask’s name and version.

