### PR TITLE
Update tunnelblick-beta to 3.7.2beta01_build_4820

### DIFF
--- a/Casks/spyder-py2.rb
+++ b/Casks/spyder-py2.rb
@@ -5,7 +5,7 @@ cask 'spyder-py2' do
   # bitbucket.org/spyder-ide/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py2.7.dmg"
   appcast 'https://github.com/spyder-ide/spyder/releases.atom',
-          checkpoint: 'c3191194a3791cd0620ce24fc0e9ba80ee6238072fab0495c52f932b02dea378'
+          checkpoint: '161dca2fb8e4ad15eb9b0d6645b56de30d98846afed368c1112278dd777da47e'
   name 'Spyder-Py2'
   homepage 'https://github.com/spyder-ide/spyder'
 

--- a/Casks/spyder-py2.rb
+++ b/Casks/spyder-py2.rb
@@ -5,7 +5,7 @@ cask 'spyder-py2' do
   # bitbucket.org/spyder-ide/ was verified as official when first introduced to the cask
   url "https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-#{version}-py2.7.dmg"
   appcast 'https://github.com/spyder-ide/spyder/releases.atom',
-          checkpoint: '161dca2fb8e4ad15eb9b0d6645b56de30d98846afed368c1112278dd777da47e'
+          checkpoint: 'c3191194a3791cd0620ce24fc0e9ba80ee6238072fab0495c52f932b02dea378'
   name 'Spyder-Py2'
   homepage 'https://github.com/spyder-ide/spyder'
 

--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.7.1beta01_build_4800'
-  sha256 'fdeb16bcad029d935ef0776069460a820094dd1243495d1757f68982434944ef'
+  version '3.7.2beta01_build_4820'
+  sha256 '5560d0cc5f23c4bb7ad29d1abf65a9da93eb1fbb860583df10f920e88fb6ab86'
 
   url "https://tunnelblick.net/release/Tunnelblick_#{version}.dmg"
   appcast 'https://www.tunnelblick.net/appcast.rss',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.