### PR TITLE
Update opera-beta to 45.0.2552.634

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '45.0.2552.632'
-  sha256 '0fd1d5f61f59ef7de58f6079a44a79d17d0df47e6934d46170c31c707be49065'
+  version '45.0.2552.634'
+  sha256 'fe965d172355963eecbea934d94115a0eae31a9aaf9c2be374091ce0c58970c1'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.