### PR TITLE
Update opera-beta to 44.0.2510.849

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '44.0.2510.433'
-  sha256 '67c1fcf8c8c482b44af65cf5ac5182dfc84e0ae5f21aba3e641234e1bb822ac2'
+  version '44.0.2510.849'
+  sha256 '690776a4921c142dcd77b9d607ca649652f5c42ff4568926414d5c6d47b064d9'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.