### PR TITLE
Bring back intellij-idea 2016.1

### DIFF
--- a/Casks/intellij-idea20161.rb
+++ b/Casks/intellij-idea20161.rb
@@ -1,0 +1,25 @@
+cask 'intellij-idea20161' do
+  version '2016.1.4,145.2070'
+  sha256 'c6ed2455cfeeb542c646e6a3d639d32e85ebe8ead87a0f3744dfa3c0a920e2f9'
+
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.before_comma}.dmg"
+  name 'IntelliJ IDEA Ultimate'
+  homepage 'https://www.jetbrains.com/idea/'
+
+  auto_updates true
+
+  app 'IntelliJ IDEA.app'
+
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+  end
+
+  zap delete: [
+                "~/Library/Caches/IntelliJIdea#{version.major_minor}",
+                "~/Library/Logs/IntelliJIdea#{version.major_minor}",
+                "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
+                "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
+                '~/Library/Preferences/com.jetbrains.intellij.plist',
+                '~/Library/Saved Application State/com.jetbrains.intellij.savedState',
+              ]
+end


### PR DESCRIPTION
After removal in https://github.com/caskroom/homebrew-versions/pull/3683

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
