### PR TITLE
Update safari-technology-preview to 27

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,8 +1,8 @@
 cask 'safari-technology-preview' do
-  version '26'
-  sha256 '5d612dcca7da026bcbd8deb3aee6fdbf3de0b05a42d47e8d09c935166d306214'
+  version '27'
+  sha256 '8165553bac747038536aef1ea88cfaa3fbc6204d8de0e38a8b43ef5b80ad25c2'
 
-  url 'https://secure-appldnld.apple.com/STP/091-01778-20170322-AB2EC7B2-0DBF-11E7-93C5-AB1400A0ED6C/SafariTechnologyPreview.dmg'
+  url 'https://secure-appldnld.apple.com/STP/091-05448-20170405-722FEA9C-18CB-11E7-9B3A-6EE000A0ED6C/SafariTechnologyPreview.dmg'
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.