### PR TITLE
Update sketch-beta to 45,43458

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '45,43445'
-  sha256 '7e0533d80cc3148e7145aeb2fefcd1ba40ad58211a312d6b3f30b9fca8b403bd'
+  version '45,43458'
+  sha256 'b0494b36bd63bfda5467d488f85dc0acec4a141b0cf8da676ef7d27b6be86c73'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '5819d13af65deb62f75c3739840c799539deb5f169f1ffe10ed0459293d8bd69'
+          checkpoint: '35c1c2ac7e2c74d2d972ab44717134a85372fb7f7579f7897c15dbfe52a5d9c2'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}