### PR TITLE
Update airmail-beta to 3.2.3.417,289

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.415,288'
-  sha256 '8183ee9cef4e6f94a1745dcff5432bacbd8d8f2f9271d7fadc463b1e4a82b2c3'
+  version '3.2.3.417,289'
+  sha256 '7d54f958cb5c44dc94fa10df4f2290b0275eead3f730523a8360919e7d046cb4'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '94a413bde8ff50972b165d1c411bd714bb3c277e315bbc6a2f38936970acaf67'
+          checkpoint: 'f1d83f0156c2441268474f4033f72c8ccfa57d536121fc4d7c42300ca7ab26ac'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.