### PR TITLE
Update toggldesktop-dev to 7.4.50

### DIFF
--- a/Casks/toggldesktop-dev.rb
+++ b/Casks/toggldesktop-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-dev' do
-  version '7.4.48'
-  sha256 '9a6ad3b2d8a843091bb2a185090d0b25cf5ef2991ce01ebaf9dcbdf5278db55a'
+  version '7.4.50'
+  sha256 'b1bc5622b46370c4b55823578d606476edb99b60ab1ace9085a826271dfc6f81'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'f97d9c99738e14f2ee92b87da235e28ba09cbedc09d837b9788c038f78d4da33'
+          checkpoint: '25e8f431647e37433ee3ad04e22177cb5482444533d0258aeb41c6f3607491aa'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}