### PR TITLE
Update sublime-text-dev to 3130

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3129'
-  sha256 'e3cbebb17a290a571c19fbb2198256d3f2ec3ab0c278594ce78934bb7d1c534a'
+  version '3130'
+  sha256 '2a93c42b152f1e95747b2c5234252995f648fdcb99136dd51e4bab9122ff98b4'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: 'c77e40481305bf1ca2c8bc68fb0a89cd6effeca9ccbaa241bb380d70a3afbe29'
+          checkpoint: 'b4c1654bc4d4cd286f6a9ae3ee2b1e06804704b26e18688b37180f579b086fc9'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.