### PR TITLE
Update sublime-text-dev to 3132

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3131'
-  sha256 'a6817137f9482dc548efeed12207ef65bc065a1f82da881025ba0fa2e5508bc6'
+  version '3132'
+  sha256 'c35624d671c1730d20409b0e7d7937782e4a3560fde4de52a0c7a0e151b3dae0'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: '9273a252d145618dddcaf9e47a8b6ee29e6a32d30452a0b2ab10c2b5bf3190b0'
+          checkpoint: 'd505121641ff1b5b9c0aaadee9c3f437a3a973cbd93ffd6fdd9f8f999e2da83c'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.