### PR TITLE
Update android-studio-canary to 2.4.0.4,171.3883974

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.4.0.3,171.3870562'
-  sha256 '41adf1d98060f6a87c3187947894140a33920eb094e537a41cfa4285a58c9ac6'
+  version '2.4.0.4,171.3883974'
+  sha256 'c543f623aa24ace236aba477ccc16a915dfda5c90d1e26d23dc0e98e4a406c08'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.