### PR TITLE
Update vivaldi-snapshot to 1.9.811.13

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.9.804.3'
-  sha256 '536fb0a7fb581ed3855e9e59ab0825f47b5538b9df6d19c468775d50ef9c1838'
+  version '1.9.811.13'
+  sha256 '50621f67e66e243179d7be1bf84f29eb7be42766f33e2a15b42fd9bb74bb42aa'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c80c0682afc0636241d400fa3dae4139383a8c3daaf4b7c5aea449f1e5adfafc'
+          checkpoint: 'bb2d30b9837d3b432c9a4adb43fc84dd14db88ddd7c9b8503dc459230d8ab7a9'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.