### PR TITLE
Update transmission-nightly to 7a1a1acd22

### DIFF
--- a/Casks/spyder-py2.rb
+++ b/Casks/spyder-py2.rb
@@ -5,7 +5,7 @@ cask 'spyder-py2' do
   # bitbucket.org/spyder-ide/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py2.7.dmg"
   appcast 'https://github.com/spyder-ide/spyder/releases.atom',
-          checkpoint: 'c3191194a3791cd0620ce24fc0e9ba80ee6238072fab0495c52f932b02dea378'
+          checkpoint: '161dca2fb8e4ad15eb9b0d6645b56de30d98846afed368c1112278dd777da47e'
   name 'Spyder-Py2'
   homepage 'https://github.com/spyder-ide/spyder'
 

--- a/Casks/spyder-py2.rb
+++ b/Casks/spyder-py2.rb
@@ -5,7 +5,7 @@ cask 'spyder-py2' do
   # bitbucket.org/spyder-ide/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py2.7.dmg"
   appcast 'https://github.com/spyder-ide/spyder/releases.atom',
-          checkpoint: '161dca2fb8e4ad15eb9b0d6645b56de30d98846afed368c1112278dd777da47e'
+          checkpoint: 'c3191194a3791cd0620ce24fc0e9ba80ee6238072fab0495c52f932b02dea378'
   name 'Spyder-Py2'
   homepage 'https://github.com/spyder-ide/spyder'
 

--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -1,6 +1,6 @@
 cask 'transmission-nightly' do
-  version '10556943e5'
-  sha256 '12209265bd7d6512cc5b97500e0049fbcaaad225930bc04162a1c6134a01680d'
+  version '7a1a1acd22'
+  sha256 'aefaf9d97235375ba9b99e4866eb03963eba580845f7c7320fb239cbeef0e82c'
 
   url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
   name 'Transmission'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.