### PR TITLE
Update android-studio-canary to 2.3.0.7,162.3742087

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.3.0.6,162.3715353'
-  sha256 '1f1315ebefa67be5d5ab307e17f9a1da8dd4c8513182420ed8021521cf0147b7'
+  version '2.3.0.7,162.3742087'
+  sha256 'a8e95c407fe8ed36ad6d89823971c365cfbbfd9256f768940998169d5c790fef'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.