### PR TITLE
Update wimoweh-beta to 1.1.58.BETA

### DIFF
--- a/Casks/wimoweh-beta.rb
+++ b/Casks/wimoweh-beta.rb
@@ -2,7 +2,7 @@ cask 'wimoweh-beta' do
   version '1.1.58.BETA'
   sha256 '4c8bd162b78e85018583e46b94eaa81b66d46668918f96fc1049d9bad580fd49'
 
-  url "https://www.serialangels.co.uk/sa-content/uploads/2015/08/Wimoweh.#{version}_.zip"
+  url "https://www.serialangels.co.uk/sa-content/uploads/2016/04/Wimoweh.#{version}_.zip"
   name 'Wimoweh'
   homepage 'http://www.serialangels.co.uk/index.php/wimoweh/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.