### PR TITLE
Update libreoffice-dev to 5.3.1.1

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-dev' do
-  version '5.3.0.3'
-  sha256 '430f9b2d324e58de5b47f70be46ee2a4690e36c0612e04314f7a99c4fca7f059'
+  version '5.3.1.1'
+  sha256 '7539b51e9afac950bb5c55c4009ff60cbc32b31be85f8ab40b314b445b841c59'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: '618643cd7d2dc4951e122e8794af5f8103d710e00633f4de816bcd9119ca3b60'
+          checkpoint: '001d62a99dcbb9a78b8936ca669eecb6d584a69175ed09381500b90c10a4a897'
   name 'LibreOffice Fresh Prerelease'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.