### PR TITLE
Update clion-eap to 2017.1.1,171.4073.32

### DIFF
--- a/Casks/clion-eap.rb
+++ b/Casks/clion-eap.rb
@@ -1,23 +1,23 @@
 cask 'clion-eap' do
-  version 'RC2,2017.1'
-  sha256 '5675cf498abe6f8331719412d7511a9c469591c78a19cc30e32ffaa17c2e5f9b'
+  version '2017.1.1,171.4073.32'
+  sha256 'a3352db3b0651cf489a06b7aecdf008e06701b3a608d24b960bb3c05cad0e0d6'
 
-  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/cpp/CLion-#{version.after_comma}.dmg"
   name 'CLion EAP'
   homepage 'https://confluence.jetbrains.com/display/CLION/Early+Access+Program'
 
   conflicts_with cask: 'clion'
 
-  app 'CLion.app'
+  app "CLion #{version.before_comma} EAP.app"
 
   uninstall_postflight do
     ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'clion') }.each { |path| File.delete(path) if File.exist?(path) }
   end
 
   zap delete: [
-                "~/Library/Application Support/CLion#{version.after_comma.major_minor}",
-                "~/Library/Caches/CLion#{version.after_comma.major_minor}",
-                "~/Library/Logs/CLion#{version.after_comma.major_minor}",
-                "~/Library/Preferences/CLion#{version.after_comma.major_minor}",
+                "~/Library/Application Support/CLion#{version.major_minor}",
+                "~/Library/Caches/CLion#{version.major_minor}",
+                "~/Library/Logs/CLion#{version.major_minor}",
+                "~/Library/Preferences/CLion#{version.major_minor}",
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.