### PR TITLE
Update firefox-beta to 52.0b7

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '52.0b6'
+  version '52.0b7'
 
   language 'de' do
-    sha256 'b131f9494da128c5c3e5b5c65ce2707fbdb258a64c716437652d4830337e9b75'
+    sha256 '052c84ab84a3277d2556952c64b97282780ecdd570385ad7f8a2af9ad0667e06'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'efcd5872d3e482b0effec805911b394622cd28984bb65a11885f185b1c971b1e'
+    sha256 '717a52c999b797e2a4ef6ab67f375821caa518250176215c391fd7501d21f524'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'ac3f47d96747eceab421d8c2ee41782d3e41d43cc4aa95f95bff98444984c916'
+    sha256 'ad51135a5492260d9a0f1936e008c740ef4ec191e3e9efc91417e75854e21ab6'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'c19454a5236a924422666e2a35df5325b8e75c6b3a9368855a1e79aa7e4db9e0'
+    sha256 '2140376ee7b7ac50d5def61d88b4da55db734c391a1ee371dc1fae78a8b9179a'
     'fr'
   end
 
   language 'gl' do
-    sha256 '648c0bd686d861ece121df73478f0db42c5caa669717acaea0bd45af8fe1c842'
+    sha256 'c37124db8c67f0a86744a438dec7c2b4c8507294219358de55defd143389cd3e'
     'gl'
   end
 
   language 'it' do
-    sha256 '9b1fde8d216c5a1d2c72729d4194aa02207566a1bc8f7938745f3068696ad008'
+    sha256 'c8c3228502aaad4d279c5b053932de9b92369570001f35df91e7cb67e85245fa'
     'it'
   end
 
   language 'ja' do
-    sha256 'e983461693e26166c81ba991f97995764001303a68a7d43d95c3960851433fa7'
+    sha256 'aa3ec8f6d65a458e596e1e4e5beb8977fd896e122cc8965c3fcbeb6711dff5b0'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'ae82170cfffd018cacecba3e99f05d22f861070e5b7b5165450d0f942f8c6647'
+    sha256 '1258db31b44c0da392fc1573740aa09773fc58b536ae17509e6bc4d98255cd87'
     'nl'
   end
 
   language 'pl' do
-    sha256 '7b8ccfd6d381133630e73235b6de5060dc8c9c08033b6bd141b2df518e8b8220'
+    sha256 'f2489e0fc6bef11ef3572c0bcc897dbf9fc2563cdc567407aefffd965d503218'
     'pl'
   end
 
   language 'pt' do
-    sha256 'faae4da91d2b45dde2f15d1a1954091d3a7fb4accd623d3509365b2f317b7d75'
+    sha256 'a6485380ec005ad008e4bc07dd10f00501e18545dcbd45abdec6b38d892f3ec6'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'f615acd685515dfa572a643c1c8e37f155c374a6fa2fd5e5890bf6f84e6fbb3d'
+    sha256 '5727d0ecc406a927740feb71b29067d3db762d0ba3bf86f2dfec38863b633fa4'
     'ru'
   end
 
   language 'uk' do
-    sha256 'c87c04022fcfe06509c0572f61094019d39fde7b4e6efbea4a199397aa2594b8'
+    sha256 '652013aa21e55c1a1482e8cd5be1524247e93a0e546e052856a2351dc2d19e0f'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '3ac94d9edc51cb2e519fe03c2d034717b2364919dae8be870043429f1b4fbc4b'
+    sha256 '71462b08a9ca2662b10ece98996c3a3e59e0b0e6f5d2cddcbef18a572d1ba51a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'da4ad721f85c6549afcf2f44d6be0a8c29fd7ad483132c5395206417abf1172a'
+    sha256 '7bc4d667b9b0055e98dccc3b5de7809e0d44766802806161a9c234799444fe52'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.