### PR TITLE
Update telegram-alpha to 2.92.91713,234

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.92.91696,231'
-  sha256 'b66d4b49dec4de74a22ec940fd5a0b9c304aaa9ab6d1217c7923279113012e35'
+  version '2.92.91713,234'
+  sha256 '680d04310c7abf8e5ee6cef5245eabdc05e052c08f5f9311659060492854d545'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c95e2464741b0be7902abe1b7f75ba2aa5e2e2b75b4b65c8b4d9476a9e458829'
+          checkpoint: '002bcbdfe7cec42e85bcccb28d7035c1d622f13fa2f6e24f3a6a890f814232e2'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.