### PR TITLE
Update firefoxnightly to 56.0a1

### DIFF
--- a/Casks/firefoxnightly.rb
+++ b/Casks/firefoxnightly.rb
@@ -1,5 +1,5 @@
 cask 'firefoxnightly' do
-  version '55.0a1'
+  version '56.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 
   language 'cs' do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.