### PR TITLE
Update sketch-beta to 44,41325

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '43.2,39068'
-  sha256 '244ab37d80f332abb5fd6769699a30deccc789af0ed510e6ebdd0125cf0f47e6'
+  version '44,41325'
+  sha256 'd812bbfe62f6f770805abcea7c91d707f440c6b363d497889f774b444078f08e'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '3e6611eb7a6a18978017f52ae62d39acbcbd804d9d62af8c7ff68a1c6d242b8e'
+          checkpoint: '6fe6d399c792158f1b4927960455a06663126df539f7bd408af1cf043cc4bab3'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.