### PR TITLE
Update telegram-alpha to 2.99.1.96758,399

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.96661,397'
-  sha256 '3b2fabb8f544bd11dfabdca6661c98d6e5465ca8eda1c578e4c5c06ab5a06850'
+  version '2.99.1.96758,399'
+  sha256 'b1b11550d1a6a49b54827cb9c5317b987357406b1b3e560a6bd0cbe7f1331b5b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c646f7b87c0d702f14aa28dc762faedced70771ee80224ed16db5a8a4c299c6c'
+          checkpoint: '63dbe93baa1103e70e21deb69723a110aed57c0dc1471a90744b82f67e6a0d6f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.