### PR TITLE
Update lilypond-dev to 2.19.61-1

### DIFF
--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -1,6 +1,6 @@
 cask 'lilypond-dev' do
-  version '2.19.52-1'
-  sha256 '099c7947b76452b187e07bfb459cac8e7aa276444e2315f9521f14bfefba8367'
+  version '2.19.61-1'
+  sha256 'db415bd8332fbb02853dcd4f66be6b8f5326e5b0144a6e44743bd4aeefb59f0d'
 
   # linuxaudio.org/lilypond was verified as official when first introduced to the cask
   url "http://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"

--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -8,9 +8,29 @@ cask 'lilypond-dev' do
   homepage 'http://lilypond.org/'
 
   app 'LilyPond.app'
-  binary "#{appdir}/LilyPond.app/Contents/Resources/bin/lilypond"
-  binary "#{appdir}/LilyPond.app/Contents/Resources/bin/lilypond-book"
-  binary "#{appdir}/LilyPond.app/Contents/Resources/bin/convert-ly"
+
+  binaries = %w[
+               abc2ly
+               convert-ly
+               lilypond
+               lilypond-book
+               musicxml2ly
+             ]
+
+  binaries.each do |shimscript|
+    binary "#{staged_path}/#{shimscript}.wrapper.sh", target: shimscript
+  end
+
+  preflight do
+    binaries.each do |shimscript|
+      # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+      IO.write "#{staged_path}/#{shimscript}.wrapper.sh", <<-EOS.undent
+          #!/bin/sh
+          exec '#{appdir}/LilyPond.app/Contents/Resources/bin/#{shimscript}' "$@"
+        EOS
+      set_permissions shimscript, '+x'
+    end
+  end
 
   zap delete: [
                 '~/Library/Preferences/org.lilypond.lilypond.plist',


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Updated to latest development version and added shimscripts for some binaries in the app bundle.