### PR TITLE
Update 1password-beta to 6.6.2.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.6.1.BETA-4'
-  sha256 '238f1ee21758b3a0ad4e6c5f8dd2870e90a9bc2d637a2f7192a17b2c1ccf6a36'
+  version '6.6.2.BETA-1'
+  sha256 '3567703ab7654b920dd983e2bfc982adef8da972bbef5e9d9f3ca364f7127f67'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.