### PR TITLE
Update vivaldi-snapshot to 1.9.818.29

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.9.818.25'
-  sha256 'b0721a8ef444fcc6367aae72ac796907c6ff9bab93228b8f4393c57ce298ee12'
+  version '1.9.818.29'
+  sha256 '3b94d5443f81091f149ad2d03a72477647c7f6266fcdfe48af5d1a5057cabd53'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '7e5a4fc16b44e72f4645f94d9709a7126f0b4e68ca2c49398862bc9258382f5e'
+          checkpoint: '789a008b7bc3b281a96ac514762dcbdf359368da175164af4504d0af99917d6f'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.