### PR TITLE
Update emacs-nightly to 2017-04-14_01-41-06-96644ed496cfc36ef886c401250203c57d77ab75

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2017-01-18_01-46-59-dbb29d7eb428dd53617d31a9cc159d889deb1e8e'
-  sha256 '4ef2851bb60f0874880c8f92033b9cb34c962137ef48ce0d6270be3e9142cb61'
+  version '2017-04-14_01-41-06-96644ed496cfc36ef886c401250203c57d77ab75'
+  sha256 '92437d6d7efddd9eda3fa27c827deeee831627521cfd3864b44babcf50995612'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '1a744938a3574eb21a294c378f920066cfbed9d28d417f6718e0ffd1b2fe4e60'
+          checkpoint: '7fc10734e00e7c404d48fa7005bcf8bd43c17346c1d28ef01bf7fb500cb1d45a'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.