### PR TITLE
Update vlc-nightly with https

### DIFF
--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -4,7 +4,7 @@ cask 'vlc-nightly' do
 
   url do
     require 'open-uri'
-    base_url = 'http://nightlies.videolan.org/build/macosx-intel/last'
+    base_url = 'https://nightlies.videolan.org/build/macosx-intel/last'
     file = open(base_url).read.scan(%r{href="([^"]+.dmg)"}).flatten.first
     "#{base_url}/#{file}"
   end


### PR DESCRIPTION
The `http://` URL is no longer working.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
