### PR TITLE
Add telegram-alpha 0.1.3864

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -10,6 +10,7 @@ cask 'telegram-alpha' do
   homepage 'https://macos.telegram.org/'
 
   auto_updates true
-
+  conflicts_with cask: 'telegram'
+  
   app 'Telegram.app'
 end

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,0 +1,15 @@
+cask 'telegram-alpha' do
+  version '0.1.3864'
+  sha256 '00e141ee6993a95d064df3e6377ea058b0095370730ef8d9710f74fa02d91775'
+
+  # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
+  url 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/89?format=zip'
+  appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
+          checkpoint: '6cb12d7e9c70704880f07b308294bc008854ec4a7d0e13f50fc385cd07e2c62b'
+  name 'Telegram for macOS'
+  homepage 'https://macos.telegram.org/'
+
+  auto_updates true
+
+  app 'Telegram.app'
+end


### PR DESCRIPTION
Add's the telegram for macOS alpha version

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
