### PR TITLE
Update emacs-pretest to 25.2-rc2

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,10 +1,10 @@
 cask 'emacs-pretest' do
-  version '25.1.90'
-  sha256 '095781645fc3445997cd8fb8732ebe90e60afac8db8f8ef62722152ed4120188'
+  version '25.2-rc2'
+  sha256 '1f5cc002a706915551d406f9bd465229fee749538a54f10fc52b27add597304d'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: '4da05813d4719aad21898361951b09648cdb5ec8223f0e6ec91c4bb822b5a0e9'
+          checkpoint: 'ecd9fa682e6f59e932c2a7c3c94d48c81719ec700ef110de27499d569bf1e4bc'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.