### PR TITLE
Update airmail-beta to 3.2.3.411,286

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.408,284'
-  sha256 '59dd612f92833b600dac56984911768ec454599cc7c9f78a95f2617fd1710d91'
+  version '3.2.3.411,286'
+  sha256 '5018b453cc143ecb6ade55ce0bdf96975266b6112bdaa4ab8d80cabd19fa211f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'e6c9dd3360edb79b129b06d9d1cc79ceb1abb47abb76c6e292f1fc7685285539'
+          checkpoint: 'd35a5bbc7d5dfca741a61e9e710efc39ccad97088045c29dcdd303d2779e0a18'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.