### PR TITLE
Update telegram-alpha to 2.99.95835,344

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.95758,343'
-  sha256 '74b8f06495c19802ad43bd98b99b9bcd5faee2008d0fefd9bce8b8a246d3dbaf'
+  version '2.99.95835,344'
+  sha256 'a93efe9def56fb4bc08c08728f053be34569a21d29db38f11254081ed9d5ee0c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '62a40e15254313c7a5e37955c9fe573c37175039509956bf64a0a6a8d31bf9bc'
+          checkpoint: 'eed0c93fd193d42970786d65bb71dc82bfba3f395fb8522b54fbe088daff4316'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.