### PR TITLE
Update virtualbox-beta - add uninstall preflight

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -10,6 +10,12 @@ cask 'virtualbox-beta' do
 
   pkg 'VirtualBox.pkg'
 
+  uninstall_preflight do
+    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack-beta")
+      system_command 'brew', args: ['cask', 'uninstall', 'virtualbox-extension-pack-beta']
+    end
+  end
+
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       %w[--unattended],


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Checks to see if `virtualbox-extension-pack-beta` exists at 
`"#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack-beta"` and uninstalls if it is found.

https://github.com/caskroom/homebrew-cask/pull/35226