### PR TITLE
Update firefox-esr to 52.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,73 +1,73 @@
 cask 'firefox-esr' do
-  version '45.7.0'
+  version '52.0'
 
   language 'de' do
-    sha256 '273b238ec26dba0521741154246ae804193fdb01ef423994d45dc97a9da626f0'
+    sha256 '59f48ff5b50e946b00adf11363218f577fceb9fc00bc9a4ebb4b3c186c467dfa'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a6e73341e464de3a0513a9d7b1a4bbac0e18d9375558e52530b69ccce017fa59'
+    sha256 '7e4953a0ee7fe1e7c14af3872e88a68815393900c82e667636af907e344cea78'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '36c3049d8c0e265e2ba3a10e57ce09b99f3aef3fac110ec32f17706e8ee5cd77'
+    sha256 'd07eae2f89aabba2b8d3e4f475d83b928156cd7bb6cfdc5169016df16b705c78'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '39543704a55ba3060c06d29f0101cbeacb401069cc7836866f630159ae2fb14e'
+    sha256 '60f83c9dc3dee037dac7cc28e22e2ab0b5a40d08209237d783f737038a1ab7f0'
     'fr'
   end
 
   language 'gl' do
-    sha256 '6055b0cc77e8ceb7a025a91662f20026d6783b76bd41b73f647d0beaca9400cb'
+    sha256 '6be1d4bd3d8328b3f48749243eff23705b4e4d7a4af73b036bf3978ea5ec46b1'
     'gl'
   end
 
   language 'it' do
-    sha256 '0560d70855915abcbd056d15aa0240d9000c21c020e18adaa150da62b7c63de8'
+    sha256 '58d837b5967224cf6e0f5d75c162877a8504ba0b12ab9ecf53d473399a806b2a'
     'it'
   end
 
   language 'ja' do
-    sha256 '66169e34584d05ab4926d336c105c23b28d5c9e9e80644a6d84b93e56efd979a'
+    sha256 '9369d75b9c1203fbd37642e912bddf6f39f6ede96eb02ec4e8e4f66453eb47d0'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'a0895735750e113538e20f75e39c35be656732b5004f6d9f4f0889a449f0468c'
+    sha256 'cd23a77fc5f8ea6dfaabd0d9350fafae746a574f190d81f8415f748260973f84'
     'nl'
   end
 
   language 'pl' do
-    sha256 'f863a7055f45a2629ba8265b9f75fcc039b31cb317d89538273bdece5f1700e2'
+    sha256 'ea0ed0de7a4a4675f24b9f66dca94a970a32912957e84a300f153d97f2303e9d'
     'pl'
   end
 
   language 'pt' do
-    sha256 'a894412afb21a43b7f199597011c1be98cb045bf1f2030aa10913bc66c6f5fae'
+    sha256 'fa1998d6092d72a0d27493fe3471c0caf8d0b6d8d15820271e532c336e647ea6'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '540a9af2f8bcdea1c9f70cfae3459667ab23ce0701ec7446521c39f31be5b834'
+    sha256 '1a7ccf116a8048f8a528bb7fc52b3a6f3514cb69153238a9fa01bdae950cf700'
     'ru'
   end
 
   language 'uk' do
-    sha256 'eca820538bd41f5da55d00935730c84483465a25e10e613b47d2fc713373dd3b'
+    sha256 'bd27502ad03491ce60d1e7cfd2f6309676232152d8fb2bd2466803c1f28c6aee'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'd6d02c3cf02159b8dbde8a310adb4cdb7d7ba6e50a5de8d4690d882ecc7b62bb'
+    sha256 'a73b8477569d2c2e87bd30bedb26e34cbba64f320d0bc67b978bd1e02e7263b2'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '515e0a4a1a92b5c64a5599447c832d094bb3de34b5813b54f3f6e643373198aa'
+    sha256 'ebf6565bfee372b5d37e6808d0278f311779cddd084db217347e132dcb8ccc35'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.