### PR TITLE
Update wine-devel to 2.10

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '2.9'
-  sha256 '4c6346deb83c819a3615dab386fdb64915e4cd4df4e73a1f4574691f74a8132d'
+  version '2.10'
+  sha256 'fb5d6b20c9e42f699afda175b50bf896540b9d127cd38858a11554be84f5f7e7'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   name 'WineHQ-devel'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.