### PR TITLE
Update emacs-nightly to 2017-04-22_01-41-02-d812d20fbc3e1eff0f10443baed801adda9031cd

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2017-04-14_01-41-06-96644ed496cfc36ef886c401250203c57d77ab75'
-  sha256 '92437d6d7efddd9eda3fa27c827deeee831627521cfd3864b44babcf50995612'
+  version '2017-04-22_01-41-02-d812d20fbc3e1eff0f10443baed801adda9031cd'
+  sha256 '7a11906cc3904da3aa0970c5e87d3c3b301d6c7584da568825075db2273ee4e1'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '7fc10734e00e7c404d48fa7005bcf8bd43c17346c1d28ef01bf7fb500cb1d45a'
+          checkpoint: '3191d01f8b1b81ce19471554d70a171f069059a82736265af7ab50f5f415745c'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.