### PR TITLE
Update rhinoceroswip to 5E92w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E78w'
-  sha256 '64ff68f675660fb3cc368c2571a38a14fa5c3d66b3abbcecab77f489a4674640'
+  version '5E92w'
+  sha256 '673e1852d4691a1db167b05371e77c1269d1bb28da601cac3776b7899f2ce41f'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '397ed876b1e6cc6d096dc4360c7b7463d6d89d108a5515e05b4072f4cee6969e'
+          checkpoint: '942f5fa2960cc2fef325bfff7c3c5fd0a0f2db0c5b4ddf934abcc6ef4e427bab'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.