### PR TITLE
Adobe Lightroom5 remove `uninstall delete: .app`

### DIFF
--- a/Casks/adobe-photoshop-lightroom571.rb
+++ b/Casks/adobe-photoshop-lightroom571.rb
@@ -9,8 +9,7 @@ cask 'adobe-photoshop-lightroom571' do
   pkg "Adobe Photoshop Lightroom #{version.major}.pkg", allow_untrusted: true
 
   uninstall pkgutil: "com.adobe.Lightroom#{version.major}",
-            quit:    "com.adobe.Lightroom#{version.major}",
-            delete:  "/Applications/Adobe Photoshop Lightroom #{version.major}.app"
+            quit:    "com.adobe.Lightroom#{version.major}"
 
   zap       delete: [
                       '~/Library/Application Support/Adobe/Lightroom',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/30801