### PR TITLE
Update IntelliJ IDEA EAP platform to version 2016.3.5 build 163.13906.18

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea-ce-eap' do
-  version '2016.3.5,163.13906.16'
-  sha256 '9cfb98432a17fbc3c11b4dfe8f89b867bbe53fcd236d597d8ad2000a00b629d6'
+  version '2016.3.5,163.13906.18'
+  sha256 '4b7a52afdd1fd8be6ea5a0116d23d8bbaf1d90337a78c4bbb8e24b0af19fbd57'
 
-  url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIC-#{version.before_comma}.dmg"
   name 'IntelliJ IDEA Community Edition EAP'
   name 'IntelliJ IDEA CE EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea-eap' do
-  version '2017.1,171.3780.15'
-  sha256 '26071b76c684797a3720fbcec116c0616950ee0d42e762215ebe188c39de9277'
+  version '2016.3.5,163.13906.16'
+  sha256 '136e679a751c4a098b2c7195efa526f8b3b51b010a96f568c875986b8eb11a71'
 
-  url "https://download-cf.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Ultimate EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,8 +1,8 @@
 cask 'intellij-idea-eap' do
-  version '2016.3.5,163.13906.16'
-  sha256 '136e679a751c4a098b2c7195efa526f8b3b51b010a96f568c875986b8eb11a71'
+  version '2016.3.5,163.13906.18'
+  sha256 '4417df3aa9fba7c75af371b51d734759b2d555930404b2063866b4e869ae3b79'
 
-  url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}.dmg"
   name 'IntelliJ IDEA Ultimate EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 


### PR DESCRIPTION
This reverts #3446.

Discussion in #3448.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
