### PR TITLE
Update iterm2-nightly to 3.1.20170519

### DIFF
--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -1,10 +1,10 @@
 cask 'iterm2-nightly' do
-  version :latest
-  sha256 :no_check
+  version '3.1.20170519'
+  sha256 '8b0e99a5ae278caf517193919232a02e1b56341ced5046aab434ecf139b81d16'
 
-  url 'https://www.iterm2.com/nightly/latest'
+  url "https://iterm2.com/downloads/nightly/iTerm2-#{version.dots_to_underscores}-nightly.zip"
   appcast 'https://iterm2.com/appcasts/nightly.xml',
-          checkpoint: '6cf0d7368f02b12bb025ac9561ec82955adc664d1aa850b9e07e852ff70f4825'
+          checkpoint: 'e9882404575bcbe5f5c7ae3bd11e4cdfd41d64851ceeae89532f9b7609ad8b22'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.