### PR TITLE
Update telegram-alpha to 2.97.94578,311

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.97.94524,310'
-  sha256 '2bf5750155a50996bac25c0fa8d8dd85df1fca93af4d3a0224f0c73320da0810'
+  version '2.97.94578,311'
+  sha256 'c8942485a4bf25b4e0c9edda529c462d4218340883f28f38f296ef93356df102'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '50ceae2033aa982c80bd7a73b00e9580d75f23383d39dec583a4e8e6a2928ed1'
+          checkpoint: '0e3b84cffcb5b78bec0603c9a32a05a9a8d03c376daa21fd28b9e4ce26546900'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.