### PR TITLE
Update openscad-snapshot to 2017.02.08

### DIFF
--- a/Casks/openscad-snapshot.rb
+++ b/Casks/openscad-snapshot.rb
@@ -1,8 +1,10 @@
 cask 'openscad-snapshot' do
-  version '2016.11.21'
-  sha256 'c45644337450bbbac5cbb361d96899f6451a12b8244511683eb7a2cd200877fa'
+  version '2017.02.08'
+  sha256 '2a8233bcf353a17b056aa60b52f07396b48db6b3a4585ff8eac49e23d0f2ac64'
 
   url "http://files.openscad.org/snapshots/OpenSCAD-#{version}.dmg"
+  appcast 'http://www.openscad.org/inc/mac_snapshot_links.js',
+          checkpoint: 'd467c39256db5382f918fe031a8d5124bd06cee5f9a7cd3f8bb79095fec7ae04'
   name 'OpenSCAD'
   homepage 'http://www.openscad.org/downloads.html#snapshots'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.