### PR TITLE
Update firefox-beta to 53.0b6

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '53.0b5'
+  version '53.0b6'
 
   language 'de' do
-    sha256 '7e9f83ef1afa1b5fb2011f38601a92a59002b2b95bad0bd052b03473919e4928'
+    sha256 '8fbf9cd279eddfb10bbe88e0755e86bd480d8c8c14f3bbc01b844bbacf315eda'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'e48345f100939db7254eeecb3db2f6f74a5dab61bd93ad627953382e1790f6b0'
+    sha256 'eec84617da65d7115cd1c4a38887081b8ea7356d60480c5dfc3ec5fcc2cb0490'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '7c84aeede3df9b3e99d951898edf5b14660a17e1cf35ba7cb85f6143f8f02ac8'
+    sha256 'e889d2f2d2b144338aacc351275e67116f3a1b038099065ac7650ff6b44474b6'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '3f84e5ed937c4a8094066d3bb7908ec609e06259fe0e8b8e41737fc6bbb99cc3'
+    sha256 'f1a7297b43cf8c31c7872f9f2c6559096952dc12498dc9503ef537f8de53bf55'
     'fr'
   end
 
   language 'gl' do
-    sha256 '77011582c9db4b49e5f42834e586aae2788109d148603de6ed4739bbc2420c5b'
+    sha256 '3df5d978306682302155d664e671b12619661c38caba48822a6b544fc604d583'
     'gl'
   end
 
   language 'it' do
-    sha256 'fe13e2a2db7b1ed1acdb0886855715d756ecab2cdcb6fcea1aeb466591e9e262'
+    sha256 'f62d4dde03035ac44fd96cf747d20e07b1a164e365b259274065abee4ae6c9fe'
     'it'
   end
 
   language 'ja' do
-    sha256 '64f1dfbf4620f17cdc5f1f61e2d881e1b275c8b60dfba3f5d1481c1492857b2b'
+    sha256 'df6d6cdbbbd8b0a83e3cab593f27cce3c3fab4ee8619a7920106b4bbe506f762'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'e118b8756212b1cf1cf9861a74fa1f49d4c698c769fb4b39e30a95070ca84019'
+    sha256 'd713126a5d03d3d5e2a5eb53aa904a0937b88d88a0e3d78f9829357ec5bfc768'
     'nl'
   end
 
   language 'pl' do
-    sha256 '1568bc2d7809ea24ac1e2707738712387961912a782e29a0134890e9c257436c'
+    sha256 'bc677c9ba722a0b252874c84dead36177879962860dfbc8816b8a8b5c277bd5c'
     'pl'
   end
 
   language 'pt' do
-    sha256 'e91cc53ee00a9382043d0f823c59d07b899b37cc62e993d2a7bc379816f1d501'
+    sha256 '79a1265232cebdb7af40395d0029fa062c9beacd1514243a9639837ac289bc89'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '31e151a55f5fdb794e639729cdf63e5e3a6ab77a1bb65b8267a0d956830e18a9'
+    sha256 'e5f805d6e00a22eee146a70a8e14e3cefba68a7fc59f654fbda2296a8d9b2717'
     'ru'
   end
 
   language 'uk' do
-    sha256 '2258d970e4216ff463a0da2b26ac25267a86e731a3aa7a342ee84784cc4bc83d'
+    sha256 '41953a7d11d7f70ddd9fc82c2418a3bb2e89bbddc3678dc10d77641cc98b7015'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '266d890921d9cd96a8e3647cfe50c61cec8582938c486c9ea2961e3a49a73c29'
+    sha256 '0fa633440120c9cfff7cabe1277a26f47a26c0d3a8b137bf14e9f3c1e9203137'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'bb84cba7efc432bd9942f1568424bd021506327e0804fa69a96dcd5fa5f7799a'
+    sha256 '7c050254a0f1552f1f7246b79b87a30afab4e30c3bcb04e72d89ad83b55f4c78'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.