### PR TITLE
Update clementine-rc to 1.3.0,rc1

### DIFF
--- a/Casks/clementine-rc.rb
+++ b/Casks/clementine-rc.rb
@@ -1,11 +1,11 @@
 cask 'clementine-rc' do
-  version '1.3.1'
-  sha256 '825aa66996237e1d3ea2723b24188ead203f298d0bec89f4c3bc6582d9e63e3a'
+  version '1.3.0,rc1'
+  sha256 'dd578a53c7fd47c89ade55eae224b5390590a32de982479ecf73e738d6620249'
 
   # github.com/clementine-player/Clementine was verified as official when first introduced to the cask
-  url "https://github.com/clementine-player/Clementine/releases/download/#{version}/clementine-#{version}.dmg"
+  url "https://github.com/clementine-player/Clementine/releases/download/#{version.major_minor}#{version.after_comma}/clementine-#{version.major_minor_patch}#{version.after_comma}.dmg"
   appcast 'https://github.com/clementine-player/Clementine/releases.atom',
-          checkpoint: '4a73a16fbd870e168e0ade5d7680dd1382c59b531ac2969a9868974eea70bbcb'
+          checkpoint: 'f2e34fdf3d07c9437f30a4119e66d57f6b4dc72c3782e695330a55ab1b865356'
   name 'Clementine'
   homepage 'https://www.clementine-player.org/'
 


### PR DESCRIPTION
- Reason for Downgrade is that 1.3.0rc1 is actually different version compare to the current release version 1.3.1
- If we are going to have 1.3.1 then there is no reason to have this cask in homebrew-versions as the cask in homebrew-cask is also install version 1.3.1

Ref#: [clementine.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/clementine.rb)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.