### PR TITLE
Update telegram-alpha to 2.91.91309,205

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.91166,204'
-  sha256 'ffcc4c5523bc43172113172eeb88a9681cf86ee8e6cb5aa5e9de4cb2a26b19ce'
+  version '2.91.91309,205'
+  sha256 'a5c4e429000bd3cc6f669e88abad6f5df512ca652c1b67c691ce4e36c376469a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '542c5fa86f4ed498efc8c715a5f4c902feeb9339744f0f495cecf576499fbdc3'
+          checkpoint: '6aa2cf52348083c403aa898fe3d21d65d444d3bb58e8e1e691d6783bb49a125f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -5,7 +5,7 @@ cask 'telegram-alpha' do
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6aa2cf52348083c403aa898fe3d21d65d444d3bb58e8e1e691d6783bb49a125f'
+          checkpoint: '24a5788cea508b12bca691827395e4da2cf0ad1ac270859970cb6624824b7098'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.