### PR TITLE
Update electron-beta to 1.7.1

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.7.0'
-  sha256 '352aa052848ec6f34f2986d88960948ea85350c0eb19ba715f8f8c98dcdbdd12'
+  version '1.7.1'
+  sha256 'e26ff7e0bfea9775d58bc4aed26a85c6827967fc66c9f9a8c1f6f0e2e58382b8'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'd9006b59ea1092a9d169cfb9f97c990826c805d879d616025a4c17836cd054bd'
+          checkpoint: 'c041c996a5aa2f0504817aee7b6f5b61c4f528113e7715e904502cc82806f65b'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.