### PR TITLE
Update airmail-beta to 3.2.3.415,288

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.414,287'
-  sha256 'b35aa3f5030ccd646b109ab98410b526d489b725ccc1f0ee77a37972260d2200'
+  version '3.2.3.415,288'
+  sha256 '8183ee9cef4e6f94a1745dcff5432bacbd8d8f2f9271d7fadc463b1e4a82b2c3'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'cea1ae70dafa5c0a385189f6125ec3f6e2abf9f4aaf715e7cd4fd5cd4c186f5b'
+          checkpoint: '94a413bde8ff50972b165d1c411bd714bb3c277e315bbc6a2f38936970acaf67'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.