### PR TITLE
Update telegram-alpha to 2.91.90980,198

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.90963,197'
-  sha256 '389b02c9619c2a1ae4d0911beee25a4e8942ccd3f5f951607037597479d09252'
+  version '2.91.90980,198'
+  sha256 '2d98aa77fa9f98f9ad83cec9edc842d1b6620530303ea95a8cddbe5239e1d8a0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '4b39738f7d58861a74be3440d212a88b600066dcf0f155f1c008615df97193e9'
+          checkpoint: '57d374c6d2bdf930b277fea581f4339b1d6b9d3757e43214756718f9663e2a72'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.