### PR TITLE
Update telegram-desktop-dev to 1.0.37.alpha

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,12 +1,13 @@
 cask 'telegram-desktop-dev' do
-  version '1.0.29'
-  sha256 'fda92753e5311eec0b545bebcc1909164bd7c7f63bff434692ea7bcc4925da88'
+  version '1.0.37.alpha'
+  sha256 '4d9220bfb06f608cdfab3acd90bca40054688b88973c511d31648a9ffc4fce5f'
 
   # tdesktop.com was verified as official when first introduced to the cask
   url "https://updates.tdesktop.com/tmac/tsetup.#{version}.dmg"
   name 'Telegram'
   homepage 'https://desktop.telegram.org/'
 
+  conflicts_with cask: 'telegram-desktop'
   depends_on macos: '>= :mountain_lion'
 
   # Renamed to avoid conflict with telegram


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.