### PR TITLE
Update vivaldi-snapshot to 1.9.818.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.9.811.13'
-  sha256 '50621f67e66e243179d7be1bf84f29eb7be42766f33e2a15b42fd9bb74bb42aa'
+  version '1.9.818.3'
+  sha256 'e2a4ab91d7642ee6419d32610f072ca93869a55138f16e44b88ed884df6c22cc'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'bb2d30b9837d3b432c9a4adb43fc84dd14db88ddd7c9b8503dc459230d8ab7a9'
+          checkpoint: 'e77b491a0effa305013064a926af91acccbfd86c4fd64331276e2da0fbede405'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.