### PR TITLE
Update telegram-alpha to 2.96.94323,297

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.95.94299,295'
-  sha256 'b14ef83d5348b05657c2c0e035b1c6985c208c5a4a54ed63a0574e034b29bce6'
+  version '2.96.94323,297'
+  sha256 '7bdffddaad3a8e8d61f890dcce01071b227f65360de3b7b118ae212031d9bba2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6be54899189eceb91443fb9d45876143145de3ed336990555b7baf50976424de'
+          checkpoint: '8d612a0f10d19acbc003f074e02f63add71119b4c4230a917db7dc62603a2001'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.