### PR TITLE
Update tap migrations - maltego

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -11,7 +11,6 @@
   "flash-player-debugger": "caskroom/cask",
   "intellij-idea-ce": "caskroom/cask",
   "macx-dvd-ripper-pro": "caskroom/cask",
-  "maltego-chlorine-ce": "caskroom/cask",
   "multimarkdown-composer-pro": "caskroom/cask",
   "opera-neon": "caskroom/cask",
   "pdfpenpro": "caskroom/cask",


### PR DESCRIPTION
I'm not sure if this should be deleted or renamed as `maltego-chlorine-ce` is now [`maltego-ce`](https://github.com/caskroom/homebrew-cask/blob/master/Casks/maltego-ce.rb)?