### PR TITLE
Update electron-beta to 1.7.3

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.7.2'
-  sha256 '8c5d40ae6c2e94f80fd2400a0671390d8930349b18306837fe3f31b4e1ef59a2'
+  version '1.7.3'
+  sha256 '083388a2c3b4fabaea02d7a5f7ac1f87c70ce44a828585c7a84b238ea1f9973a'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '1014293e532fd1bbc8e9e9253e4da37b622aa513bd3fdb38d85504c51c3b2f96'
+          checkpoint: '7ab41f4712a993ed6548558a86a6ea608254b5161cfe306bd5cd336df5204c2f'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.