### PR TITLE
Update telegram-alpha to 2.94.92864,238

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.92.91713,234'
-  sha256 '680d04310c7abf8e5ee6cef5245eabdc05e052c08f5f9311659060492854d545'
+  version '2.94.92864,238'
+  sha256 '5534106cf4424e4affccd4c41b41e57d84ad35adcb71d78541cbe8f8bf445d57'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '002bcbdfe7cec42e85bcccb28d7035c1d622f13fa2f6e24f3a6a890f814232e2'
+          checkpoint: '9e7fe555d238ca42e5e70d1d5c36786202bcdba6f0609928979a215ef3d757cc'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.