### PR TITLE
Update docker-edge to 17.05.0-ce-mac11,17656

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.05.0-ce-mac9,17434'
-  sha256 'f1d3a66116354122ca508c7377cb47a76c7b21b9e5243d68233d214eab7421fe'
+  version '17.05.0-ce-mac11,17656'
+  sha256 '1ae2d1664b834508ec507268e5802eb73c30840a996c6cbc14214ab29a1ec8bd'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: '92cb5cb1c9e4fa9fdbddd722c5dc40057bdc9d1f81678c708368919bd2a4acb8'
+          checkpoint: '1b7dd6a5192139d07c425bd76203ca7c0b8818abd78d26784a13fb34e3d0e34f'
   name 'Docker Community Edition for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

> 17.05.0-ce-mac11 (17656)
security fix for CVE-2017-7308