### PR TITLE
Update firefox-beta to 54.0b3

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,73 +1,73 @@
 cask 'firefox-beta' do
-  version '54.0b2'
+  version '54.0b3'
 
   language 'de' do
-    sha256 '9d720833dc9d1242d77a4c0dd1fd61bc826783636a23405d6b30c18bfb159982'
+    sha256 '4f982c7dc8bd7a25c84dad423bb8ade04bff1b1216aa386b1d9be5bebdf246ce'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '2d81bd5d0544b2c3ee710e7e056f87b50ed7f469903b552e14138802dae930dd'
+    sha256 'b57677f545070b703333e36b7a11d620cfd12eb16411257169d5a93412a422c8'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'd97a5aba859fb1c2a2407a1c7bf2725bcbb3068bec0721155928e039cae168d6'
+    sha256 'abd8daa519dc3d3493fc631d4d461b5a8d99a98c8b147744c3787e1b18ad4747'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '6e5e06ab645fbdb61a8c556038235e01420b4b2f24480e3f7214c6de9f070246'
+    sha256 '186e97b4f9d811d90abd54cfb66056fbcfe054f843fd3377394c5b5494d2588d'
     'fr'
   end
 
   language 'gl' do
-    sha256 '63a6074c88a4bc2a6c874ae4a6c0c7ebcaa654106f90640ae0b57763c3bf6af9'
+    sha256 '092cbc7d1695b98f24e48202871178e8dcb6802ecf9123cffd7f888127f8623e'
     'gl'
   end
 
   language 'it' do
-    sha256 '788b67d2aa573445457e4e5c2b8a823026326aaa057493435f16ddf014060dc7'
+    sha256 'bca830fff4f9bc82320b7551ac992ac1ace9b79b8b0e754b3dfeb2e5585e9125'
     'it'
   end
 
   language 'ja' do
-    sha256 'cd8eeda96b0edf5abcfe081df6272ebe8488c237dd26d61cf5f096d456d20c73'
+    sha256 '64bd9a4bddd50a020b8b46b4d9289131da4d408b68a64afed1fb914c891ae1d2'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '40c46f36f89df992938dd2da90e35ee40759d50ed29e558bac5f7c7bd1b6a2dc'
+    sha256 '9eabfeba814f98a4b6f5e6341da804330d52d5f811db6b869c5d02cf3382e672'
     'nl'
   end
 
   language 'pl' do
-    sha256 '97693da36ef3b848ff80d98e760d5244dea954edff0121e98e90ef3476213c40'
+    sha256 '653d1a411ddee513c4e4b0ab6fe96bcc8eaff3cb8ca7f0c6f89d34027dad7d08'
     'pl'
   end
 
   language 'pt' do
-    sha256 'a7d02ea5bb134e960e56ec326d2d6cdfb15abc54bced065f1836722ae021a466'
+    sha256 '933431a0d045b32e5fe51453c590a4199dff9e02adf1e81a16f33819a757e01c'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'b4545923a0625a26cab1a3d20e35c87b5c1478d2e402fe1f276d64c09be17f88'
+    sha256 '37702a902c6d38faa439c3186bbfa5a49c115bb5f7ea4c1ce231992520033447'
     'ru'
   end
 
   language 'uk' do
-    sha256 '9376cd7a0df730537e15db057683caf205911401bf6f3befba46f9cf9bd6a6b8'
+    sha256 '40b9807c34f0c8d251ee5fd6efd731b87b016c804ed90cb9f6fceb1a771e42fb'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '6ebc5152ddacd56c4bcc4a6793bf2bfda1c1e1072bd15e0cd7bd8693213a16bb'
+    sha256 '2efe1863fcef555a1ef8254d55e1543fe8d103731f2a1d827d974388a9776f10'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '2a141666d4ab2692e82e3e6b0ec6a07628b4063af4f05183c52e40e5b2655fda'
+    sha256 'a590834abe1890f8f5ff0bc21524917e05a8a46a054ea80b80463edfc5904fa6'
     'zh-CN'
   end
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.