### PR TITLE
Update wine-devel to 2.9

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '2.8'
-  sha256 'a1281ffb7787f94f95d6f573fb1c2147abb281578fd8fcaabde9d270e82ee236'
+  version '2.9'
+  sha256 '4c6346deb83c819a3615dab386fdb64915e4cd4df4e73a1f4574691f74a8132d'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   name 'WineHQ-devel'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.