### PR TITLE
Update rhinoceroswip to 5E104w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E92w'
-  sha256 '673e1852d4691a1db167b05371e77c1269d1bb28da601cac3776b7899f2ce41f'
+  version '5E104w'
+  sha256 'c3819d45eef808839f608030ec6ef1743af697f5b4fd962bbc1609fdcb8a4e9f'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '942f5fa2960cc2fef325bfff7c3c5fd0a0f2db0c5b4ddf934abcc6ef4e427bab'
+          checkpoint: '2e86cec1d2200fe9a2ada8d3b2c88bd7c7f0aa25a0b376a9f660a5b6e5e0c631'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}