### PR TITLE
Update java9-beta to 1.9,174

### DIFF
--- a/Casks/java9-beta.rb
+++ b/Casks/java9-beta.rb
@@ -1,6 +1,6 @@
 cask 'java9-beta' do
-  version '1.9,173'
-  sha256 'b32eb31e88caccbd70dc94ce23c3caf7028122f632d4518f0d3a83e73161fbb7'
+  version '1.9,174'
+  sha256 '26bc393ebf422edf9ffb04a92e5be604b390e13eb532c12eba9f0ad20d5ef4ba'
 
   url "http://download.java.net/java/jdk#{version.before_comma.minor}/archive/#{version.after_comma}/binaries/jdk-#{version.before_comma.minor}-ea+#{version.after_comma}_osx-x64_bin.dmg",
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}