### PR TITLE
Update airmail-beta to 3.2.6,429,300

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.6,428,299'
-  sha256 '94d67eae641ea371372df2e3eb796e9e331ee7c0d918dc89357b28cbbfffdb1b'
+  version '3.2.6,429,300'
+  sha256 '45b7ed1653c395466b30fb60b69b3b84a73530eb72af1a4a88ff80caff007d88'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'bf05521bcc81028159f0e472e293760c8d511dfe538cd4ea58d77a38beb5f781'
+          checkpoint: '94b61b56b79d6b8476ff9681883f8235be6521285b823f80e346e1ff1998607f'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.