### PR TITLE
Update opera-beta to 45.0.2552.225

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '45.0.2552.89'
-  sha256 '4003fd26ab33289ea3da4c8ec76c680531198b2f8730034dbb41adf29fc5d943'
+  version '45.0.2552.225'
+  sha256 '34fdb0bb236260d2ca690645da42361f80e9539f8b861881eb0c72cc7fec231a'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.