### PR TITLE
Update toggldesktop-dev to 7.4.25

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.24'
-  sha256 '7fdb1a308644e3fbdf3d2db52ac7de117a95b9798450220e18dcd88ac97867fe'
+  version '7.4.25'
+  sha256 'a1be39fdc477ee94ff27d7749b4693be9fa639a9fb0eee6128569500c215c1eb'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '1a8dad2bdfe1e4d0183e0483970d5c53545ca7494cd4310bfbc3fc7031e06c96'
+          checkpoint: '7d415f36fcd10a5450af4934a11723571a75adf26cdccfc37ae4126880abefc0'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.