### PR TITLE
Update electron-beta to 1.7.2

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.7.1'
-  sha256 'e26ff7e0bfea9775d58bc4aed26a85c6827967fc66c9f9a8c1f6f0e2e58382b8'
+  version '1.7.2'
+  sha256 '8c5d40ae6c2e94f80fd2400a0671390d8930349b18306837fe3f31b4e1ef59a2'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '72fe4eef9cf453d5cd2d6d65fdab88c03e6644967ffbb4598e27d41ea5a8ad28'
+          checkpoint: '1014293e532fd1bbc8e9e9253e4da37b622aa513bd3fdb38d85504c51c3b2f96'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.