### PR TITLE
Update telegram-alpha to 2.99.96110,353

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.96045,352'
-  sha256 'f4202ed9b0cde20cee6bd48fa0fe47de53a2bf69480339d5aa0932169bf704cd'
+  version '2.99.96110,353'
+  sha256 'fbee6fc036819fbfdfb45539a706e30506aef346a6e194f1c8b29a0323067e8a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '65b1e79f1d87f5109962a7e112eef71926be4af99ae1b9de9c0046cd1666b0a6'
+          checkpoint: 'eb078a05f6830b16b5993a4c30b99dfd82a644a71686fd37bcd430b8c0fdac0d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.