### PR TITLE
Update kicad-nightly to match kicad

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -7,10 +7,14 @@ cask 'kicad-nightly' do
   homepage 'http://kicad-pcb.org/'
 
   suite 'Kicad-apps', target: 'Kicad'
-  artifact 'kicad', target: "#{ENV['HOME']}/Library/Application Support/kicad"
+  artifact 'kicad', target: '/Library/Application Support/kicad'
 
   preflight do
-    system_command '/bin/mkdir', args: ['--', "#{staged_path}/Kicad-apps"]
-    system_command '/bin/mv', args: ['--', *Dir["#{staged_path}/Kicad/*.app"], "#{staged_path}/Kicad-apps/"]
+    FileUtils.cd staged_path do
+      FileUtils.mkdir 'Kicad-apps'
+      FileUtils.mv Dir.glob('Kicad/*.app'), 'Kicad-apps'
+    end
   end
+
+  zap delete: '~/Library/Preferences/kicad'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updated `kicad-nightly` to match changes made to `kicad` in https://github.com/caskroom/homebrew-cask/pull/33274