### PR TITLE
Update electron-beta to 1.6.8

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.6.7'
-  sha256 'e52f45787a9046a589815a9726c2e3a2b440de11cebe851c678b179f0107172d'
+  version '1.6.8'
+  sha256 '40fb4f098321f1a1988d379e4a617df59513ad8e6faa9a3c741a6934f8366ee4'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'e56438a8ed14c1ed15b4f5780d4fd6ea80f7a791edb8159d1e11aa67debde192'
+          checkpoint: '6e4158cccd5bed9d4d5734713f194467bd2798560e9046b5369b68a19421d4ca'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.