### PR TITLE
Update airmail-beta to 3.2.9,437,305

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.7,434,304'
-  sha256 'b9a2e7d1811f78942ae03d138affb6e9fec5e74d4001ad14793e2a69b7f58ba6'
+  version '3.2.9,437,305'
+  sha256 '4ebe9bcedaf38452c611095429f40dff474a40c6918ebabecbfa4ea56562ab47'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'f4d9506736ce5ebfeeb073fb945c641ca976e63900088d933009d5eb0e9358ef'
+          checkpoint: 'fae0f559e72c3b5b14b7ebdbc81c672f9f362e2c1490189303d336ff92c5b510'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.