### PR TITLE
Rename docker-beta to docker-edge

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,11 +1,11 @@
-cask 'docker-beta' do
+cask 'docker-edge' do
   version '17.04.0-ce-mac7,16352'
   sha256 '3b943c031317dce773393accdb82396355837d23520ef9f28d96c38e0ab05c09'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
           checkpoint: 'd4c29f943d9857ad856903086f24b21a1d8bac4a2b19759565c08c07b1c25608'
-  name 'Docker for Mac Beta'
+  name 'Docker Community Edition for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'
 
   auto_updates true


### PR DESCRIPTION
To follow docker team naming convention.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
