### PR TITLE
Update opera-developer to 46.0.2567.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '46.0.2556.0'
-  sha256 'b994e5abf24967b11dfb570ec6b5154f08ac4df49c5e70ee42f750ff44d72ca6'
+  version '46.0.2567.0'
+  sha256 '60bb547ab91487885f9bf36529a85e72ed95c6d1b55ea6382ec095a6ab6582d1'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.