### PR TITLE
Looks like a silent bump to '1.19.0-beta1'

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
   version '1.19.0-beta1'
-  sha256 '6a853f4b5e8734bfd5e4126eec158a36b97639eb7ede7b71538951397e599a86'
+  sha256 '3bb135a1ae6ad10fb8bce9f49a2a7b9a50a3fa9e82c1537fcf44ae0e1b631d08'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '87135fecea7358a3412a9010a0e30cbe08c2cc4e6b181505e9d774900c1731a4'
+          checkpoint: 'a41308774b0a3a467420dc1ff6ecd72e0aaa0aee774b551cb4be6dfb83c45d8d'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
```
Error: Checksum for Cask 'atom-beta' does not match.

Expected: 6a853f4b5e8734bfd5e4126eec158a36b97639eb7ede7b71538951397e599a86
Actual:   3bb135a1ae6ad10fb8bce9f49a2a7b9a50a3fa9e82c1537fcf44ae0e1b631d08
File:     /Users/benc/Library/Caches/Homebrew/Cask/atom-beta--1.19.0-beta1.zip

To retry an incomplete download, remove the file above.
Error: Install incomplete.
tyr:~/Library/Caches/Homebrew/Cask benc$ brew cask info atom-beta
atom-beta: 1.19.0-beta1
https://atom.io/beta
Not installed
From: https://github.com/caskroom/homebrew-versions/blob/master/Casks/atom-beta.rb
==> Name
Github Atom Beta
```

new sha and checkpoint; "re-released" 8 hours ago.... URL below

---
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [X] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: https://github.com/atom/atom/releases/tag/v1.19.0-beta1
