### PR TITLE
Update opera-beta to 45.0.2552.453

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '45.0.2552.225'
-  sha256 '34fdb0bb236260d2ca690645da42361f80e9539f8b861881eb0c72cc7fec231a'
+  version '45.0.2552.453'
+  sha256 'c9bc4bb478a0114e8d8014eb7570a55309c48bbfe18e6d207d78748f4cea8081'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.