### PR TITLE
Update dropbox-beta to 24.3.14

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,11 +1,9 @@
 cask 'dropbox-beta' do
-  version '24.3.13'
-  sha256 '68f5512fbca73da5b8048332b8eb8b4b851538d5ef5bc2398f763c2a72834414'
+  version '24.3.14'
+  sha256 '1467268dc36d19dd8480d3f08a4de2a39a126acbc0cfcfdfe86a2a64cc82a91b'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
-  appcast 'https://www.dropbox.com/release_notes/rss.xml',
-          checkpoint: '2794637a8b028d903f0d27432291dce968886923a86325994156cf1206edec80'
   name 'Dropbox'
   homepage 'https://www.dropboxforum.com/t5/Desktop-client-builds/bd-p/101003016'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.