### PR TITLE
Update airmail-beta to 3.2.7,434,304

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.7,433,303'
-  sha256 '9e2439734874097d0bff6a2c4a0ab6beb767e47c5ca3a61b886821704e01667a'
+  version '3.2.7,434,304'
+  sha256 'b9a2e7d1811f78942ae03d138affb6e9fec5e74d4001ad14793e2a69b7f58ba6'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '391442ed49ad7648fe8686e7aef71dacc5b907e5b893a21ce909982ea91ce9bb'
+          checkpoint: 'f4d9506736ce5ebfeeb073fb945c641ca976e63900088d933009d5eb0e9358ef'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.