### PR TITLE
Update sketch-beta to 45,43276

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '44.1,41454'
-  sha256 '552fc1ecd00ea75af3742dc36786a1b3ebe36ebf45637d54e67e02e94413a24d'
+  version '45,43276'
+  sha256 '32df24ea5f23fba293d080cbc59d2e90e62c6480d00bff08f3fd6fbb9d88175e'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '4adc022456901074ec346158ad8ce074fcb2cbaa1075ab7a15ad533877b37ec9'
+          checkpoint: '156a6feda72473dc788aa7f938e5d36523966d9602b4a15e9d7a301542fbb76d'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.