### PR TITLE
Update omegat-dev to 4.1.1

### DIFF
--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -3,7 +3,7 @@ cask 'omegat-dev' do
   sha256 '1ffe17252bce43c1922760811ac5df8b55e7ff075dbc969387c06cf126cbd30e'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
           checkpoint: '7775eec68c7ea509552572bd1304925c654554cac557ee3d0ea5b3cba6522a0e'
   name 'OmegaT Development'

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,6 +1,6 @@
 cask 'omegat-dev' do
   version '4.1.1'
-  sha256 '1ffe17252bce43c1922760811ac5df8b55e7ff075dbc969387c06cf126cbd30e'
+  sha256 '4a3b03e98e61527f14442a49eb6563b1a6df0d7bf22e22be751e6cff63734739'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -5,7 +5,7 @@ cask 'omegat-dev' do
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
-          checkpoint: '66d1d12c29bf7aa884131ecac2e6f500d91d1585943b70b713b8cb1b180d0219'
+          checkpoint: '7775eec68c7ea509552572bd1304925c654554cac557ee3d0ea5b3cba6522a0e'
   name 'OmegaT Development'
   homepage 'http://www.omegat.org/'
 

--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,11 +1,11 @@
 cask 'omegat-dev' do
-  version '4.1.0'
-  sha256 '32ecddcf71a92973bb3578d009aadfac762742df9b7eacf2cc60c75251f84762'
+  version '4.1.1'
+  sha256 '1ffe17252bce43c1922760811ac5df8b55e7ff075dbc969387c06cf126cbd30e'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
-          checkpoint: 'cb4a14253651e4e411a07161493400a78880897bb0e162eb62130b415f400fd8'
+          checkpoint: '66d1d12c29bf7aa884131ecac2e6f500d91d1585943b70b713b8cb1b180d0219'
   name 'OmegaT Development'
   homepage 'http://www.omegat.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.