### PR TITLE
Update vivaldi-snapshot to 1.10.867.27

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.867.3'
-  sha256 '56e879fb8254c48f6048cce936fb114df636df6b3a1f7abafc7324bc814d7c37'
+  version '1.10.867.27'
+  sha256 '29af8b26a3454579663b30a541f0ac4e6e95f48d020480eee1e2b7c68f9444b5'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '513d0f97b2edd625a7c5b40cfac77b82d82f8a3e785058cf722daf1642af3532'
+          checkpoint: 'ab9fe8cc38012de103dab485205c0156cbee41b2559dde1ba07f03622e3766fb'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.