### PR TITLE
Update 1password-beta to 6.8.BETA-3

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -3,6 +3,8 @@ cask '1password-beta' do
   sha256 '3a875bb6b50a071dc5dd2ad1cc20cf4c6513ba2c69ee65118aa29e132a80ded3'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
+  appcast 'https://app-updates.agilebits.com/product_history/OPM4',
+          checkpoint: '8a58ba649363b0fc4aa5b1f1c6c59a2a07e3e686a5ee0851a7cb9e799461c6a1'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.