### PR TITLE
Update julia-nightly to 0.7.0-448acca718

### DIFF
--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,6 +1,6 @@
 cask 'julia-nightly' do
-  version '0.7.0-ecf10a2092'
-  sha256 '0399589efd9f97bce46af90eb1ae17b25e346c965f9a93b86f945ace622f1229'
+  version '0.7.0-448acca718'
+  sha256 'bf862dbb9bd69058f0bab8f9eb4f283b1ac7b47babdb1992ccfc457451513f28'
 
   # amazonaws.com/julianightlies was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/julianightlies/bin/osx/x64/#{version.sub(%r{(\d+\.\d+).*}, '\1')}/julia-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.