### PR TITLE
gpgtools-beta remove `uninstall delete: .app`

### DIFF
--- a/Casks/gpgtools-beta.rb
+++ b/Casks/gpgtools-beta.rb
@@ -48,8 +48,6 @@ cask 'gpgtools-beta' do
                          '/private/etc/manpaths.d/MacGPG2',
                          '/private/tmp/gpg-agent',
                          '/Library/PreferencePanes/GPGPreferences.prefPane',
-                         '/Applications/GPG Keychain Access.app',
-                         '/Applications/GPG Keychain.app',
                          '/Library/Application Support/GPGTools',
                          '/Library/Frameworks/Libmacgpg.framework',
                        ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/30801