### PR TITLE
Remove outdated elcapitan version of safari-technology-preview

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,13 +1,8 @@
 cask 'safari-technology-preview' do
-  if MacOS.version <= :el_capitan
-    version :latest
-    sha256 'e19500bd87d7be249ebace9796b131ab62f39d1a10b5113713735f847e5f3e42'
-    url 'http://appldnld.apple.com/STP/031-81900-20160926-E7046BDA-8434-11E6-83C5-ADC333D2D062/SafariTechnologyPreview.dmg'
-  else
-    version '26'
-    sha256 '5d612dcca7da026bcbd8deb3aee6fdbf3de0b05a42d47e8d09c935166d306214'
-    url 'https://secure-appldnld.apple.com/STP/091-01778-20170322-AB2EC7B2-0DBF-11E7-93C5-AB1400A0ED6C/SafariTechnologyPreview.dmg'
-  end
+  version '26'
+  sha256 '5d612dcca7da026bcbd8deb3aee6fdbf3de0b05a42d47e8d09c935166d306214'
+
+  url 'https://secure-appldnld.apple.com/STP/091-01778-20170322-AB2EC7B2-0DBF-11E7-93C5-AB1400A0ED6C/SafariTechnologyPreview.dmg'
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'
 


### PR DESCRIPTION
Currently "version :latest" without turning sha256 to :no_check, won't work on an actual El Capitan, which is done by me, sorry (because previous value, 24, was also untrue indication of the version, as version 24 was not published on 20160926 obviously). Can we instead remove the platform specific conditioning and make things more maintainable?