### PR TITLE
Update airmail-beta to 3.2.6,431,302

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.6,430,301'
-  sha256 '404d2c80dc793d32a7d639a9e5cf50490158275362ad9d4b713c7c6c269caa7a'
+  version '3.2.6,431,302'
+  sha256 'c0b6818dbd3560c7e71b7b3661e286a6a13e8a4cf0a2510ba9611e4379bc0f1d'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '2d1054e7241c4f2189b59c898e9c66e983fc7f3d51e318c4574cb77496949d1f'
+          checkpoint: '14e027cff6ec368725cb81a0e2d27cce17589b40ccfb82ade416579f83448134'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.