### PR TITLE
Update vivaldi-snapshot to 1.10.867.32

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.10.867.27'
-  sha256 '29af8b26a3454579663b30a541f0ac4e6e95f48d020480eee1e2b7c68f9444b5'
+  version '1.10.867.32'
+  sha256 'a2922f96eb642461bb51a1209e588411e40db0103546ada038a1185eeaace667'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'ab9fe8cc38012de103dab485205c0156cbee41b2559dde1ba07f03622e3766fb'
+          checkpoint: 'a24ab07c620a9ec5999e314af23db374483d83e3ed9a3b74b55b51281cb7170f'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}