### PR TITLE
Update visual-studio-code-insiders to 1.11.0,05f19eec2042555ca04e5f014befa95248a65fe9

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.11.0,01091bb0831f7ce07db3cdc3ad66abb4141ffd8d'
-  sha256 '2beaafb7cac2c9f03aad39f2d0e5135638c3edfdb05ac7fde32b25d96b94dad3'
+  version '1.11.0,05f19eec2042555ca04e5f014befa95248a65fe9'
+  sha256 '21ea9a2b729daed846c18a4625fb1da364c64fa45acbdd9d47dd46a3afad9566'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.