### PR TITLE
Update earlybird to 54.0a2

### DIFF
--- a/Casks/earlybird.rb
+++ b/Casks/earlybird.rb
@@ -1,5 +1,5 @@
 cask 'earlybird' do
-  version '52.0a2'
+  version '54.0a2'
   sha256 :no_check # required as upstream package is updated in-placea
 
   url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-aurora/thunderbird-#{version}.en-US.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.