### PR TITLE
Update iterm2-beta to 3.1.beta.3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,6 +1,6 @@
 cask 'iterm2-beta' do
-  version '3.1.beta.2'
-  sha256 '734c9fe31761f5da993458e94d198f30921053bde0a0ef1bbedcdfdab07a7114'
+  version '3.1.beta.3'
+  sha256 'f8a49c5160c9a48d1d1f5f4eb12092cb09181bcc327ef70655a65251ce0d253e'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   name 'iTerm2'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.