### PR TITLE
Update sourcetree-beta to 2.5.3b1

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -1,11 +1,11 @@
 cask 'sourcetree-beta' do
-  version '2.5.2b2'
-  sha256 '3037c3d9124a4b402989a784fad50c6cd07f42031e9df61aff2493e956810440'
+  version '2.5.3b1'
+  sha256 'e2ed396cd9938f247b0231db1e98e9e85205698606cf2b5a9fafe3e910cb23f1'
 
   # atlassian.com was verified as official when first introduced to the cask
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastBeta.xml',
-          checkpoint: 'd68b7d313b143c7764d7e00500b63a3befffc19b80c4dffe9710f584a73e6de9'
+          checkpoint: 'acde869179a03e9bc8547e7467d291b5d1f5c1d001f51d9274a9e76ca94ab426'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.