### PR TITLE
Revert "telegram-desktop-dev: set auto_updates true"

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -7,7 +7,6 @@ cask 'telegram-desktop-dev' do
   name 'Telegram'
   homepage 'https://desktop.telegram.org/'
 
-  auto_updates true
   conflicts_with cask: 'telegram-desktop'
   depends_on macos: '>= :mountain_lion'
 


### PR DESCRIPTION
This reverts commit e229bc5bfb96b1eec3f7f00e8b8fe78c5a08034c.
The problem is that we mix different branches of this app during updates, because stable version may be higher then alpha. So one may install this will break [cask-upgrade](buo/homebrew-cask-upgrade) for this cask, because one may install it when it has app from stable and will not get next alpha version. 