### PR TITLE
Update dropbox-beta to 25.3.20

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '25.3.19'
-  sha256 'd02860407074fdb020657701c1abd80590702a62daa683a0412f9cbc6d1a1e97'
+  version '25.3.20'
+  sha256 'fc5a9d69132ba72c9ca610eed7141de173be4a04771928e0571efc1ea641c27f'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.