### PR TITLE
Update docker-edge to 17.06.0-rc4-ce-mac15,18357

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.06.0-rc2-ce-mac14,18280'
-  sha256 '938790287fa6c4bf94858a05fbf4a9cda9b3f641dcbe54710a5b8880a6104136'
+  version '17.06.0-rc4-ce-mac15,18357'
+  sha256 '36146ccefe4101be190f6099852260c0af78b6b118b14805952ba4872da894e7'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: 'e6b8be3b34526dea511b46478aef47c2cfbdefe9d3479df0daa4363b851edc55'
+          checkpoint: '9442a13e46c70f0b7ea23f6b60cba8b489f8d31e791cc1624aafccfc090b25d4'
   name 'Docker Community Edition for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}