### PR TITLE
Update firefox-esr to 52.2.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '52.1.0'
+  version '52.2.0'
 
   language 'cs' do
-    sha256 'baedabffbfdcef9d3cf08d1971a7b1c83293345f74130d64af32202de9bf6e97'
+    sha256 'c17de949170124735616d70004251775635f5279c0d89dca0a97c906a20ad326'
     'cs'
   end
 
   language 'de' do
-    sha256 'd59a72100c1bd6339f3bbc40fe211f0a9a3fc16e9b1b51c067885f7c3c247e1c'
+    sha256 '64509378f1c9a6ed7f6edd4040e0f7548a047047faf0d04037cf9f6de415ed9e'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '341230c9e57ed2c04af65334c7b4d0132df5b743f18d7d485ef801b80ca9ec46'
+    sha256 'b1af75ee02c76c560fe560799c3a01839f22dec43dbeb6c7466e8298b6f51d04'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'c6f8f07bcab2782825538bbfc34eb46396b14e67f95993e7b06555d6b8b6b9a6'
+    sha256 'e83c0dea856a5b5dc92a745e7c8372c500017145db622a12ac11f6ee8cb3069b'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '6ed596b27678618b94787cacb6825eb1a50b1f79333fa2a472f18c9340159475'
+    sha256 '0f3ff17eabc55d446a0776e0fe62be1665b1eb1ce50932232f27a8af844eee13'
     'fr'
   end
 
   language 'gl' do
-    sha256 '9212efcdb2dd26a3695295add54ed0f7dc54a16fdcbc6d4c46c5611cabe17e7d'
+    sha256 'ac1491917226d115cdabaccd5ba84a86ee4f6726f219d4b5f7a8f695b2c08bdf'
     'gl'
   end
 
   language 'it' do
-    sha256 '0302f198f06e8707d4e963dc996aab8b4b514b18278b569f72887c9e82fa9c21'
+    sha256 'a141cd38e65adfd1e011d7eeb457549a097a1d0514df8616e78d4a6a74752642'
     'it'
   end
 
   language 'ja' do
-    sha256 '20403786bd6fb54024149ecf6acad55ddaf440ecccf9412d154cd79dfedcabb6'
+    sha256 'c7e9428746a0f20cda28486a5c650f3888b0e9198dfc7c83cbea85ee76060ce3'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'fcfd7f62fd26bed1b25db6e5497ab739cbac1de45659fa59f814dfad1b5cf1d1'
+    sha256 '432e56f7a61f5d867a294fcafd5607f8c0c1688b93fb4a82195ca9de8e35ce91'
     'nl'
   end
 
   language 'pl' do
-    sha256 'ac4b5c73f68ca7fa8b7771b9b5b3e308484e26c5e484004b08375d2a26c5c06e'
+    sha256 'd7bf67536b4a3eb0a1e1441bfe2e4a542867d2a61dd15e84f122a174ff8b8386'
     'pl'
   end
 
   language 'pt' do
-    sha256 '8d7607c6a9b8c523e9362e625e418ab96bc66f51f46c288beeb936b2c9ba5725'
+    sha256 '5e75c03130223983865d8a210bae3e13eb560328f2bd9c147e92816e882c526c'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '9f2c360fe70d2f72752c82db8083ba7ff78be4940353d5987e821feab5754f01'
+    sha256 '9a26e216af4ae5b0e70aad282592e1ea19906f8a28fd19c1b7859f372abd5f12'
     'ru'
   end
 
   language 'uk' do
-    sha256 '78290d152f505e267795c9cf534f1170ede418908d87b2e63f644fe2724db6ec'
+    sha256 'e6059383279232b90ed5159723312fba343d9d815106cb7033e61518e2f6e22b'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'b0add3b2b21b3a48f027e69e38764c0b56d71816fcd7f5fa89f41765389b83e9'
+    sha256 '6a6ee3a667d3d63da34a0a82cf86a30ef7c00b7ba56b79c61e3cdf5218857230'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'c02f1505c91240b24d9bd9dfc586c329de8958a40626b1f0a27b987da6a13314'
+    sha256 '5add0fded82f7f44fa6df1b0e7d9b358f34eb91a96d4bbc3b7bc1aaa8c625b5c'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.