### PR TITLE
Update visual-studio-code-insiders to 1.14.0,4541e70733f110ada8d0b4266bc922565d74950a

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.13.0,f977399d58f7b64db35047fafe0c6e59e15f11d5'
-  sha256 'a97eefd661c0182164d6f6185ec473d9dbb758924beeac0b7ee44b845ef8ded4'
+  version '1.14.0,4541e70733f110ada8d0b4266bc922565d74950a'
+  sha256 '30adb8048a2b73b418dc8e312cab97f37285c17c3d07630efd752a41f1dcb76d'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.