### PR TITLE
Update tower-beta to 2.6.2-350,350-b7d5b8fb

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.6.2-349,349-a254b81d'
-  sha256 '7232fda68eafcb1d8079e98241b60f45671dda084af7a37392d326306c7a2e03'
+  version '2.6.2-350,350-b7d5b8fb'
+  sha256 'a83de3400c8b333002d1e6b7d5bc3a767f1205061af585c5072da974e245d833'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: '009963eb3971cba981274db08c9972c950131eeecfd4943ea8d4d8b04fb0f172'
+          checkpoint: 'e9e290f18100da28b50463bcc2d3a5045edfcbcdd0ab2d1a1974c5f5a1517337'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.