### PR TITLE
Update kodi-development to 20170418-5066f8f

### DIFF
--- a/Casks/kodi-development.rb
+++ b/Casks/kodi-development.rb
@@ -1,6 +1,6 @@
 cask 'kodi-development' do
-  version '20170410-7f7f7e8'
-  sha256 '5fa8d2861514fa9e9f6f7870b5490d393bdc0abf368feac31a7224543221977d'
+  version '20170418-5066f8f'
+  sha256 '989c6373ec99089d5a779411b64ecba652bff0a5ce8ee7ac20fc0c1445c31e7e'
 
   url "http://mirrors.kodi.tv/nightlies/osx/x86_64/Krypton/kodi-#{version}-Krypton-x86_64.dmg"
   name 'Kodi-Development'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.