### PR TITLE
Update telegram-alpha to 3.0.85236,134

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.84710,112'
-  sha256 'c4b907f0235988ba5c92cae803d085e019a9989ee3256845fbad250a81764548'
+  version '3.0.85236,134'
+  sha256 '3fe989891a2b5a13cc651e09cdd91b403511152d9bd7d41355ea675318518fae'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'fbdd5c06978996e55e8449e574a2088112a99e1d3a43c13a91682ff66ef5a1ac'
+          checkpoint: '453f2434998f4574e5a9cdcc229051fc8e9c339b5b1c370f2ef8ee74196062c8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -5,7 +5,7 @@ cask 'telegram-alpha' do
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '453f2434998f4574e5a9cdcc229051fc8e9c339b5b1c370f2ef8ee74196062c8'
+          checkpoint: 'b1c76841d4811866208b08ad492691a7ec8a8763773bf93a368d03d3d5751e02'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.