### PR TITLE
Update airmail-beta to 3.2.6.430,301

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.6,429,300'
-  sha256 '45b7ed1653c395466b30fb60b69b3b84a73530eb72af1a4a88ff80caff007d88'
+  version '3.2.6.430,301'
+  sha256 '404d2c80dc793d32a7d639a9e5cf50490158275362ad9d4b713c7c6c269caa7a'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '94b61b56b79d6b8476ff9681883f8235be6521285b823f80e346e1ff1998607f'
+          checkpoint: '2d1054e7241c4f2189b59c898e9c66e983fc7f3d51e318c4574cb77496949d1f'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.