### PR TITLE
Update telegram-alpha to 3.0.86044,148

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.85236,134'
-  sha256 '3fe989891a2b5a13cc651e09cdd91b403511152d9bd7d41355ea675318518fae'
+  version '3.0.86044,148'
+  sha256 '77fc791bc5e811ad2a762291a134bed618fd2b0da67bbb07ed9af2f7a4925629'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b1c76841d4811866208b08ad492691a7ec8a8763773bf93a368d03d3d5751e02'
+          checkpoint: 'bd9bc028f0cdbb1c2f3f58ee105e01b9ee18a1c970fbcca907754c8e057892ac'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.