### PR TITLE
Update vivaldi-snapshot to 1.8.770.40

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.8.770.38'
-  sha256 'eab0e072e6d66edd51488500b93d8c99a9c1fa0bb1585ef0d3c8fa86abdec8cb'
+  version '1.8.770.40'
+  sha256 '0bf31e8f1a4c3176fa2b7664a919c7ebc76bf0b1f9ae1a95429cfc951b065292'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'be9bc8c0401ed80865b4190b076e566a34ca8463a33ab55970b135fca33f4a80'
+          checkpoint: '306e61c696f5fff61497f58c48feef83e61ed0eb514cfbbf94876ad5d112aa8c'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.