### PR TITLE
Update atom-beta to 1.17.0-beta3

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.17.0-beta2'
-  sha256 '0b9438ce3d360a45227be96ca2eabc3d61df9229bbb2016066b04e6ae85fe9c6'
+  version '1.17.0-beta3'
+  sha256 'dc524bc482dd04683c84f59bb670a8e306c6eb9a9fe2c0cf78226bf5d28ab1a9'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: 'b24309cfa479cddedc02d6763cfe658a3c2ef795b1e4e16cc21d4458ebbd6eba'
+          checkpoint: '784f2ba61f3529295df63410ba87cd4a99fdff542efe06e52f3251f0e94491e3'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.