### PR TITLE
Update opera-developer to 47.0.2615.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '46.0.2602.0'
-  sha256 'fec28f76ff5f7225254bd6b0126406c1ca7fba71888c5b9acb4a22d0f68baef6'
+  version '47.0.2615.0'
+  sha256 '37abd28e18c8c5b86415f5510637f8d63c01ead2e34870a30f2966f52539c631'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.