### PR TITLE
Update virtualbox-beta to 5.1.21-114652

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -1,11 +1,6 @@
 cask 'virtualbox-beta' do
-  if MacOS.version <= :lion
-    version '4.3.32-103443'
-    sha256 '08defbf310b7ba5852fa8dd951438bb9b1528bb1544211568861986110e807f7'
-  else
-    version '5.1.19-114236'
-    sha256 '977e1af4911e81074ebe95cfe3bad4054431b2d5d66c344efd6905afbf2125de'
-  end
+  version '5.1.21-114652'
+  sha256 '508c260334c20e31c27de5a04e2a60b5523deb96ce927cda797dd93872641d5f'
 
   url "https://www.virtualbox.org/download/testcase/VirtualBox-#{version}-OSX.dmg"
   name 'Oracle VirtualBox'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Remove `lion` support.

https://github.com/caskroom/homebrew-cask/issues/32560