### PR TITLE
Update telegram-alpha to 2.92.91400,210

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.91.91309,205'
-  sha256 'a5c4e429000bd3cc6f669e88abad6f5df512ca652c1b67c691ce4e36c376469a'
+  version '2.92.91400,210'
+  sha256 '2dc90d1c51fac017acdf2eccafdade5e145f946c683502d56cb6002e1519cd0c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '24a5788cea508b12bca691827395e4da2cf0ad1ac270859970cb6624824b7098'
+          checkpoint: 'b19e9b3564b831ea4a8eb3556d13e4cbe43087b59c20d9cbbbf578907f252c70'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.