### PR TITLE
Update opera-developer to 47.0.2628.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '47.0.2615.0'
-  sha256 '37abd28e18c8c5b86415f5510637f8d63c01ead2e34870a30f2966f52539c631'
+  version '47.0.2628.0'
+  sha256 'e0f3cc07e0966d4b4620ca833c8eefc4a9361e31f663ba0fa2e82d858ea5ff87'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}