### PR TITLE
Update airmail-beta to 3.3,439

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.2.9,437,305'
-  sha256 '4ebe9bcedaf38452c611095429f40dff474a40c6918ebabecbfa4ea56562ab47'
+  version '3.3,439'
+  sha256 '503f66b93dbd065c1a4a9fbe2a88908143ee5fdbf5544f09f42123a3872a12e2'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'fae0f559e72c3b5b14b7ebdbc81c672f9f362e2c1490189303d336ff92c5b510'
+          checkpoint: '2dda353e9e220ffb207d26250734b5b462b46c23f263bc930b27e983dec5a959'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.