### PR TITLE
Update dropbox-beta to 25.3.19

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '24.3.15'
-  sha256 '9bd33b619b85fa3d73bf5a30413f4127141c2fdf10c88dc3773900c6640c483d'
+  version '25.3.19'
+  sha256 'd02860407074fdb020657701c1abd80590702a62daa683a0412f9cbc6d1a1e97'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.