### PR TITLE
Update emacs-pretest to 25.2-rc2

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -4,7 +4,7 @@ cask 'emacs-pretest' do
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: 'ecd9fa682e6f59e932c2a7c3c94d48c81719ec700ef110de27499d569bf1e4bc'
+          checkpoint: 'ea71786763eedb4198a155cc3f0c7728f0757ea8dc3473c6494d7e8b99ec2ff8'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.