### PR TITLE
Update vivaldi-snapshot to 1.10.862.6

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.856.16'
-  sha256 '2b855a9f110d025a7a5e9d7c3ef3e4380e3ad0bebd9d1cc8ee49dd6bd4f0fdd9'
+  version '1.10.862.6'
+  sha256 'a85fb509600d533e8cdf420ea5d6eccc147384c244d8a43e43f542bcdec20b0f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '6c7a2a11ce539a03dc3c623c500c7894b04f364df1ac70c572e300be15b1c7f2'
+          checkpoint: '08d0d2a168952836c9d691a1e6d1573ab69f55a42ded10543447abf8d42f9a83'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.