### PR TITLE
Update iterm2-beta to 3.1.beta.2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,6 +1,6 @@
 cask 'iterm2-beta' do
-  version '3.1.beta.1'
-  sha256 'bacb379041382d181ca7998b04b68db2f3a40107699b860c9c43e3595ac9542e'
+  version '3.1.beta.2'
+  sha256 '734c9fe31761f5da993458e94d198f30921053bde0a0ef1bbedcdfdab07a7114'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.