### PR TITLE
Update telegram-alpha to 2.96.94461,305

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.96.94324,300'
-  sha256 'd3543313df822617ba761ce36e8d501c124c281b41ac158c4e0615551afaf304'
+  version '2.96.94461,305'
+  sha256 'fca444a56b5bfcbf2dcca246bd966485b8e084f444aad965820d520e13a32a73'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '81fbb0fb0bac790d4cd0d5f5d4ce183a1311d4d6827b1dfd5a199be70fd31aa8'
+          checkpoint: '7c0cdbfa248f9ffa5fff166f6437dea0601ae05898c36e5b943166a07e1596eb'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.