### PR TITLE
Update firefox-beta to 54.0b1

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '53.0b9'
+  version '54.0b1'
 
   language 'de' do
-    sha256 '851dc69c4d1cd821b3efcade9445c26049325e976bb6fea72dae85d7acdc9e29'
+    sha256 '92579323553f5b6ec99f70e6ad6102b1eaeacb892cc638d4c315abf4ec41e9b0'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '729c6f316be4966f098484b6c358746ab085f7e3187b3eb281b08b37e72c8964'
+    sha256 '4a30b2e384be6203e1db018aae5eea1c476ebaf224bcde982fe957eb791700de'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'c9e4ec074523a965834088873505b30efe2a0706017d6ddaa1f02a9b991f4f9f'
+    sha256 'a36ea6373305e9dbc030ff56fc26715287fa3b01e3c8c8bd34fd20b0fdb7b1b3'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'fb65aac8135238150022c14a89f5e41d320ee05d47b4c03ae66da4c4bcabf182'
+    sha256 'ea760aad46322c3957407517d51ffa2a7a322f2ff1e73c6fea900e11bbce3d30'
     'fr'
   end
 
   language 'gl' do
-    sha256 '69478735189bc8093f9154970d9edfc92ce267057a8008a714ef21d301317e3a'
+    sha256 '011bf2358e11e8b2252b71497b6fa102021c693fbb65a875ac9134f7e4b1ed88'
     'gl'
   end
 
   language 'it' do
-    sha256 '577e7cb1f968162137ee003c923238ef18e1d792e365cccad1a151436c9ef09e'
+    sha256 '600b67eff5655c20e9a5141583c246034154fde2670ce912aad9701bb087c6c8'
     'it'
   end
 
   language 'ja' do
-    sha256 '753af4f2de40fac32039f67f1d7eb569747f72d68576631ca6b0c143f4d5ef88'
+    sha256 '7f52e7f7a1b532a554196ab4e9f22a260c9ce2587bbe4d5684329738ad685f97'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '06c1a51aca9bad29506d8f6a9cd6e3d0e1b36bf7f07e4c7f105aa79b912b3ce7'
+    sha256 'b8c8da2d50b381e998703ac35fe2a47e29b5fb299e8b208aba9042682bb39bf1'
     'nl'
   end
 
   language 'pl' do
-    sha256 '2b466a5396dfb94c95e804a53a17980cebd19086e00b3f08cd7b619d320354ce'
+    sha256 '2588026beab6e7c90aab9b4a86ca0b2005e86bfd66a3acca6e947387f804001f'
     'pl'
   end
 
   language 'pt' do
-    sha256 '49c49c4c8243190d704d70f1bea61ce5a9520548522417d1bee79dca6b114a17'
+    sha256 'c3a5010a0d24389a31f81a332cddddc1ea3b9929629129df8ed9f84f93eee4a0'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '85866d1b32456c112ee3c19fcd774547b4d6edf4c1e24180e62244da35b7daa5'
+    sha256 '677c17497d1426b3720e4c275e424ce1b4281cf9b6b33ec35908893c65e29b27'
     'ru'
   end
 
   language 'uk' do
-    sha256 '34eb6b58f7311caa67821a43ecdf9ee6b863158865eedce8c5a8055258206157'
+    sha256 '053724fadd5896f7621bcee91d79a6fe98ef6d554b22ecfda62c3ef39ac9815f'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '6de1d514b0b52e7743082f777239b6eb45a6bc1b48d14b97c93e318d19684ac4'
+    sha256 'acc0dc95cc9e5f0e0705352847db70274d103307d863c60445a0ff689e418a12'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '72a63fecbe19c51a44a48a9e3f147ea09f06124a74f1c8c93a00f20fe5e6ec4a'
+    sha256 'ec0cee48a4fb27c52d4d2bd584dcc50284d4e407977d0b0ef38f8f20b13d0a90'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.