### PR TITLE
Update toggldesktop-dev to 7.4.34

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.32'
-  sha256 '32eee4a7b143f0c498c07184e07171030f93ebd08fdd0331c1064f7a6caba08c'
+  version '7.4.34'
+  sha256 'b4bef01482451187055bb4dac6ef43819472ae9c1c3db919884ea7b020d7f3b2'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '2c4cb072aa601cbb6e7d4c9027748b7f0f4a3ff2c1a56057b1be879ef787dbe4'
+          checkpoint: '877751184fd096a267c1355346d32bb004fc5139341149d0708794ec8869b129'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.