### PR TITLE
Update telegram-alpha to 2.97.94524,310

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.96.94514,309'
-  sha256 'dba454d88244d9bd9afb2c82d53e66f90c2a6d9a38d4fbadaa3464fe0b243593'
+  version '2.97.94524,310'
+  sha256 '2bf5750155a50996bac25c0fa8d8dd85df1fca93af4d3a0224f0c73320da0810'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'ea20e4baff1f4305f24ec57915d3c6e9d9ed0554ee4caa93ba54db95afcf5fba'
+          checkpoint: '50ceae2033aa982c80bd7a73b00e9580d75f23383d39dec583a4e8e6a2928ed1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.