### PR TITLE
Update telegram-alpha to 2.98.95664,341

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.98.95631,339'
-  sha256 '65cb38af89bfe1e86ea643fddbbaf840996019916080598c557e64285c8810ca'
+  version '2.98.95664,341'
+  sha256 '374dae5373577845ed36d6cdf08ad3d90e9294cacb4d9276b4e3b46baa3b5464'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '88ba8052f9189904c4debb08be1fa4ecdc4660fcc9151b8c8fdbd668c151e285'
+          checkpoint: 'edc3ad3ecccd52d10c629aeaa68d01e6e388466744132061ad4298116de4f614'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.