### PR TITLE
Update atom-beta to 1.18.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.18.0-beta1'
-  sha256 '81c354b5bad8e1a775263e295e35706f41573bbea9e151200222da4638069e8f'
+  version '1.18.0-beta2'
+  sha256 '0134cc094e16d1d39156dd26aff46e99664567656f83a2fb984db7491f9b0dc8'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '2c5cfa18985150ad99fdf5c266922d41720ca8e7aef8d8bcb8fdb3b4ae2f6163'
+          checkpoint: '6fac9860be5ba1bbd0d60bcddc16e7badc07360763d8bfdd1e95bfb874b2d43e'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.