### PR TITLE
Update tower-beta to 2.6.2-352,352-98de2678

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.6.2-350,350-b7d5b8fb'
-  sha256 'a83de3400c8b333002d1e6b7d5bc3a767f1205061af585c5072da974e245d833'
+  version '2.6.2-352,352-98de2678'
+  sha256 '409d0d6b581353d4f76e7b9836344da3cc46c8b39f2ae68763ec95afcf1e98da'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: 'e9e290f18100da28b50463bcc2d3a5045edfcbcdd0ab2d1a1974c5f5a1517337'
+          checkpoint: '42b5f362e7320734ac841354fecb92c47ee79d5b5c03a28797407bb27ff63426'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.