### PR TITLE
Update telegram-alpha to 2.91.90372,183

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.90272,178'
-  sha256 'f78ddae7839a0bef2b4727ea216ca500c041adf3cb911bf6adbb125d1b1bab20'
+  version '2.91.90372,183'
+  sha256 '90aa5cf46b44d658f83c52715dae598bd4cb9e51b783c5516f1ccd07dbd19c25'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '477650738a13df75eecb976bafdaceae4d1c1839d2b077d3de7c83d0b1deca9b'
+          checkpoint: '9b4c7349d83e8d7c83315ba73b124c3deefc8c83f2fa8506c6e80a718cbe205f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.