### PR TITLE
Update minishift-beta to 1.0.0-beta.5

### DIFF
--- a/Casks/minishift-beta.rb
+++ b/Casks/minishift-beta.rb
@@ -1,10 +1,10 @@
 cask 'minishift-beta' do
-  version '1.0.0-beta.4'
-  sha256 '9b15ed1c0d5386be3a5e9014ef633664c3d797a20ace15c580c48f5b905b9d26'
+  version '1.0.0-beta.5'
+  sha256 '226ca3ced26a58f12c64cfa48ae100cc405527f261678ddf3ccd034eb1fe767a'
 
   url "https://github.com/minishift/minishift/releases/download/v#{version}/minishift-#{version}-darwin-amd64.tgz"
   appcast 'https://github.com/minishift/minishift/releases.atom',
-          checkpoint: '62cb709cd9a1fb5a357cb74cac835ab9c18bd9249ebf8a9aad801ca017ea7046'
+          checkpoint: '07a9028acc486a2aae16f422f3d98fdd624ef091690e2e35fa28e1d869117a95'
   name 'Minishift'
   homepage 'https://github.com/minishift/minishift'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.