### PR TITLE
Update airmail-beta to 3.2.6,426,296

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.3.423,295'
-  sha256 'a585da884c298d3e59ac92d5a5a616558c71f5797ee9f59da547e7033b3e4a12'
+  version '3.2.6,426,296'
+  sha256 '00f9f06d25ff99a59070e3faa447806c1988bc64efa43b9ba44948ede798fb6f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'bc1f18ec26824d7a2f2d7d401415f3f17880b5bc5ef9a000dcc048bef3b6d25a'
+          checkpoint: '2fc89a068921128bb90a19120256564f184b10335b686ee224f5773ca738b07e'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.