### PR TITLE
Update android-studio-canary to 2.4.0.6,171.3934896

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.4.0.5,171.3909050'
-  sha256 '7ee2d3daf79489dff15cf70dcec72b85d75c602261851396112b9b6e9385bd15'
+  version '2.4.0.6,171.3934896'
+  sha256 '66d82f8aaa8124a9420f15faf22e58f573961e0f2314bb40bfe51867772810c9'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.