### PR TITLE
Update telegram-alpha to 0.1.4275,99

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '0.1.3958,91'
-  sha256 '5ceb82666a10994d8b50b996f14a094bd180aa85709bf8dc26f98128e56e86ef'
+  version '0.1.4275,99'
+  sha256 '6b5b631723a79a51adbf11a212eb5303e56f06dc7be0fd55c9650631b0633eb1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '31ec158fc213ae3a4cdcabed7902fb35b5154b4b9556881af026cfc1afebb94d'
+          checkpoint: '13d8b9170d98fe2f13f9892e94bed62e3d4076215fc67e9e591a2ad8c7ec0083'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'
@@ -13,6 +13,6 @@ cask 'telegram-alpha' do
   auto_updates true
   conflicts_with cask: 'telegram'
   depends_on macos: '>= :yosemite'
-  
+
   app 'Telegram.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.