### PR TITLE
Update telegram-alpha to 0.1.3958

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '0.1.3864'
-  sha256 '00e141ee6993a95d064df3e6377ea058b0095370730ef8d9710f74fa02d91775'
+  version '0.1.3958'
+  sha256 '5ceb82666a10994d8b50b996f14a094bd180aa85709bf8dc26f98128e56e86ef'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
-  url 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/89?format=zip'
+  url 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/91?format=zip'
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6cb12d7e9c70704880f07b308294bc008854ec4a7d0e13f50fc385cd07e2c62b'
+          checkpoint: '31ec158fc213ae3a4cdcabed7902fb35b5154b4b9556881af026cfc1afebb94d'
   name 'Telegram for macOS'
   homepage 'https://macos.telegram.org/'
 


### PR DESCRIPTION
Updates the telegram-alpha cask

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.



[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
