### PR TITLE
Remove `suppress_move_to_applications` and `shimscript` chmod

### DIFF
--- a/Casks/alfred2.rb
+++ b/Casks/alfred2.rb
@@ -11,10 +11,6 @@ cask 'alfred2' do
 
   app 'Alfred 2.app'
 
-  postflight do
-    suppress_move_to_applications key: 'suppressMoveToApplications'
-  end
-
   uninstall quit:       'com.runningwithcrayons.Alfred-2',
             login_item: 'Alfred 2'
 

--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -16,10 +16,6 @@ cask 'atom-beta' do
   binary "#{appdir}/Atom Beta.app/Contents/Resources/app/apm/node_modules/.bin/apm", target: 'apm-beta'
   binary "#{appdir}/Atom Beta.app/Contents/Resources/app/atom.sh", target: 'atom-beta'
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   zap delete: [
                 '~/.atom',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',

--- a/Casks/dash2.rb
+++ b/Casks/dash2.rb
@@ -8,10 +8,6 @@ cask 'dash2' do
 
   app 'Dash.app'
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   zap delete: [
                 '~/Library/Application Support/Dash',
                 '~/Library/Preferences/com.kapeli.dash.plist',

--- a/Casks/dash3.rb
+++ b/Casks/dash3.rb
@@ -12,10 +12,6 @@ cask 'dash3' do
 
   app 'Dash.app'
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   zap delete: [
                 '~/Library/Application Support/Dash',
                 '~/Library/Application Support/com.kapeli.dashdoc',

--- a/Casks/flux-beta.rb
+++ b/Casks/flux-beta.rb
@@ -13,10 +13,6 @@ cask 'flux-beta' do
 
   app 'Flux.app'
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   uninstall login_item: 'Flux'
 
   zap delete: [

--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -30,7 +30,6 @@ cask 'libreoffice-still' do
       #!/bin/sh
       '#{appdir}/LibreOffice.app/Contents/MacOS/soffice' "$@"
     EOS
-    set_permissions shimscript, '+x'
   end
 
   zap delete: [

--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -28,7 +28,6 @@ cask 'lilypond-dev' do
           #!/bin/sh
           exec '#{appdir}/LilyPond.app/Contents/Resources/bin/#{shimscript}' "$@"
         EOS
-      set_permissions shimscript, '+x'
     end
   end
 

--- a/Casks/sourcetree-alpha.rb
+++ b/Casks/sourcetree-alpha.rb
@@ -15,10 +15,6 @@ cask 'sourcetree-alpha' do
   app 'SourceTree Alpha.app'
   binary "#{appdir}/SourceTree Alpha.app/Contents/Resources/stree"
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   uninstall launchctl: 'com.atlassian.SourceTreePrivilegedHelper2',
             quit:      'com.torusknot.SourceTreeNotMAS'
 

--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -15,10 +15,6 @@ cask 'sourcetree-beta' do
   app 'SourceTree-Beta.app'
   binary "#{appdir}/SourceTree-Beta.app/Contents/Resources/stree"
 
-  postflight do
-    suppress_move_to_applications
-  end
-
   uninstall launchctl: 'com.atlassian.SourceTreePrivilegedHelper2',
             quit:      'com.torusknot.SourceTreeNotMAS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/pull/34871