### PR TITLE
Update airmail-beta to 3.2.3.414,287

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.411,286'
-  sha256 '5018b453cc143ecb6ade55ce0bdf96975266b6112bdaa4ab8d80cabd19fa211f'
+  version '3.2.3.414,287'
+  sha256 'b35aa3f5030ccd646b109ab98410b526d489b725ccc1f0ee77a37972260d2200'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'd35a5bbc7d5dfca741a61e9e710efc39ccad97088045c29dcdd303d2779e0a18'
+          checkpoint: 'cea1ae70dafa5c0a385189f6125ec3f6e2abf9f4aaf715e7cd4fd5cd4c186f5b'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.