### PR TITLE
Update telegram-alpha to 2.97.95511,333

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.97.95446,330'
-  sha256 'b3af4b10afe0e235fe8d37c64219056691b1a797f300f13edc2975c58d8dcb57'
+  version '2.97.95511,333'
+  sha256 'eeaa73e7bcddc0cfcf126b827e84b04f01e2f8a3fdc278b12df4e3f7114ac39b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c54de3fd2fa94d3753bcce22c3160985e94b89fc24f480c483a5d155372a26e1'
+          checkpoint: 'ba1a0768a82e5ffd93fd5829789b18df62896d2e3c0daa718c5833acc11a0d59'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.