### PR TITLE
Update android-studio-canary to 2.4.0.0,171.3804684

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,19 +1,19 @@
 cask 'android-studio-canary' do
-  version '2.3.0.7,162.3742087'
-  sha256 'a8e95c407fe8ed36ad6d89823971c365cfbbfd9256f768940998169d5c790fef'
+  version '2.4.0.0,171.3804684'
+  sha256 '00fbc39c6f6afc286de51180a107809e079f343697a809f5e450820af238584b'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'
   homepage 'https://sites.google.com/a/android.com/tools/download/studio/canary'
 
-  app 'Android Studio.app'
+  app "Android Studio #{version.major_minor} Preview.app"
 
   zap delete: [
-                "~/Library/Preferences/AndroidStudio#{version.major_minor}",
+                "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",
+                "~/Library/Caches/AndroidStudioPreview#{version.major_minor}",
+                "~/Library/Logs/AndroidStudioPreview#{version.major_minor}",
+                "~/Library/Preferences/AndroidStudioPreview#{version.major_minor}",
                 '~/Library/Preferences/com.google.android.studio.plist',
-                "~/Library/Application Support/AndroidStudio#{version.major_minor}",
-                "~/Library/Logs/AndroidStudio#{version.major_minor}",
-                "~/Library/Caches/AndroidStudio#{version.major_minor}",
               ],
       rmdir:  '~/AndroidStudioProjects'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.