### PR TITLE
Update firefox-beta to 53.0b9

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '53.0b8'
+  version '53.0b9'
 
   language 'de' do
-    sha256 'ab87322c20ae0c0a1abedfb74ba11e756b2865894cd8d87da6b13ab08423fdcc'
+    sha256 '851dc69c4d1cd821b3efcade9445c26049325e976bb6fea72dae85d7acdc9e29'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '2f56b7c9f4a679cd92522e141115be45f81bbda448547b70b808ec29f3991778'
+    sha256 '729c6f316be4966f098484b6c358746ab085f7e3187b3eb281b08b37e72c8964'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '85fa2aea9c93f01bcd4195fd0e8a56c5e3a41361032ee75c7df6211cfe38c0b1'
+    sha256 'c9e4ec074523a965834088873505b30efe2a0706017d6ddaa1f02a9b991f4f9f'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '2cb0d45d11b687a80c5ae20d922360f2105a1a39face479965860ae5e0338b82'
+    sha256 'fb65aac8135238150022c14a89f5e41d320ee05d47b4c03ae66da4c4bcabf182'
     'fr'
   end
 
   language 'gl' do
-    sha256 'f9df40bf840b8d194d974c746cbc2a57d7c76418d67068eac933f73d4faf7533'
+    sha256 '69478735189bc8093f9154970d9edfc92ce267057a8008a714ef21d301317e3a'
     'gl'
   end
 
   language 'it' do
-    sha256 '4fdc1805eefca441fa35eeea48c6686e649e994f6077d31511d953b5d36c084f'
+    sha256 '577e7cb1f968162137ee003c923238ef18e1d792e365cccad1a151436c9ef09e'
     'it'
   end
 
   language 'ja' do
-    sha256 'd1034df4f7418bf07ff35f2abce71a821a6b2f98c1caaa587965112bd973ea6b'
+    sha256 '753af4f2de40fac32039f67f1d7eb569747f72d68576631ca6b0c143f4d5ef88'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '77b9c2690c76d0491e523e7e2c15e0e2e9c1620613736740201c7dfe86efcf48'
+    sha256 '06c1a51aca9bad29506d8f6a9cd6e3d0e1b36bf7f07e4c7f105aa79b912b3ce7'
     'nl'
   end
 
   language 'pl' do
-    sha256 '7ea2aea6899a26a87a8f7653830947c7ec7668be792210a43f53cef5d107fc54'
+    sha256 '2b466a5396dfb94c95e804a53a17980cebd19086e00b3f08cd7b619d320354ce'
     'pl'
   end
 
   language 'pt' do
-    sha256 '87fc0fc99b71a016fcc6edf724aa18e4b8cae6beec1d4bec28ee0d8ec5d0d587'
+    sha256 '49c49c4c8243190d704d70f1bea61ce5a9520548522417d1bee79dca6b114a17'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '33e14d2a9469d7665f559873008e838fcc70d05a09d02fc5337bfb9e01993738'
+    sha256 '85866d1b32456c112ee3c19fcd774547b4d6edf4c1e24180e62244da35b7daa5'
     'ru'
   end
 
   language 'uk' do
-    sha256 'ab42da4506a5e174b6b92c8251e64233dc5a8b08c36e9dc3640e798f172e226e'
+    sha256 '34eb6b58f7311caa67821a43ecdf9ee6b863158865eedce8c5a8055258206157'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '137f878d0318e670c0705b755cfe38561ab4c687d683d96ad9ef5492be857c21'
+    sha256 '6de1d514b0b52e7743082f777239b6eb45a6bc1b48d14b97c93e318d19684ac4'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '45ee9d3e64203f3c1587967e7d57a39396fc1cd7fc96a7e31ee75ce883a678f1'
+    sha256 '72a63fecbe19c51a44a48a9e3f147ea09f06124a74f1c8c93a00f20fe5e6ec4a'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.