### PR TITLE
Update toggldesktop-beta to 7.4.31

### DIFF
--- a/Casks/toggldesktop-beta.rb
+++ b/Casks/toggldesktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-beta' do
-  version '7.4.18'
-  sha256 'e0e6a2a44e91fb34fba9d7cb1e3a41a288ec55da9415efae18a83b396ab88287'
+  version '7.4.31'
+  sha256 '7e543bcc3aa9cb4fa40dfb62162b82d661e6b3419d56cfdf1418312aea98c4ce'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: '9aaab086611a52c3a30cd435fc87e6b28e293175b00fc6446e883b4fd9218ade'
+          checkpoint: 'fb9e89f0b331f58d8f61bb41aa5bc546be77e0b299fb2a40f3e1373185feb4a5'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.