### PR TITLE
Update emacs-nightly to 2017-05-09_01-41-06-daaec72a82e76f916e639acb51a8ad602433e8a9

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2017-04-22_01-41-02-d812d20fbc3e1eff0f10443baed801adda9031cd'
-  sha256 '7a11906cc3904da3aa0970c5e87d3c3b301d6c7584da568825075db2273ee4e1'
+  version '2017-05-09_01-41-06-daaec72a82e76f916e639acb51a8ad602433e8a9'
+  sha256 '07deda2329d2dcaa5faef88a151b409aaf10a05dfd8d0d1d2bbd7e7f593391e1'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '3191d01f8b1b81ce19471554d70a171f069059a82736265af7ab50f5f415745c'
+          checkpoint: '9bdf3d1af5d3a58bb2bba6f59e2e4bd6234ea8ef1fff0dfeda880e7fd00a1122'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.