### PR TITLE
Update docker-beta to 17.05.0-ce-rc1-mac8,16582

### DIFF
--- a/Casks/docker-beta.rb
+++ b/Casks/docker-beta.rb
@@ -1,10 +1,10 @@
 cask 'docker-beta' do
-  version '17.04.0-ce-mac7,16352'
-  sha256 '3b943c031317dce773393accdb82396355837d23520ef9f28d96c38e0ab05c09'
+  version '17.05.0-ce-rc1-mac8,16582'
+  sha256 '82fe284fd4022778324f1030b1675ba827e2ec95f466663fa0645a1b112c43c3'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: 'd4c29f943d9857ad856903086f24b21a1d8bac4a2b19759565c08c07b1c25608'
+          checkpoint: '4458e68fcf0bb0d80d6d9f64d042d919556690a9bf1fd70e78236b767d27fe4f'
   name 'Docker for Mac Beta'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.