### PR TITLE
Update vlc-nightly.rb

### DIFF
--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -6,7 +6,7 @@ cask 'vlc-nightly' do
     require 'open-uri'
     base_url = 'https://nightlies.videolan.org/build/macosx-intel/last/'
     file = open(base_url).read.scan(%r{href="([^"]+.dmg)"}).flatten.first
-    "#{base_url}/#{file}"
+    "#{base_url}#{file}"
   end
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Remove unnecessary `/` from `url do`

```
==> Downloading https://nightlies.videolan.org/build/macosx-intel/last//vlc-3.0.0-20170329-0438-git.dmg
```

`base_url` trailing `/` is required #3444.