### PR TITLE
Upgrade wmail-prerelease 2.2.1

### DIFF
--- a/Casks/wmail-prerelease.rb
+++ b/Casks/wmail-prerelease.rb
@@ -1,11 +1,11 @@
 cask 'wmail-prerelease' do
-  version '2.1.1'
-  sha256 '87ba6695be4ed5d6664d411cb4f09639d49fe9c8c89f08c5d03d1895f8c95a32'
+  version '2.2.1'
+  sha256 'e2e8ecdbe7e6b4b5526f4ff932296a47b9cc30adc33fd3e1ac2b26bae27b13c8'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
   url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_prerelease_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: '3f8d154cc47118f8070fb1a92f76b2c12928e5ad3a5d4019c788653209cedeec'
+          checkpoint: '1287488a9a4d771b86ecb667eef9b44eb0a50a558ccfcc9fb8e76c137c73e2bd'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
