### PR TITLE
Update docker-beta to 17.03.0-ce-mac1 build 15587

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '1.13.1-beta42,15350'
-  sha256 '7ebb88129e3cec7c196cac60ec8bf2b3bd7da3f541f8e8a94cf3aae1e340f194'
+  version '17.03.0-ce-mac1,15587'
+  sha256 '6a3bada125706a4ac99608dd61d70ea55b0a8ab78740ee41d1f0d29e84c96870'
 
   url "https://download.docker.com/mac/beta/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'a6d4a82b2f54819e4dc7329f624931800c4bef73a81f33097231df46029339f9'
+          checkpoint: '35a2c3188a02bb52839ebb16e71273f104a676ab52ffae7323171960eb87c3aa'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/products/docker'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
