### PR TITLE
Update vivaldi-snapshot to 1.9.818.25

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.9.818.22'
-  sha256 '23a302d2bc9d2677636ee7f62c9cb7152faed8e2b047c8159260487fc5f70bf3'
+  version '1.9.818.25'
+  sha256 'b0721a8ef444fcc6367aae72ac796907c6ff9bab93228b8f4393c57ce298ee12'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'bb86e4c5d77ff33183befeea4fc158ecb4f33026f41207b69eddb2b51740df14'
+          checkpoint: '7e5a4fc16b44e72f4645f94d9709a7126f0b4e68ca2c49398862bc9258382f5e'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.