### PR TITLE
Update toggldesktop-dev to 7.4.31

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.28'
-  sha256 '5f6a41982790b81bc6266dd6a3758c3d828aeab9ab64599ac6c645ed09792c0f'
+  version '7.4.31'
+  sha256 '7e543bcc3aa9cb4fa40dfb62162b82d661e6b3419d56cfdf1418312aea98c4ce'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'd6f5130a83bbc877d9a78d2ef871430e662e814f3393bd84a697f59ff665710b'
+          checkpoint: '6d8f85663c821c8ce0516ab40e58729fa5354a2c59e06307a5935c15f1e77181'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---
One of the casks should be considered for removal: `toggldesktop-dev.rb` or `toggldesktop-beta.rb`. Both point to the exact same version with same sha256 checksums (https://github.com/caskroom/homebrew-versions/pull/3546).