### PR TITLE
Update toggldesktop-dev to 7.4.37

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.34'
-  sha256 'b4bef01482451187055bb4dac6ef43819472ae9c1c3db919884ea7b020d7f3b2'
+  version '7.4.37'
+  sha256 '066d22db9d009e480c0c85b9251e1fa3505e49fc9660cb1d7e5bcd62c4cc37cf'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '877751184fd096a267c1355346d32bb004fc5139341149d0708794ec8869b129'
+          checkpoint: '0c06e586032d3bff493e3f487cd16e673a9eb83fecd2cc488085a1c7c3f51119'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.