### PR TITLE
Update IntelliJ IDEA EAP to 2017.1.2 build 171.4249.4

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -1,15 +1,15 @@
 cask 'intellij-idea-ce-eap' do
-  version '2016.3.6,163.15188.11'
-  sha256 '86be1e9bd529e28b851e311abc9b9bac8be1770f32738f2385276644c1b4a6e3'
+  version '2017.1.2,171.4249.4'
+  sha256 '3ad5bea53b8d75e99330afd2b4401a66e31aa3af381cf1ed8e36b605902f263b'
 
-  url "https://download.jetbrains.com/idea/ideaIC-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIC-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Community Edition EAP'
   name 'IntelliJ IDEA CE EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true
 
-  app 'IntelliJ IDEA CE.app'
+  app "IntelliJ IDEA #{version.before_comma} CE EAP.app"
 
   uninstall_postflight do
     ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }

--- a/Casks/intellij-idea-eap.rb
+++ b/Casks/intellij-idea-eap.rb
@@ -1,14 +1,14 @@
 cask 'intellij-idea-eap' do
-  version '2016.3.6,163.15188.11'
-  sha256 '69a7af4773d03927cac5b3427e09dee7a3cae46bf3b7e57e7abbe6d6fe6f72ea'
+  version '2017.1.2,171.4249.4'
+  sha256 '2a094a9655de0d845c38af2b10b1f446771063fc1114877e3a9fde69e782f175'
 
-  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}.dmg"
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.after_comma}.dmg"
   name 'IntelliJ IDEA Ultimate EAP'
   homepage "https://confluence.jetbrains.com/display/IDEADEV/IDEA+#{version.major_minor}+EAP"
 
   auto_updates true
 
-  app 'IntelliJ IDEA.app'
+  app "IntelliJ IDEA #{version.before_comma} EAP.app"
 
   uninstall_postflight do
     ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
