### PR TITLE
Update webkit-nightly to r213013

### DIFF
--- a/Casks/webkit-nightly.rb
+++ b/Casks/webkit-nightly.rb
@@ -1,6 +1,6 @@
 cask 'webkit-nightly' do
-  version 'r212809'
-  sha256 '771c0a92b927c4974efcd4bd3095fe90e3949c52bf4f570c8cb9931da67ec0cf'
+  version 'r213013'
+  sha256 'a20b11be5dd42ca7b84f8b296f5953731fdcc110fee7efaeb22c2e5c1f8c8cae'
 
   url "https://builds-nightly.webkit.org/files/trunk/mac/WebKit-SVN-#{version}.dmg"
   name 'WebKit Nightly'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.