### PR TITLE
Add Flux v39.93

### DIFF
--- a/Casks/flux-beta.rb
+++ b/Casks/flux-beta.rb
@@ -9,6 +9,7 @@ cask 'flux-beta' do
   homepage 'https://justgetflux.com/'
 
   auto_updates true
+  conflicts_with cask: 'flux'
 
   app 'Flux.app'
 

--- a/Casks/flux-beta.rb
+++ b/Casks/flux-beta.rb
@@ -1,0 +1,25 @@
+cask 'flux-beta' do
+  version '39.93'
+  sha256 'b182d321956cb540bb7fa6d3357817981c5d45ab103a56ece7fd5582d879b1ce'
+
+  url "https://justgetflux.com/mac/Flux#{version}.zip"
+  appcast 'https://justgetflux.com/mac/macflux.xml',
+          checkpoint: 'f6127c732fe64848139f952b0ff08dcd4ba97f1a58d6599857d6268ad035b5ec'
+  name 'f.lux'
+  homepage 'https://justgetflux.com/'
+
+  auto_updates true
+
+  app 'Flux.app'
+
+  postflight do
+    suppress_move_to_applications
+  end
+
+  uninstall login_item: 'Flux'
+
+  zap delete: [
+                '~/Library/Preferences/org.herf.Flux.plist',
+                '~/Library/Caches/org.herf.Flux',
+              ]
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
    - Looks like flux-beta was previously removed in #2042 because the URL gave a 404. The most current beta ([v39.93](https://forum.justgetflux.com/topic/3466/f-lux-beta-39-9)) has a working download link.
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
