### PR TITLE
Update opera-beta to 44.0.2510.401

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '44.0.2510.73'
-  sha256 '46efd4cf4f8177e8ea4e9bb1820fb9371009aa050917977ed459aa7e28fd79b1'
+  version '44.0.2510.401'
+  sha256 'bc1d62708c43a5478d9ee9b02bc0092e1601ab7068573c294ad5ff243c919e9f'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #.