### PR TITLE
Update telegram-alpha to 2.99.1.96620,395

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.96152,355'
-  sha256 '75ecffd934e11298f62a148efe1f0cf10fd182ce9b1fa0b7956b69deb693ddb9'
+  version '2.99.1.96620,395'
+  sha256 '3ec3acd5c75267302273d9722f64b152b603bda6060e5d12fb28576000aebf36'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7a019e2ce1220397da7e3575c0f6d80c7eeefd3b09d15170cfc50e5e87ffdd86'
+          checkpoint: 'f62d3d6683ee1b43346a354af614aeb7cb64ffdb083e17d8a1e47b5f2e57d673'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.