### PR TITLE
Update docker-beta to 17.03.0-ce-mac2,15657

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '17.03.0-ce-mac1,15587'
-  sha256 '6a3bada125706a4ac99608dd61d70ea55b0a8ab78740ee41d1f0d29e84c96870'
+  version '17.03.0-ce-mac2,15657'
+  sha256 '14d72c0c986d4955e12fa3cba094e9c2a4b03ed244fa43151661cf537965ef1c'
 
   url "https://download.docker.com/mac/beta/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: '35a2c3188a02bb52839ebb16e71273f104a676ab52ffae7323171960eb87c3aa'
+          checkpoint: 'b2690032da2b2bd33b0e8ec005dad379f1a8064bd7137bda4123aed075daabd1'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.