### PR TITLE
Update safari-technology-preview to 26

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
   if MacOS.version <= :el_capitan
-    version '24'
+    version :latest
     sha256 'e19500bd87d7be249ebace9796b131ab62f39d1a10b5113713735f847e5f3e42'
     url 'http://appldnld.apple.com/STP/031-81900-20160926-E7046BDA-8434-11E6-83C5-ADC333D2D062/SafariTechnologyPreview.dmg'
   else
-    version '25'
-    sha256 'aba67c63ceb23dd73380cd9ae61da766728ebe466ab5159953cc63bf324d4627'
-    url 'https://secure-appldnld.apple.com/STP/091-00989-20170308-2ABA2488-037D-11E7-AC26-30643AE38D09/SafariTechnologyPreview.dmg'
+    version '26'
+    sha256 '5d612dcca7da026bcbd8deb3aee6fdbf3de0b05a42d47e8d09c935166d306214'
+    url 'https://secure-appldnld.apple.com/STP/091-01778-20170322-AB2EC7B2-0DBF-11E7-93C5-AB1400A0ED6C/SafariTechnologyPreview.dmg'
   end
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
