### PR TITLE
Update airmail-beta to 3.2.6.428,298

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.6.426,296'
-  sha256 '00f9f06d25ff99a59070e3faa447806c1988bc64efa43b9ba44948ede798fb6f'
+  version '3.2.6.428,298'
+  sha256 'cbf742863978b9cee4b79638c523a82c9285e3eefae5ad6659441152d7fb57af'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '2fc89a068921128bb90a19120256564f184b10335b686ee224f5773ca738b07e'
+          checkpoint: 'd4e87f1f180e59823ec376ec05ac61df7e2265886595d28d76e1f29b98c1f090'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.