### PR TITLE
Update opera-developer to 45.0.2539.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '45.0.2531.0'
-  sha256 '063a37849dcbae4b1376106b872e9563f8f4bbe13077c4efab4412622ee1c335'
+  version '45.0.2539.0'
+  sha256 'd910addce7e5d28e70b274e0ab99e9cc8e47d068060772389d4835745990bf41'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.