### PR TITLE
Update sketch-beta to 44.1,41454

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '44,41325'
-  sha256 'd812bbfe62f6f770805abcea7c91d707f440c6b363d497889f774b444078f08e'
+  version '44.1,41454'
+  sha256 '552fc1ecd00ea75af3742dc36786a1b3ebe36ebf45637d54e67e02e94413a24d'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '6fe6d399c792158f1b4927960455a06663126df539f7bd408af1cf043cc4bab3'
+          checkpoint: '4adc022456901074ec346158ad8ce074fcb2cbaa1075ab7a15ad533877b37ec9'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.