### PR TITLE
Update minishift-beta to 1.0.0-beta.4

### DIFF
--- a/Casks/minishift-beta.rb
+++ b/Casks/minishift-beta.rb
@@ -1,10 +1,10 @@
 cask 'minishift-beta' do
-  version '1.0.0-beta.3'
-  sha256 '9b3be4c205aab7e6d562060e1b39ca0ccd5c5fe033d997c1a77b2a1b0109171e'
+  version '1.0.0-beta.4'
+  sha256 '9b15ed1c0d5386be3a5e9014ef633664c3d797a20ace15c580c48f5b905b9d26'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '3cae2c14bce9583c25ae8b0537faac2176631688fd8e05bc938c4df6e7caf722'
+          checkpoint: '62cb709cd9a1fb5a357cb74cac835ab9c18bd9249ebf8a9aad801ca017ea7046'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.