### PR TITLE
Update gpgtools-beta.rb

### DIFF
--- a/Casks/gpgtools-beta.rb
+++ b/Casks/gpgtools-beta.rb
@@ -13,16 +13,6 @@ cask 'gpgtools-beta' do
 
   pkg 'Install.pkg'
 
-  # TODO: remove all ENV variables
-  postflight do
-    system_command '/usr/local/MacGPG2/libexec/fixGpgHome',
-                   args: [
-                           Etc.getpwuid(Process.euid).name,
-                           ENV['GNUPGHOME'] ? ENV['GNUPGHOME'] : Pathname.new(File.expand_path('~')).join('.gnupg'),
-                         ],
-                   sudo: true
-  end
-
   uninstall_postflight do
     %w[gpg gpg2 gpg-agent].map { |exec_name| "/usr/local/bin/#{exec_name}" }.each do |exec|
       File.rm(exec) if File.exist?(exec) && File.readlink(exec).include?('MacGPG2')


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed unneeded `postflight`.

Postflight would cause the install to hang. Only occurs with new installs.

PR for `caskroom/cask` `gpgtools` is [#31765](https://github.com/caskroom/homebrew-cask/pull/31765) but also applies to `gpgtools-beta`.

Fix was for [#29297](https://github.com/caskroom/homebrew-cask/issues/29297), see this [comment.](https://github.com/caskroom/homebrew-cask/issues/29297#issuecomment-290953604)