### PR TITLE
Update telegram-alpha to 2.99.1.96661,397

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.96620,395'
-  sha256 '3ec3acd5c75267302273d9722f64b152b603bda6060e5d12fb28576000aebf36'
+  version '2.99.1.96661,397'
+  sha256 '3b2fabb8f544bd11dfabdca6661c98d6e5465ca8eda1c578e4c5c06ab5a06850'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f62d3d6683ee1b43346a354af614aeb7cb64ffdb083e17d8a1e47b5f2e57d673'
+          checkpoint: 'c646f7b87c0d702f14aa28dc762faedced70771ee80224ed16db5a8a4c299c6c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.