### PR TITLE
Update tower-beta to 2.6.2-349,349-a254b81d

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.6.1-347,347-121ed402'
-  sha256 'acc31729627641973bbb49b101e076e78b9ec2e09d047eb46264119f98f51067'
+  version '2.6.2-349,349-a254b81d'
+  sha256 '7232fda68eafcb1d8079e98241b60f45671dda084af7a37392d326306c7a2e03'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: 'da389b14aff86c5d8981137f93ef61ec82c349354052412d55140d7c4b16d61f'
+          checkpoint: '009963eb3971cba981274db08c9972c950131eeecfd4943ea8d4d8b04fb0f172'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.