### PR TITLE
Update mongodb-compass-beta to 1.6.0-beta.0

### DIFF
--- a/Casks/mongodb-compass-beta.rb
+++ b/Casks/mongodb-compass-beta.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-beta' do
-  version '1.5.0-beta.0'
-  sha256 'd2b557bdca3cbb1249113c006060476faa6377b80bd0a6cfeb7fc44a303b65a2'
+  version '1.6.0-beta.0'
+  sha256 'b68243e42980d6d214e738f139647d58306fe756c5ae68441e66ee376e46c46b'
 
   url "https://downloads.mongodb.com/compass/beta/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.