### PR TITLE
Update airmail-beta to 3.2.3.421,293

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.420,292'
-  sha256 '5847fae6ddbdaff92822f5bc232f46470981f523c6ddfbc580faa13479ffd66b'
+  version '3.2.3.421,293'
+  sha256 :no_check
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'aa310b7986163dd4effec2a64eddff2c9e12fe67a00a002ef3aa233a6b9bf7f8'
+          checkpoint: '19f5eae7776db3c69b95512d2b693448870221f3868874a81647e8ae1736d491'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.