### PR TITLE
Update adobe-photoshop-lightroom600 - preflight / uninstall_preflight

### DIFF
--- a/Casks/adobe-photoshop-lightroom600.rb
+++ b/Casks/adobe-photoshop-lightroom600.rb
@@ -13,8 +13,12 @@ cask 'adobe-photoshop-lightroom600' do
   # and https://github.com/caskroom/homebrew-versions/pull/296
 
   preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/deploy/AdobeLightroom6.install.xml"
@@ -23,8 +27,12 @@ cask 'adobe-photoshop-lightroom600' do
   end
 
   uninstall_preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/deploy/AdobeLightroom6.remove.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-cask/issues/33956

Update `preflight` and `uninstall_preflight` to match [adobe-photoshop-lightroom](https://github.com/caskroom/homebrew-cask/blob/154192f5ca55049d1d08406df166afff24e3da04/Casks/adobe-photoshop-lightroom.rb)