### PR TITLE
Update toggldesktop-dev to 7.4.32

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.31'
-  sha256 '7e543bcc3aa9cb4fa40dfb62162b82d661e6b3419d56cfdf1418312aea98c4ce'
+  version '7.4.32'
+  sha256 '32eee4a7b143f0c498c07184e07171030f93ebd08fdd0331c1064f7a6caba08c'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '6d8f85663c821c8ce0516ab40e58729fa5354a2c59e06307a5935c15f1e77181'
+          checkpoint: '2c4cb072aa601cbb6e7d4c9027748b7f0f4a3ff2c1a56057b1be879ef787dbe4'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.