### PR TITLE
Update sketch-beta to 43,38976

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '43,38963'
-  sha256 'f4fdffeed4491c77eb8192502e902e55129f6431b7e03ad441d3b1e697a47b75'
+  version '43,38976'
+  sha256 'f0c0d0dd6b0c72684a158f456af4715f43e0673e669d09f8f5830f15860ecce6'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '98236c4d5e142e4ee0e8713d951db1b069745f7e9d9294e4ea8d4f71e0f4cb6a'
+          checkpoint: '1809b075466d4c7175ea24689a72474e969df56d724721301d59a207691237de'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.