### PR TITLE
Added cask for OmegaT 4.1.0 (Beta)

### DIFF
--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,6 +1,6 @@
 cask 'omegat-dev' do
   version '4.1.0'
-  sha256 :no_check
+  sha256 '32ecddcf71a92973bb3578d009aadfac762742df9b7eacf2cc60c75251f84762'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -4,8 +4,8 @@ cask 'omegat-dev' do
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
-  appcast 'https://sourceforge.net/projects/omegat/rss',
-          checkpoint: 'ee727bd624e9fc1e1358f540422afe8b6f5d917258e97db85d3cb9c8115f4519'
+  appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
+          checkpoint: 'cb4a14253651e4e411a07161493400a78880897bb0e162eb62130b415f400fd8'
   name 'OmegaT Development'
   homepage 'http://www.omegat.org/'
 

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,0 +1,17 @@
+cask 'omegat-dev' do
+  version '4.1.0'
+  sha256 :no_check
+
+  # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
+  appcast 'https://sourceforge.net/projects/omegat/rss',
+          checkpoint: 'ee727bd624e9fc1e1358f540422afe8b6f5d917258e97db85d3cb9c8115f4519'
+  name 'OmegaT Development'
+  homepage 'http://www.omegat.org/'
+
+  app "OmegaT_#{version}_Beta_Mac_Signed/OmegaT.app", target: 'OmegaT Development.app'
+
+  caveats do
+    depends_on_java('8+')
+  end
+end

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -9,7 +9,7 @@ cask 'omegat-dev' do
   name 'OmegaT Development'
   homepage 'http://www.omegat.org/'
 
-  app "OmegaT_#{version}_Beta_Mac_Signed/OmegaT.app", target: 'OmegaT Development.app'
+  app "OmegaT_#{version}_Beta_Mac_Signed/OmegaT.app"
 
   caveats do
     depends_on_java('8+')


### PR DESCRIPTION
Created a cask for OmegaT 4.1.0 Beta with a special target for “OmegaT
Development”, enabling it to be run concurrently with the stable.