### PR TITLE
Update omnifocus-beta to 2.9.x-r285870

### DIFF
--- a/Casks/omnifocus-beta.rb
+++ b/Casks/omnifocus-beta.rb
@@ -1,6 +1,6 @@
 cask 'omnifocus-beta' do
-  version '2.x-r283691'
-  sha256 'bcec103e80344dd8d4f42007ba5c17ed288888ec542990472702e244cdf857ae'
+  version '2.9.x-r285870'
+  sha256 'ca4a77430ffbb09c66bcee7ce60842c2824206f47b0c7136b4934b432baada85'
 
   url "https://omnistaging.omnigroup.com/omnifocus/releases/OmniFocus-#{version}-Test.dmg"
   name 'OmniFocus'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.