### PR TITLE
Update toggldesktop-dev to 7.4.28

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.25'
-  sha256 'a1be39fdc477ee94ff27d7749b4693be9fa639a9fb0eee6128569500c215c1eb'
+  version '7.4.28'
+  sha256 '5f6a41982790b81bc6266dd6a3758c3d828aeab9ab64599ac6c645ed09792c0f'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '7d415f36fcd10a5450af4934a11723571a75adf26cdccfc37ae4126880abefc0'
+          checkpoint: 'd6f5130a83bbc877d9a78d2ef871430e662e814f3393bd84a697f59ff665710b'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.