### PR TITLE
Update firefoxdeveloperedition to 54.0a2

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,34 +1,42 @@
 cask 'firefoxdeveloperedition' do
-  version :latest
-  sha256 :no_check
+  version '54.0a2'
 
   language 'en', default: true do
+    sha256 'b1df02574d0010913192a02d1299fe19585d05081b3431f1ddcba3918de9c7e7'
     'en-US'
   end
 
   language 'ja' do
+    sha256 '9edab5376f2aeca6f0279ee0e5069d427468d918d9eb41f4ee1d8f709a3c6f13'
     'ja-JP-mac'
   end
 
   language 'ru' do
+    sha256 '6b0d5852a13d7281c74d0d696fe4506a1cab6ea83869b2959a09bae0e13ccdd2'
     'ru'
   end
 
   language 'uk' do
+    sha256 'e4724e560ee47b1792c89b65b4bc3684170ece5535046a4c71afef7bc0079f49'
     'uk'
   end
 
   language 'zh-TW' do
+    sha256 '8d4f097b70623786d2ae53e7d055a4aa29249de01e3433d4b71e347e60921c53'
     'zh-TW'
   end
 
   language 'zh' do
+    sha256 '5d460592d4b3170beccaede98997a4ff6a5537a909106852b33ca6415bbf742e'
     'zh-CN'
   end
 
-  url "https://download.mozilla.org/?product=firefox-aurora-latest-#{language == 'en-US' ? 'ssl' : 'l10n'}&os=osx&lang=#{language}"
+  # mozilla.net was verified as official when first introduced to the cask
+  url "https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-aurora#{language != 'en-US' ? '-l10n' : ''}/firefox-#{version}.#{language}.mac.dmg"
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
+
+  auto_updates true
 
   app 'FirefoxDeveloperEdition.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
