### PR TITLE
Update vivaldi-snapshot to 1.10.867.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.862.6'
-  sha256 'a85fb509600d533e8cdf420ea5d6eccc147384c244d8a43e43f542bcdec20b0f'
+  version '1.10.867.3'
+  sha256 '56e879fb8254c48f6048cce936fb114df636df6b3a1f7abafc7324bc814d7c37'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '08d0d2a168952836c9d691a1e6d1573ab69f55a42ded10543447abf8d42f9a83'
+          checkpoint: '513d0f97b2edd625a7c5b40cfac77b82d82f8a3e785058cf722daf1642af3532'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.