### PR TITLE
Update electron-beta to 1.7.0

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.6.9'
-  sha256 '02b2393be8b454c06fa2906f127d1fe51708369727b48cd293e1f064c0c8a2fe'
+  version '1.7.0'
+  sha256 '352aa052848ec6f34f2986d88960948ea85350c0eb19ba715f8f8c98dcdbdd12'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '362b5578ff0e87bbfaf94f5ac126e404da2cf3bb41a4dacd2274f4367dbced8b'
+          checkpoint: 'd9006b59ea1092a9d169cfb9f97c990826c805d879d616025a4c17836cd054bd'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.