### PR TITLE
Update clion-eap to 2017.1,171.3224.8

### DIFF
--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -1,6 +1,6 @@
 cask 'clion-eap' do
-  version '2017.1,171.3019.8'
-  sha256 '9c1dcb4709e71657073e029052155d52e6eae0a2244b1ea955a31b46a93b62bc'
+  version '2017.1,171.3224.8'
+  sha256 'c1467f7f2a79a0c7dc49d2200903fae22e891a20648402dc2b07a7ab96ac4844'
 
   url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}.dmg"
   name 'CLion EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.