### PR TITLE
Update adium-beta to 1.5.10.3b1

### DIFF
--- a/Casks/adium-beta.rb
+++ b/Casks/adium-beta.rb
@@ -1,6 +1,6 @@
 cask 'adium-beta' do
-  version '1.5.11b3'
-  sha256 '999e1931a52dc327b3a6e8492ffa9df724a837c88ad9637a501be2e3b6710078'
+  version '1.5.10.3b1'
+  sha256 '6c1c7b58e23bf4b1e024eb7c5592eaa5b4d6b2ea33e0fb75e32aa0b0c4672085'
 
   # adiumx.cachefly.net was verified as official when first introduced to the cask
   url "https://adiumx.cachefly.net/Adium_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.


<img width="915" alt="adium_beta_-_1_5_10_3b1" src="https://cloud.githubusercontent.com/assets/450222/25868199/df07adac-34c9-11e7-8b30-9695d30a1de0.png">
