### PR TITLE
Update opera-developer to 46.0.2590.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '46.0.2573.0'
-  sha256 '35b1d6c06a650ed322baa459339126555d4d2ebe7ae4663cf080c7bb33f7fdc6'
+  version '46.0.2590.0'
+  sha256 '1a5c206a4ca9c8736159dde1114c214b629f20413abeb3b43d0909748cc6f1ed'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.