### PR TITLE
Update transmission-nightly to 10556943e5

### DIFF
--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -1,6 +1,6 @@
 cask 'transmission-nightly' do
-  version 'fdfbe225da'
-  sha256 '33a6604b23c6707be6790a43ae0fd2ad31b3bd34f0e01fef550c87e5c3f403aa'
+  version '10556943e5'
+  sha256 '12209265bd7d6512cc5b97500e0049fbcaaad225930bc04162a1c6134a01680d'
 
   url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
   name 'Transmission'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.