### PR TITLE
Update wmail-prerelease to 2.3.1

### DIFF
--- a/Casks/wmail-prerelease.rb
+++ b/Casks/wmail-prerelease.rb
@@ -1,11 +1,11 @@
 cask 'wmail-prerelease' do
-  version '2.2.1'
-  sha256 'e2e8ecdbe7e6b4b5526f4ff932296a47b9cc30adc33fd3e1ac2b26bae27b13c8'
+  version '2.3.1'
+  sha256 '06195daef38df002c26058ace0efbc8d86e8778150c9be27d48d0aaec7e68328'
 
   # github.com/Thomas101/wmail was verified as official when first introduced to the cask
   url "https://github.com/Thomas101/wmail/releases/download/v#{version}/WMail_#{version.dots_to_underscores}_prerelease_osx.dmg"
   appcast 'https://github.com/Thomas101/wmail/releases.atom',
-          checkpoint: '1287488a9a4d771b86ecb667eef9b44eb0a50a558ccfcc9fb8e76c137c73e2bd'
+          checkpoint: '8bdfc9efd95dffeb007621e2c8d8959f1f8eb490ff72694508bab598e8cbb1e5'
   name 'WMail'
   homepage 'https://thomas101.github.io/wmail/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.