### PR TITLE
Update tower-beta to 2.6.2-353,353-e3840772

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '2.6.2-352,352-98de2678'
-  sha256 '409d0d6b581353d4f76e7b9836344da3cc46c8b39f2ae68763ec95afcf1e98da'
+  version '2.6.2-353,353-e3840772'
+  sha256 '69ebe1fdda18d644b83524b5e14068021d20309e9c8a8f75fdadc9c73cae4c63'
 
   # amazonaws.com/apps/tower2-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/#{version.after_comma}/Tower-2-#{version.before_comma}.zip"
   appcast 'https://updates.fournova.com/updates/tower2-mac/beta',
-          checkpoint: '42b5f362e7320734ac841354fecb92c47ee79d5b5c03a28797407bb27ff63426'
+          checkpoint: 'eaff23e6d6be5cb3b3ec5a6075257833e95d176f249308efdacfc5a6958d5c67'
   name 'Tower'
   homepage 'https://www.git-tower.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.