### PR TITLE
Update airmail-beta to 3.2.3.418,290

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.417,289'
-  sha256 '7d54f958cb5c44dc94fa10df4f2290b0275eead3f730523a8360919e7d046cb4'
+  version '3.2.3.418,290'
+  sha256 'dc9cf38953fe6f4528e7eaf462b552b17d70e7ebfdf49efb220205ab5a1e47ff'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'f1d83f0156c2441268474f4033f72c8ccfa57d536121fc4d7c42300ca7ab26ac'
+          checkpoint: 'cc447d343228a378e9553c02e6ee036da9342734c5844b13b6dc7cf28aed46f8'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.