### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.31,750

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.30,740'
-  sha256 '4c221c7040c72541ce6862a01bbb161dd4f5b77be1fa152cbb7d703c7f5a87be'
+  version '8.2.31,750'
+  sha256 'd5aca47884f1b35018d3c9f730e984356e9a143f3ae8df80d74053296a519e35'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'af01677e9cfc1e4cb04b34525cbda3cecf298eb5deb85983eb0693321aea08dd'
+          checkpoint: 'f8291a6300817d9262085b2dd542fc8c7ced1f2188aaabcc2bcf628ca51458b4'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.