### PR TITLE
Update sketch-beta to 43.2,39068

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '43.2,39056'
-  sha256 '21ec0130118a555dfb9ac3118b211e6e77dbee106ee59108459a57c95f740e89'
+  version '43.2,39068'
+  sha256 '244ab37d80f332abb5fd6769699a30deccc789af0ed510e6ebdd0125cf0f47e6'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '216b80e10c64ab0975f0e21cb350641ec1c2035ab3207e1a1f7cdaee7c75bf5f'
+          checkpoint: '3e6611eb7a6a18978017f52ae62d39acbcbd804d9d62af8c7ff68a1c6d242b8e'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.