### PR TITLE
Update telegram-alpha to 2.97.94583,312

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.97.94578,311'
-  sha256 'c8942485a4bf25b4e0c9edda529c462d4218340883f28f38f296ef93356df102'
+  version '2.97.94583,312'
+  sha256 '95163dcc4a7de78578b2734395b47fdd494f9b005216b28a7e9f84624fd0fccb'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '0e3b84cffcb5b78bec0603c9a32a05a9a8d03c376daa21fd28b9e4ce26546900'
+          checkpoint: '866d76d4ea47ad1a37e4a214213f615f4a32aec848658a668b2b1b9733323630'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.