### PR TITLE
Update datagrip-eap to 2017.1,171.3780.53

### DIFF
--- a/Casks/datagrip-eap.rb
+++ b/Casks/datagrip-eap.rb
@@ -8,7 +8,7 @@ cask 'datagrip-eap' do
 
   conflicts_with cask: 'datagrip'
 
-  app "DataGrip #{version.before_comma} EAP.app"
+  app 'DataGrip.app'
 
   uninstall_postflight do
     ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'datagrip') }.each { |path| File.delete(path) if File.exist?(path) }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.