### PR TITLE
Update telegram-alpha to 2.91.90582,190

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.90444,188'
-  sha256 '7eb5585ad07e6367544f1a35b9ebe7a8662617fe3d4909b6afe48f35f6c6bf44'
+  version '2.91.90483,189'
+  sha256 '4ad5077afece4ffb68d41f0312a467ec83dac5777dc64fb458f2ad91198a62c5'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '3dd5c61d9397174c91748cb77487c96d2b550def6b25ee419bb5300089ec09c2'
+          checkpoint: 'bf6e692dec021d9448fd2969b391688631201df5cd04fcd421d338bff651d414'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.90483,189'
-  sha256 '4ad5077afece4ffb68d41f0312a467ec83dac5777dc64fb458f2ad91198a62c5'
+  version '2.91.90582,190'
+  sha256 '7dce91a685f1140df9707d6250092283889181c396967ccddee40f63bd1c6a8d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bf6e692dec021d9448fd2969b391688631201df5cd04fcd421d338bff651d414'
+          checkpoint: '12578d72fb0adc7391e18c13a729499b015a7fbb2e7779256fc292fa830522b7'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.