### PR TITLE
Update toggldesktop-dev to 7.4.42

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.40'
-  sha256 'b125f6cee7adaa8256de77a38068220172588aa1775a7b82332975b3ca49007f'
+  version '7.4.42'
+  sha256 '14430977b771a368f281138fc45b8deec4dfb9780f33ce9c7cf72e2e8f6238c0'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '89fda5bdf78b28f10c09bccb86e3a88e5492fd3ded7bd0080bff07cda66a284e'
+          checkpoint: '23dcc17a2673d305bbd9673323f50eac768aca18c0e6f485f6438b12cadffb3e'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.