### PR TITLE
Update telegram-alpha to 2.95.94181,288

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.94.93020,241'
-  sha256 'ac20b9daaf9f82e9e0caba8f3363d6a5648651b5e158353608e0cd5a1b0e84a8'
+  version '2.95.94181,288'
+  sha256 '4ca111f4c43746a96bb3f387ea525e7b41b70cf4777a1bbd25fac348ec1d9378'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '544c2d963a266431eaa758b8ac39bdaae805c93d804bb9461812cc7efe11ff51'
+          checkpoint: '344b01b2fad3ef2a328bedd76055b0de49c649edf622f7b30169c6b4441097a8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.