### PR TITLE
Update toggldesktop-dev to 7.4.47

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.46'
-  sha256 '3e5fbe9fd08c05bd65b045f72d1de6b6dccd227fd0912b974f1cb10b965d6098'
+  version '7.4.47'
+  sha256 '1dd41946486763c767aa25ecf425e3cbf529c7bd95060a88776655581df627f7'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'e5703d50d9fde16d9c557b109217663de763995e71d907cae3c65dd38e9347a9'
+          checkpoint: '6a0c79f360da2c7c4c6f611b04932f57fe5922d83da2edb0e80da3c8d028d50c'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.