### PR TITLE
Update safari-technology-preview to 24

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,11 +1,11 @@
 cask 'safari-technology-preview' do
-  version :latest
-  sha256 :no_check
+  version '24'
+  sha256 '205d821e368719517d085f10cd0147754f3dd25e80f4bdac9b8d10e464bd9a86'
 
   if MacOS.version <= :el_capitan
     url 'http://appldnld.apple.com/STP/031-81900-20160926-E7046BDA-8434-11E6-83C5-ADC333D2D062/SafariTechnologyPreview.dmg'
   else
-    url 'https://secure-appldnld.apple.com/STP/031-98194-20170208-718B1142-D9F2-11E6-9947-B4F4B59B175E/SafariTechnologyPreview.dmg'
+    url 'https://secure-appldnld.apple.com/STP/031-99186-20170222-C862D208-F85A-11E6-A32A-BD4DE1925776/SafariTechnologyPreview.dmg'
   end
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.