### PR TITLE
Update firefox-beta to 52.0b9

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '52.0b8'
+  version '52.0b9'
 
   language 'de' do
-    sha256 '63a5c93fb7cc28cbff107003ebce469b48d8ed02d90c09767c9f5567fac77351'
+    sha256 '381feb32485ce13c907641256c3771520aede353b8a490fb4b5ba1862cda6967'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'eac9c750b2cf7687c186d34b27b76a0de4b761b95940d8693f42df2b61e916b1'
+    sha256 'fad254e9b963a72d93f353bb8d30a66396a2e049900fa7588d89e81d78dd6275'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '1545d8a1349f53ab0d5bd66a91d3250fb5b133b3c19c24d68aa8dcc1fa1b89a5'
+    sha256 '2411d42ad01be30e04153f7dcd2e0840767bf0e139d3657a02443616476e57f5'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'cc61ab3879a110ed897bccb182d08b06158c7a4f64f69d13630d768eff5f250a'
+    sha256 'e6c4cf9f2165c7aa12c1a57cfcc433e7fb26d195d40afa85663a4760e3f8f908'
     'fr'
   end
 
   language 'gl' do
-    sha256 'e882504d5fab0a17d3933c1b20089ecd015b9c67c4d12f56641b7778aa588950'
+    sha256 '562d30cb3bbd67e0150757bd6cbcde6a6d429b0a84bf13018eb5b73d66c3a6d5'
     'gl'
   end
 
   language 'it' do
-    sha256 '7aaa8b8d6311f167b856acfc8991eb1fc70baa33027dd41060569d939a54a6b7'
+    sha256 '1587c7ff79199e47561858fc34e8f83194779feb7d18894b50dc2e16b55bcefb'
     'it'
   end
 
   language 'ja' do
-    sha256 '7ec95df3b814ff2bea19551298ca41d53b7957690b8aa14a556799aa2b7154a8'
+    sha256 '67be8f02364f4f3cd543ebc31a7858765d985038c1b4ec67642103c3ccc9dc7e'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '99392f86043106cdb7720ec4cd29206ac419381e32c5c554ba09f53081637e77'
+    sha256 'e5b2d7c69e38227eb90db862391c325d675176c3a56ba0df012eb13df83681b6'
     'nl'
   end
 
   language 'pl' do
-    sha256 'bad355e8f6fee8cef4e0c5b95a25338a91ef8ba8ab45d807ac431789d0b1c04b'
+    sha256 'd188c614fc0820cdacca602a7b4d7848b45b1cdf602a86a1b07971917510e18b'
     'pl'
   end
 
   language 'pt' do
-    sha256 '7b065a16cdc82cce3a2c0faf1e1408cf4be8e8a6f7ca9a94759210b2fdb948aa'
+    sha256 '5d5925a612b726606e9168f93176ffbb37f1f19a3a04de6dfd326eea280cd91b'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '6ce7787f4ee0e3fe571802274411d15bb13b03eae5c47d414146ae18d2727604'
+    sha256 'c25c1afc01a85c61202d6bf413d2307d3eba4f12c9750bc8b49c76e54f2c8025'
     'ru'
   end
 
   language 'uk' do
-    sha256 '00039acebe78ba9ce3a1a46f27882a5c970839a145028a97d8a788a34af013a2'
+    sha256 '6c888dd219a9089baf17bd49190de61243adfcc9ac97add4615681f304781c55'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'c1b50cd30f861eabc2aa0793bd30b7d9ae4298e6eb8cb984acff78e140498b1b'
+    sha256 '52a46447e57d51b4e5262f4187f762efeebb2c1c3ea23ac42a93d622c8f2f52b'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '2419afa06197abeb2f368314cc3dd5e208160a6d4e6d7d2b4ef659528599ea37'
+    sha256 '5f12c887a80ef3dda0dd2ef2d0bfc92db1f1b75ab9c7ba9be00264aefc3198e3'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.