### PR TITLE
Update telegram-alpha to 3.0.84710,112

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '0.1.4375,102'
-  sha256 'fcb1e1330cb12672d9a678d0ee89b56ef7810b326644e656bfb59cb2ee04328a'
+  version '3.0.84710,112'
+  sha256 'c4b907f0235988ba5c92cae803d085e019a9989ee3256845fbad250a81764548'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '296fc3c849c16643683be5d1fc8e132207928389629266ea0636458c67e6ca6f'
+          checkpoint: 'fbdd5c06978996e55e8449e574a2088112a99e1d3a43c13a91682ff66ef5a1ac'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.