### PR TITLE
Update iterm2-beta to 3.1.beta.1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,13 +1,13 @@
 cask 'iterm2-beta' do
-  version '3.0.14'
-  sha256 'bed63a85d48d4e0ec2f49858aa4a6ce5dcb7bb3eaf78f87124ed5239b6a7e936'
+  version '3.1.beta.1'
+  sha256 'bacb379041382d181ca7998b04b68db2f3a40107699b860c9c43e3595ac9542e'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 
   auto_updates true
-  depends_on macos: '>= 10.8'
+  depends_on macos: '>= 10.10'
 
   app 'iTerm.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.