### PR TITLE
Update virtualbox-beta to 5.1.19-114236

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -3,11 +3,11 @@ cask 'virtualbox-beta' do
     version '4.3.32-103443'
     sha256 '08defbf310b7ba5852fa8dd951438bb9b1528bb1544211568861986110e807f7'
   else
-    version '5.1.10,112026'
-    sha256 '3500f07be9f5e27a08c00cc626981230bdaf639f6fad0b82ecf731a0580cccef'
+    version '5.1.19-114236'
+    sha256 '977e1af4911e81074ebe95cfe3bad4054431b2d5d66c344efd6905afbf2125de'
   end
 
-  url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
+  url "https://www.virtualbox.org/download/testcase/VirtualBox-#{version}-OSX.dmg"
   name 'Oracle VirtualBox'
   homepage 'https://www.virtualbox.org/wiki/Testbuilds'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.