### PR TITLE
Update vivaldi-snapshot to 1.10.845.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.838.7'
-  sha256 'a5384c0c59d3f684d8402bcf2b338fb2bb925a580f4de721de254dbfcb0a6d97'
+  version '1.10.845.3'
+  sha256 'd542f8de1ccf1ee62353f617e6e11284e5eb8772bff00733b2cdca550fbd4520'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '00bbbbcca01ecf1bf35819bb4fe78f7008c75e12061a4244d7c8a50f2cc298d3'
+          checkpoint: 'dc48175d5d62efbbec9fa297e50788343de90a6d80750f924bd91b2985f3c08e'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.