### PR TITLE
Update java9-beta to 1.9,169

### DIFF
--- a/Casks/java9-beta.rb
+++ b/Casks/java9-beta.rb
@@ -1,11 +1,11 @@
 cask 'java9-beta' do
-  version '1.9,168'
-  sha256 '3e4d387efe9df3d8ed4dd30ada7593cdfc6f1ab9dfd63e30dc9a28e568a7f9e3'
+  version '1.9,169'
+  sha256 'ada3b889992031087a1963cbfaef595fb1c325bd5e836669e17932489129caf7'
 
-  url "http://www.java.net/download/java/jdk#{version.before_comma.minor}/archive/#{version.after_comma}/binaries/jdk-#{version.before_comma.minor}-ea+#{version.after_comma}_osx-x64_bin.dmg",
+  url "http://download.java.net/java/jdk#{version.before_comma.minor}/archive/#{version.after_comma}/binaries/jdk-#{version.before_comma.minor}-ea+#{version.after_comma}_osx-x64_bin.dmg",
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }
   name 'Java Standard Edition Development Kit'
-  homepage 'https://jdk9.java.net/download/'
+  homepage 'http://jdk.java.net/9/'
 
   pkg 'JDK 9.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Changed `url` to http://download.java.net

Closes https://github.com/caskroom/homebrew-versions/pull/3866