### PR TITLE
Update atom-beta to 1.17.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.17.0-beta1'
-  sha256 '456273a318ccbeb032c75968310f146adf7860296207919f3cfe76fd3f5cb549'
+  version '1.17.0-beta2'
+  sha256 '0b9438ce3d360a45227be96ca2eabc3d61df9229bbb2016066b04e6ae85fe9c6'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '5840ffd23a35ab573b7b2640930a0e1fad098bc818b0674d1414ea9164c1dfa8'
+          checkpoint: 'b24309cfa479cddedc02d6763cfe658a3c2ef795b1e4e16cc21d4458ebbd6eba'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.