### PR TITLE
Update webstorm-eap to 2017.1,171.3224.7

### DIFF
--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -1,6 +1,6 @@
 cask 'webstorm-eap' do
-  version '2017.1,171.3019.10'
-  sha256 '1b19ebcce4a7ce033a428d8cf9a612a31bb9e960b5a90d33a3117a5f364f4026'
+  version '2017.1,171.3224.7'
+  sha256 'e0399e42170a36566d4c58ee278148469d108b9b85ea7389e22ed4bff3517167'
 
   url "https://download.jetbrains.com/webstorm/WebStorm-EAP-#{version.after_comma}.dmg"
   name 'WebStorm EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.