### PR TITLE
Update vivaldi-snapshot to 1.8.770.32

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.8.770.25'
-  sha256 'bbab9b560535ee87d04d1cce6c3b41d317273a06599d7ee4699e279dee478637'
+  version '1.8.770.32'
+  sha256 'ea537762a9056d15da043025941d5b9cac6d8d76d12f431b8fe61b8512ef3993'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '1708982095625c02822e501b8963747031c0657a53b9afe80e4f73f2dcfb1e4c'
+          checkpoint: '89b29c2bf2964445485b14ba8f7907b2ab0b85807c2e6893d59248383ad096af'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.