### PR TITLE
Update toggldesktop-beta to 7.4.38

### DIFF
--- a/Casks/toggldesktop-beta.rb
+++ b/Casks/toggldesktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-beta' do
-  version '7.4.31'
-  sha256 '7e543bcc3aa9cb4fa40dfb62162b82d661e6b3419d56cfdf1418312aea98c4ce'
+  version '7.4.38'
+  sha256 '58bb90a92bb96efeb22d1cec4bcef42e2c202cfe592f797026a15165aea6ba89'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: 'fb9e89f0b331f58d8f61bb41aa5bc546be77e0b299fb2a40f3e1373185feb4a5'
+          checkpoint: 'a0307899bc768e57bc5e4f644e676497b599c75225504720eabf52f51e79299f'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.