### PR TITLE
Update intellij-idea-eap to 2016.3.4,163.13906.3

### DIFF
--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,6 +1,6 @@
 cask 'intellij-idea-eap' do
-  version '2016.3.4,163.12024.11'
-  sha256 '0b24a485d84a249b79d0e486aadfeeb93495256498e39792289b75f50e488ecf'
+  version '2016.3.4,163.13906.3'
+  sha256 '997c76568de8f96aa490142b40e33e2f72ff1e9b6eeee638dd62cf9bee26fe2b'
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.