### PR TITLE
Added Psi+ 0.16.545.538.

### DIFF
--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -1,0 +1,21 @@
+cask 'psi-plus' do
+  version '0.16.545.538,2016-04-26'
+  sha256 '137730bba82e4050f45f6d7d3c06ebd2e183eb23b30df93d35bb5d1563fae79d'
+
+  # sourceforge.net/psi was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/project/psiplus/Mac-OS-X/psi-plus-#{version.before_comma}-qt4-git-#{version.after_comma}-macosx.dmg"
+  appcast 'https://sourceforge.net/projects/psiplus/rss',
+          checkpoint: '6bfd1ea5481b4565924ecad3a1a631808fa9b7a484d14bb72d624365338183c4'
+  name 'Psi+'
+  homepage 'http://psi-plus.com/'
+
+  app 'Psi+.app'
+
+  uninstall quit: 'com.googlecode.psi-dev'
+
+  zap delete: [
+                '~/Library/Saved Application State/com.googlecode.psi-dev.savedState',
+                '~/Library/Caches/Psi+',
+                '~/Library/Application Support/Psi+',
+              ]
+end

--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -2,10 +2,10 @@ cask 'psi-plus' do
   version '0.16.545.538,2016-04-26'
   sha256 '137730bba82e4050f45f6d7d3c06ebd2e183eb23b30df93d35bb5d1563fae79d'
 
-  # downloads.sourceforge.net/project/psiplus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/project/psiplus/Mac-OS-X/psi-plus-#{version.before_comma}-qt4-git-#{version.after_comma}-macosx.dmg"
+  # downloads.sourceforge.net/psiplus/Mac-OS-X was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/psiplus/Mac-OS-X/psi-plus-#{version.before_comma}-qt4-git-#{version.after_comma}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/psiplus/rss',
-          checkpoint: '6bfd1ea5481b4565924ecad3a1a631808fa9b7a484d14bb72d624365338183c4'
+          checkpoint: 'c2997be42f402406e09df8a5bae045270400021852728c0cb2b6d8d119dfc0e8'
   name 'Psi+'
   homepage 'http://psi-plus.com/'
 

--- a/Casks/psi-plus.rb
+++ b/Casks/psi-plus.rb
@@ -2,7 +2,7 @@ cask 'psi-plus' do
   version '0.16.545.538,2016-04-26'
   sha256 '137730bba82e4050f45f6d7d3c06ebd2e183eb23b30df93d35bb5d1563fae79d'
 
-  # sourceforge.net/psi was verified as official when first introduced to the cask
+  # downloads.sourceforge.net/project/psiplus was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/project/psiplus/Mac-OS-X/psi-plus-#{version.before_comma}-qt4-git-#{version.after_comma}-macosx.dmg"
   appcast 'https://sourceforge.net/projects/psiplus/rss',
           checkpoint: '6bfd1ea5481b4565924ecad3a1a631808fa9b7a484d14bb72d624365338183c4'


### PR DESCRIPTION
audit and style are failing because of non-standard sourceforge url.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
