### PR TITLE
Update telegram-alpha to 2.92.91502,222

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.92.91466,217'
-  sha256 'f2b6f613f19db8c0b2aa48202fab40aa4966fd0a6a609f297f0205a1b9d710ce'
+  version '2.92.91502,222'
+  sha256 '4f60e8428c33cf9a81cf3e0b87a6aa040f05327523a852ce4c490971190bc028'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '54fcfde73f87c7198becb3830c900abff51a5ccbfca0d4eb4d174a321d147e76'
+          checkpoint: '56a97dd88eefed4ef9cf2677e51b7b13ee8d671c9db8814592354a0e3b8c2560'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.