### PR TITLE
Update dropbox-beta to 22.3.20

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '21.3.24'
-  sha256 'fea9f38b265cd05f4a0a52e99e88ba7ef92a087f57f6892a6a3a04fdba553119'
+  version '22.3.20'
+  sha256 'aa069065ab164de55e95af2857dae350b3db6688cf412d285b1db846ef3b2c22'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.