### PR TITLE
Update vivaldi-snapshot to 1.8.770.25

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.8.770.9'
-  sha256 '24895a6b296eaeceb3bae2e36147495192f25b3a592ec52ca04fcb639b94391d'
+  version '1.8.770.25'
+  sha256 'bbab9b560535ee87d04d1cce6c3b41d317273a06599d7ee4699e279dee478637'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '79210e1de8860aa3369ed872f1f8ca1a4a7b9fb378000849ba397e130e03c244'
+          checkpoint: '1708982095625c02822e501b8963747031c0657a53b9afe80e4f73f2dcfb1e4c'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.