### PR TITLE
Update vivaldi-snapshot to 1.9.818.40

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.9.818.29'
-  sha256 '3b94d5443f81091f149ad2d03a72477647c7f6266fcdfe48af5d1a5057cabd53'
+  version '1.9.818.40'
+  sha256 '9e6996de5b04bdba28425d96a1bdcec98b06546581f510ea16d9e00cd8e1c093'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '789a008b7bc3b281a96ac514762dcbdf359368da175164af4504d0af99917d6f'
+          checkpoint: '78116cbf375a7d675267284143fb90d460e3b7ec9edf00062a74254c68814ebf'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.