### PR TITLE
Update emacs-nightly to 2017-05-16_01-41-03-4635016869f7b85dfe37669674677a7dcaab20c4

### DIFF
--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -1,10 +1,10 @@
 cask 'emacs-nightly' do
-  version '2017-05-10_01-41-03-48e6e9a939cd0442497ee2e7b317d94ff9103cfb'
-  sha256 '3b49031f4c20d628287bd62015d9ed007d0933db3cae02e784118ff47a70a983'
+  version '2017-05-16_01-41-03-4635016869f7b85dfe37669674677a7dcaab20c4'
+  sha256 '098ea2ada798d91aec346dad5addc626e95ae8dde3752782ea293a809079b1c9'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/daily',
-          checkpoint: '6eec8467e7762dd50a2d79e87bdd89ae220b2a6b3e5cfcd50cafb2a3737e35b7'
+          checkpoint: 'e419896a16e4a7e2b25b1494802d3a7f40ea9d5fab1a76a81959253768cced9b'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.