### PR TITLE
Update android-studio-canary to 2.4.0.3,171.3870562

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.4.0.2,171.3829324'
-  sha256 '4d135ac753e4aec34173f442c91e85167e1505a1c3488998101f276548dc1fd3'
+  version '2.4.0.3,171.3870562'
+  sha256 '41adf1d98060f6a87c3187947894140a33920eb094e537a41cfa4285a58c9ac6'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.