### PR TITLE
Update vivaldi-snapshot to 1.10.856.16

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.845.3'
-  sha256 'd542f8de1ccf1ee62353f617e6e11284e5eb8772bff00733b2cdca550fbd4520'
+  version '1.10.856.16'
+  sha256 '2b855a9f110d025a7a5e9d7c3ef3e4380e3ad0bebd9d1cc8ee49dd6bd4f0fdd9'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'dc48175d5d62efbbec9fa297e50788343de90a6d80750f924bd91b2985f3c08e'
+          checkpoint: '6c7a2a11ce539a03dc3c623c500c7894b04f364df1ac70c572e300be15b1c7f2'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.