### PR TITLE
Update sketch-beta to 43,38998

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '43,38976'
-  sha256 'f0c0d0dd6b0c72684a158f456af4715f43e0673e669d09f8f5830f15860ecce6'
+  version '43,38998'
+  sha256 '134927c36a4e0f4bcc8ee454a6a75a7fe73f7cdd24f0d35f223509059910a2c7'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '1809b075466d4c7175ea24689a72474e969df56d724721301d59a207691237de'
+          checkpoint: '18c2b4692ca6ac143d48eeb95bed87d1ebf61d1f0eafbf8311918fa3f370e381'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.