### PR TITLE
Update docker-beta to 17.03.1-ce-rc1-mac3,15924

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '17.03.0-ce-mac2,15657'
-  sha256 '14d72c0c986d4955e12fa3cba094e9c2a4b03ed244fa43151661cf537965ef1c'
+  version '17.03.1-ce-rc1-mac3,15924'
+  sha256 '95a6c3b7531fb7778c722425a002f16709f8ddd3731b5725c6aa5fbd3e2e5c4d'
 
-  url "https://download.docker.com/mac/beta/#{version.after_comma}/Docker.dmg"
+  url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'b2690032da2b2bd33b0e8ec005dad379f1a8064bd7137bda4123aed075daabd1'
+          checkpoint: 'b65d52e05656e04d71dc0712410a4906d8ffbd76abdd54fa1766ece6aae326cd'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.