### PR TITLE
Update telegram-alpha to 2.97.95446,330

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.97.95377,327'
-  sha256 '405b9b89d66ffcd520a06f0c254081d2c6511f613201b8e589e077708eb25db7'
+  version '2.97.95446,330'
+  sha256 'b3af4b10afe0e235fe8d37c64219056691b1a797f300f13edc2975c58d8dcb57'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '8632e8066a0342ff1ff93c5a46e923d80ea6a9224677b4aeead3f42f9f076053'
+          checkpoint: 'c54de3fd2fa94d3753bcce22c3160985e94b89fc24f480c483a5d155372a26e1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.