### PR TITLE
Added uninstall postflight for all jetbrains apps

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -10,6 +10,10 @@ cask 'appcode-eap' do
 
   app "AppCode #{version.before_comma} EAP.app"
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'appcode') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Application Support/AppCode#{version.before_comma}",
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.jetbrains.appcode-eap.sfl',

--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -10,6 +10,10 @@ cask 'clion-eap' do
 
   app 'CLion.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Application Support/CLion#{version.after_comma.major_minor}",
                 "~/Library/Caches/CLion#{version.after_comma.major_minor}",

--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -10,6 +10,10 @@ cask 'datagrip-eap' do
 
   app "DataGrip #{version.before_comma} EAP.app"
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'datagrip') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Application Support/DataGrip#{version.before_comma}",
                 "~/Library/Caches/DataGrip#{version.before_comma}",

--- a/Casks/gogland-eap.rb
+++ b/Casks/gogland-eap.rb
@@ -10,6 +10,10 @@ cask 'gogland-eap' do
 
   app "Gogland #{version.before_comma} EAP.app"
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'Gogland') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Preferences/Gogland#{version.major_minor}",
                 "~/Library/Application Support/Gogland#{version.major_minor}",

--- a/Casks/intellij-idea-ce-eap-nextversion.rb
+++ b/Casks/intellij-idea-ce-eap-nextversion.rb
@@ -10,7 +10,9 @@ cask 'intellij-idea-ce-eap-nextversion' do
 
   app 'IntelliJ IDEA #{version.before_comma} CE EAP.app'
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -11,7 +11,9 @@ cask 'intellij-idea-ce-eap' do
 
   app 'IntelliJ IDEA CE.app'
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/IdeaIC#{version.major_minor}",

--- a/Casks/intellij-idea-eap-nextversion.rb
+++ b/Casks/intellij-idea-eap-nextversion.rb
@@ -10,7 +10,9 @@ cask 'intellij-idea-eap-nextversion' do
 
   app "IntelliJ IDEA #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/IntelliJIdea#{version.major_minor}",

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -10,7 +10,9 @@ cask 'intellij-idea-eap' do
 
   app 'IntelliJ IDEA.app'
 
-  uninstall delete: '/usr/local/bin/idea'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",

--- a/Casks/intellij-idea20161.rb
+++ b/Casks/intellij-idea20161.rb
@@ -10,6 +10,10 @@ cask 'intellij-idea20161' do
 
   app 'IntelliJ IDEA.app'
 
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",

--- a/Casks/phpstorm-eap.rb
+++ b/Casks/phpstorm-eap.rb
@@ -10,7 +10,9 @@ cask 'phpstorm-eap' do
 
   app "PhpStorm #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/pstorm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'pstorm') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/PhpStorm#{version.major_minor}",

--- a/Casks/pycharm-ce-eap.rb
+++ b/Casks/pycharm-ce-eap.rb
@@ -11,7 +11,9 @@ cask 'pycharm-ce-eap' do
 
   app "PyCharm CE #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/charm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/PyCharm#{version.before_comma.major_minor}",

--- a/Casks/pycharm-eap.rb
+++ b/Casks/pycharm-eap.rb
@@ -10,7 +10,9 @@ cask 'pycharm-eap' do
 
   app "PyCharm #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/charm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'charm') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/PyCharm#{version.before_comma}",

--- a/Casks/rubymine-eap.rb
+++ b/Casks/rubymine-eap.rb
@@ -10,7 +10,9 @@ cask 'rubymine-eap' do
 
   app 'RubyMine EAP.app'
 
-  uninstall delete: '/usr/local/bin/mine'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'mine') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Preferences/RubyMine#{version.major_minor}",

--- a/Casks/webstorm-eap.rb
+++ b/Casks/webstorm-eap.rb
@@ -10,7 +10,9 @@ cask 'webstorm-eap' do
 
   app "WebStorm #{version.before_comma} EAP.app"
 
-  uninstall delete: '/usr/local/bin/wstorm'
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'wstorm') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
 
   zap delete: [
                 "~/Library/Application Support/WebStorm#{version.major_minor}",


### PR DESCRIPTION
Updated appcode-eap.rb
Updated clion-eap.rb
Updated datagrip-eap.rb
Updated gogland-eap.rb
Updated intellij-idea-ce-eap-nextversion.rb
Updated intellij-idea-ce-eap.rb
Updated intellij-idea-eap-nextversion.rb
Updated intellij-idea-eap.rb
Updated intellij-idea20161.rb
Updated phpstorm-eap.rb
Updated pycharm-ce-eap.rb
Updated pycharm-eap.rb
Updated rubymine-eap.rb
Updated webstorm-eap.rb

This is in addition to change on Cask PR 31870 [hombrew-cask#31870](https://github.com/caskroom/homebrew-cask/pull/31870)

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.