### PR TITLE
Update docker-beta to 17.04.0-ce-rc2-mac6,16165

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '17.03.1-ce-rc1-mac3,15924'
-  sha256 '95a6c3b7531fb7778c722425a002f16709f8ddd3731b5725c6aa5fbd3e2e5c4d'
+  version '17.04.0-ce-rc2-mac6,16165'
+  sha256 '57f41e914c180d17449f6872d66df7a5a7555c418ce32ce88e13e10462cbcd75'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
-  appcast 'https://download.docker.com/mac/beta/appcast.xml',
-          checkpoint: 'b65d52e05656e04d71dc0712410a4906d8ffbd76abdd54fa1766ece6aae326cd'
+  appcast 'https://download.docker.com/mac/edge/appcast.xml',
+          checkpoint: '078f74fdfcda6575ef06024f0a265057ca3241612603c6a38b4f2f27b0b538a9'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.