### PR TITLE
Update opera-beta to 45.0.2552.89

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '44.0.2510.849'
-  sha256 '690776a4921c142dcd77b9d607ca649652f5c42ff4568926414d5c6d47b064d9'
+  version '45.0.2552.89'
+  sha256 '4003fd26ab33289ea3da4c8ec76c680531198b2f8730034dbb41adf29fc5d943'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.