### PR TITLE
Update telegram-alpha to 2.96.94502,307

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -5,7 +5,7 @@ cask 'telegram-alpha' do
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '11b32a662cd63d3108aa23b4f13deb4100485cdc36387a2f7ea5b35d3f1d228e'
+          checkpoint: '407d011c90c85dc65687d97cbffd9749436fb966f39345ae94c5a99ca3753058'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.96.94461,305'
-  sha256 'fca444a56b5bfcbf2dcca246bd966485b8e084f444aad965820d520e13a32a73'
+  version '2.96.94502,307'
+  sha256 '23611d971eaa09f403674df1d34b6b97c4f47666dfada2472e8be41ed4ca8513'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7c0cdbfa248f9ffa5fff166f6437dea0601ae05898c36e5b943166a07e1596eb'
+          checkpoint: '11b32a662cd63d3108aa23b4f13deb4100485cdc36387a2f7ea5b35d3f1d228e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -5,7 +5,7 @@ cask 'telegram-alpha' do
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '407d011c90c85dc65687d97cbffd9749436fb966f39345ae94c5a99ca3753058'
+          checkpoint: 'ea20e4baff1f4305f24ec57915d3c6e9d9ed0554ee4caa93ba54db95afcf5fba'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.