### PR TITLE
Update telegram-desktop-dev to 1.1.2

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.0.37.alpha'
-  sha256 '4d9220bfb06f608cdfab3acd90bca40054688b88973c511d31648a9ffc4fce5f'
+  version '1.1.2'
+  sha256 '70eb515b2dd628c2d164aed100c22f694544a47e1b351b580d2d3da2f8c80e32'
 
   # tdesktop.com was verified as official when first introduced to the cask
   url "https://updates.tdesktop.com/tmac/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This version is from stable branch, but we had agreed that this is fine in #31772