### PR TITLE
Update dropbox-beta to 27.3.21

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '26.3.21'
-  sha256 '69ca9ecee99b58dab116ec9dd386d2a190e1782efe2cd2ea1d4fc13fcc7f4c39'
+  version '27.3.21'
+  sha256 '997fd6d008e9475771a70b3fdf6839141ec82fcd0d2f1e29fb6131164e33c918'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.