### PR TITLE
Update safari-technology-preview - add High Sierra version

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,10 +1,18 @@
 cask 'safari-technology-preview' do
   version '32'
-  sha256 'd728879a085817f8c87106bafbe30f2fa30c71b090daa26e5624fce5a373b431'
 
-  url 'http://secure-appldnld.apple.com/STP/091-15727-20170607-1AFFE048-4A2F-11E7-B717-E0A12D6174CC/SafariTechnologyPreview.dmg'
+  if MacOS.version == :sierra
+    sha256 'd728879a085817f8c87106bafbe30f2fa30c71b090daa26e5624fce5a373b431'
+    url 'http://secure-appldnld.apple.com/STP/091-15727-20170607-1AFFE048-4A2F-11E7-B717-E0A12D6174CC/SafariTechnologyPreview.dmg'
+  else
+    sha256 '99cfe1aa255f83c8556dcb6f4dd3bc624b7268b2e56fbea5168fc5c43f9a3f63'
+    url 'http://secure-appldnld.apple.com/STP/091-07971-20170607-1AFFE2D2-4A2F-11E7-B717-DFA12D6174CC/SafariTechnologyPreview.dmg'
+  end
+
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'
+
+  depends_on macos: '>= :sierra'
 
   pkg 'Safari Technology Preview.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Add High Sierra `version`

Add `depends_on macos: '>= :sierra'` https://developer.apple.com/safari/download/