### PR TITLE
Update openrefine-dev to 2.7-rc.1

### DIFF
--- a/Casks/openrefine-dev.rb
+++ b/Casks/openrefine-dev.rb
@@ -1,6 +1,6 @@
 cask 'openrefine-dev' do
-  version '2.6-rc.2'
-  sha256 '7703016e4935961ce89c26c0c4c780011329321ed32367082f329dae38704037'
+  version '2.7-rc.1'
+  sha256 'fade2d4a3663f183daa50a87e71ddfbef7a54dfe12c25d728b3e1a5a9fb8286c'
 
   # github.com/OpenRefine/OpenRefine was verified as official when first introduced to the cask
   url "https://github.com/OpenRefine/OpenRefine/releases/download/#{version}/openrefine-mac-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.