### PR TITLE
Update firefox-beta to 53.0b5

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '53.0b4'
+  version '53.0b5'
 
   language 'de' do
-    sha256 '211f3a3c8908e61b17ffc005db8558f92dc3a7bc903d8f7de9ce21ea85289792'
+    sha256 '7e9f83ef1afa1b5fb2011f38601a92a59002b2b95bad0bd052b03473919e4928'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '99787aecf7a2b26284219f9d1451a6a872c3bfbe5c4f46ca2a5fa76d32a148a4'
+    sha256 'e48345f100939db7254eeecb3db2f6f74a5dab61bd93ad627953382e1790f6b0'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '30e7c6f35ac45415b93b001a9730b12bf81fb5ac1295509972e8c2ec91097c1d'
+    sha256 '7c84aeede3df9b3e99d951898edf5b14660a17e1cf35ba7cb85f6143f8f02ac8'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '3bbd340fcca82744fa5c728bc6deda68e0598a92f94b87a7b7a1385f3c6b2aa3'
+    sha256 '3f84e5ed937c4a8094066d3bb7908ec609e06259fe0e8b8e41737fc6bbb99cc3'
     'fr'
   end
 
   language 'gl' do
-    sha256 '5553b5c1c7275f3d513efd1b19e0210575d18fc3621377834a4ad77810ad8f34'
+    sha256 '77011582c9db4b49e5f42834e586aae2788109d148603de6ed4739bbc2420c5b'
     'gl'
   end
 
   language 'it' do
-    sha256 'c2bbb6b195b0d8fa63bb2fa4c5892307a4f6207e02dc06d2db2dd921d3f34365'
+    sha256 'fe13e2a2db7b1ed1acdb0886855715d756ecab2cdcb6fcea1aeb466591e9e262'
     'it'
   end
 
   language 'ja' do
-    sha256 '0d674963d930823cbac78fe211df7985952a5d653e61a5a1d3c816d576f7daec'
+    sha256 '64f1dfbf4620f17cdc5f1f61e2d881e1b275c8b60dfba3f5d1481c1492857b2b'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '39460fd43ce8fe9d38fa7266d905e93e5be20750cf8f9a489f87ac978cae32a5'
+    sha256 'e118b8756212b1cf1cf9861a74fa1f49d4c698c769fb4b39e30a95070ca84019'
     'nl'
   end
 
   language 'pl' do
-    sha256 '86a0f39e6e9c55a39ecdc50cbd61d858d6605eeccaa5f71cbed1c18886f73964'
+    sha256 '1568bc2d7809ea24ac1e2707738712387961912a782e29a0134890e9c257436c'
     'pl'
   end
 
   language 'pt' do
-    sha256 'c490432a8a452f95918a52dab1a446b5ac77cd1eff6a0dc9683bf8b6c2ddd420'
+    sha256 'e91cc53ee00a9382043d0f823c59d07b899b37cc62e993d2a7bc379816f1d501'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '3ab3e9e6bd27b5e2d2457b4cae0bd16cba8115be298aa5233d78ab82a363ec4b'
+    sha256 '31e151a55f5fdb794e639729cdf63e5e3a6ab77a1bb65b8267a0d956830e18a9'
     'ru'
   end
 
   language 'uk' do
-    sha256 '90563793b6cbd07cc09110ab7c8c5e164b34232b7c48e2616d6ffe1aa9f8d365'
+    sha256 '2258d970e4216ff463a0da2b26ac25267a86e731a3aa7a342ee84784cc4bc83d'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '79fd41fc37b43614c68957f392322c9e685cff58b287d1b57790f243f3d82ff8'
+    sha256 '266d890921d9cd96a8e3647cfe50c61cec8582938c486c9ea2961e3a49a73c29'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'ba178e5e9a0938479134f0550f7d52ab9359629de5b51412867f566189019f5b'
+    sha256 'bb84cba7efc432bd9942f1568424bd021506327e0804fa69a96dcd5fa5f7799a'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.