### PR TITLE
Update toggldesktop-dev to 7.4.38

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.37'
-  sha256 '066d22db9d009e480c0c85b9251e1fa3505e49fc9660cb1d7e5bcd62c4cc37cf'
+  version '7.4.38'
+  sha256 '58bb90a92bb96efeb22d1cec4bcef42e2c202cfe592f797026a15165aea6ba89'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '0c06e586032d3bff493e3f487cd16e673a9eb83fecd2cc488085a1c7c3f51119'
+          checkpoint: 'c6d7c5fe7b030bf0cd63b3ae985344768ad9ebdc9eff70f44ac496bc156f0cb3'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.