### PR TITLE
Move back to latest version for Firefox Developer Edition

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,42 +1,34 @@
 cask 'firefoxdeveloperedition' do
-  version '54.0a2'
+  version :latest
+  sha256 :no_check
 
   language 'en', default: true do
-    sha256 '910bde849efba3e0064997d357661ba6b71820533b095886521b770e30b09bbb'
     'en-US'
   end
 
   language 'ja' do
-    sha256 'ae7a9f27cfb0e6e1aacdef07b6bec183247bc2263bc89e9b1fef266dc000910f'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 '3888bc01b1b5a8bf6516b5d4b26630dfe2161d1c4f883d4a5b73cf8e73aeaa80'
     'ru'
   end
 
   language 'uk' do
-    sha256 '2c2d016385412aa4a3d1e01b9366d87c066672a5609f012951372582406c0ef5'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '6d99c4f763506b3272e07dcd7126582eabaa56968c80ceb83ae8a046f28d006a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '6e170e212e358095d590ccce1700a2238368f35234b9518abcf143cfa4f2e29a'
     'zh-CN'
   end
 
-  # mozilla.net was verified as official when first introduced to the cask
-  url "https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-aurora#{language != 'en-US' ? '-l10n' : ''}/firefox-#{version}.#{language}.mac.dmg"
+  url "https://download.mozilla.org/?product=firefox-aurora-latest-#{language == 'en-US' ? 'ssl' : 'l10n'}&os=osx&lang=#{language}"
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
-
-  auto_updates true
 
   app 'FirefoxDeveloperEdition.app'
 end


### PR DESCRIPTION
... as before ecc54919b.

This cask has recently been switched from latest to specific versions and hash, and since then has undergone several updates. I have just come to use it and I found the hash is already outdated:
```
==> Downloading https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-aurora/firefox-54.0a2.en-US.mac.dmg
######################################################################## 100.0%
==> Verifying checksum for Cask firefoxdeveloperedition
==> Note: running "brew update" may fix sha256 checksum errors
Error: sha256 mismatch
Expected: 910bde849efba3e0064997d357661ba6b71820533b095886521b770e30b09bbb
Actual: e0f4846fbfc02682eff27e318ef43eb6fab6168eba213e41b1382d8b9bc89b85
File: /Users/luca/Library/Caches/Homebrew/Cask/firefoxdeveloperedition--54.0a2.dmg
To retry an incomplete download, remove the file above.
```
Hence I propose to revert back to latest without hash.

----

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.