### PR TITLE
Update visual-studio-code-insiders to 1.12.0,0bec115779b11a9d78bdb24ad7918c22524ea2ac

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '2.4.0.5,171.3909050'
-  sha256 '7ee2d3daf79489dff15cf70dcec72b85d75c602261851396112b9b6e9385bd15'
+  version '2.4.0.6,171.3934896'
+  sha256 '66d82f8aaa8124a9420f15faf22e58f573961e0f2314bb40bfe51867772810c9'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.12.0,6e45311b5781d6550f469d0381d97d0d92e48f6b'
-  sha256 'd868dd834425b668f68fde319d4997e43852103e40e835750b34c3a24b26c012'
+  version '1.12.0,0bec115779b11a9d78bdb24ad7918c22524ea2ac'
+  sha256 'e4575f048225fa04c0581c880ca9d8a78cd176f456708001cf05d93d2c08ded8'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.