### PR TITLE
Update 1password-beta to 6.7.1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.7.BETA-5'
-  sha256 'cd2888013645885d8f1a249f65cbbb718146df655905225d999bdf857b596545'
+  version '6.7.1'
+  sha256 '86144a2e4f39880dd483d1aae3a57ee25ce8f6a9d87c8b4056cfc1c48721faf3'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.