### PR TITLE
Update telegram-alpha to 2.99.1.97664,419

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.96953,403'
-  sha256 'e97911be6cd994f5963c69a114d81ca58b582b96a629a246fda0d4db90693573'
+  version '2.99.1.97664,419'
+  sha256 'feb6f3fc140862fbcf379a7c469efe7694e5a438127be264c3098c1ff9fd47ed'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2b88ab3d91e78c2b3d3a79b6dd82c51721399be4c8f333d157f6f0393104f78e'
+          checkpoint: '0d40c18fb93f2ac25211de3ad713da1a9ece09a18d5dcd754e89e397df428eb1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}