### PR TITLE
Update opera-developer to 45.0.2545.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '45.0.2539.0'
-  sha256 'd910addce7e5d28e70b274e0ab99e9cc8e47d068060772389d4835745990bf41'
+  version '45.0.2545.0'
+  sha256 '66d487279b6dd77f651eff4da162e560c87e19daec18a4a6a2d1ecfc99c494f1'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.