### PR TITLE
Update wine-staging to 2.9

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '2.8'
-  sha256 '2f544ff835c871ad9c17d375c5691ea351dbdb6778a99c751dd7aaa0bf3b15ab'
+  version '2.9'
+  sha256 '738c33008f2a0f09001d3068290111a28526e9dfdd1c4a72fcc7130f537ee6f6'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.