### PR TITLE
Remove binary - virtualbox-beta

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -14,8 +14,6 @@ cask 'virtualbox-beta' do
   auto_updates true
 
   pkg 'VirtualBox.pkg'
-  binary '/Applications/VirtualBox.app/Contents/MacOS/VBoxManage'
-  binary '/Applications/VirtualBox.app/Contents/MacOS/VBoxHeadless'
 
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Removed `binary` stanzas. Virtualbox installer creates them automatically.

Removed in caskroom with [#16072](https://github.com/caskroom/homebrew-cask/pull/16072)

```
Error: It seems there is already a Binary at '/usr/local/bin/VBoxManage'; not linking.
```