### PR TITLE
Update 1password-beta to 6.6.1.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.6.BETA-11'
-  sha256 '047d4f1f5964129b929c017c72ae19cff02b5ab7965aa464a3b93e439e27b294'
+  version '6.6.1.BETA-1'
+  sha256 '9853bdf022526b6f24d713767bf40ba2c3b46a14e0407c571547a18803ec792b'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.