### PR TITLE
Update charles-applejava-beta to 4.1.1b1

### DIFF
--- a/Casks/charles-applejava-beta.rb
+++ b/Casks/charles-applejava-beta.rb
@@ -1,8 +1,8 @@
 cask 'charles-applejava-beta' do
-  version '3.11.6b3'
-  sha256 '2f005c976fd4776835122e73349df65121bc6e3b3f775e395c855b3b14e9888b'
+  version '4.1.1b1'
+  sha256 '37a3b99ca83f799ba53caf5f634bcf45401753389557bde9fe6f9372f1b44d41'
 
-  url "https://www.charlesproxy.com/assets/release/#{version.gsub(%r{b\d$}, '')}/charles-proxy-#{version}-applejava.dmg"
+  url "https://www.charlesproxy.com/assets/release/#{version.gsub(%r{b\d$}, '')}/charles-proxy-#{version}.dmg"
   name 'Charles'
   homepage 'https://www.charlesproxy.com/download/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.