### PR TITLE
Update telegram-alpha to 2.97.95234,322

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.97.95201,320'
-  sha256 '4b9edb60367646f98dceeae22a662dc064593c61a881d2d058f048c8afd7eb66'
+  version '2.97.95234,322'
+  sha256 '5a0b8ea2398a0554322a2b6d55ecc7e0428f9e9d3d845da5dc015132046a8b84'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'efb4dd2deac5c63e896304d9de65138edfd3c689070ed05b74329d357a4d6233'
+          checkpoint: '4c2d648be77b9681041390bd84e8cc21ae18bacefc889025ba3241ddd10325b5'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.