### PR TITLE
Update clion-eap to RC,2017.1

### DIFF
--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -1,19 +1,19 @@
 cask 'clion-eap' do
-  version '2017.1,171.3780.24'
-  sha256 '611e5ced6ebe9566550727490c6373aae01b4ecbcbd3a834acca2c2b4856ed1d'
+  version 'RC,2017.1'
+  sha256 '3d8371cfa8362c1d50cd536ed0309ddf47090abcdb98aeb71b48bc79c589382e'
 
-  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}.dmg"
+  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}-#{version.before_comma}.dmg"
   name 'CLion EAP'
   homepage 'https://confluence.jetbrains.com/display/CLION/Early+Access+Program'
 
   conflicts_with cask: 'clion'
 
-  app "CLion #{version.before_comma} EAP.app"
+  app "CLion #{version.after_comma} EAP.app"
 
   zap delete: [
-                "~/Library/Application Support/CLion#{version.major_minor}",
-                "~/Library/Caches/CLion#{version.major_minor}",
-                "~/Library/Logs/CLion#{version.major_minor}",
-                "~/Library/Preferences/CLion#{version.major_minor}",
+                "~/Library/Application Support/CLion#{version.after_comma.major_minor}",
+                "~/Library/Caches/CLion#{version.after_comma.major_minor}",
+                "~/Library/Logs/CLion#{version.after_comma.major_minor}",
+                "~/Library/Preferences/CLion#{version.after_comma.major_minor}",
               ]
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.