### PR TITLE
Update wine-staging to 2.5

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '2.4-3'
-  sha256 'faf391159a4826ed489ba53150df8440ecbc9e7f88aea89791f43c4cea2bf31d'
+  version '2.5'
+  sha256 'c7a9819fc652c8c0ce0f64f0b0e0dfad8807bb438a9ebb58b7ea8daf396e3487'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.