### PR TITLE
Update sublime-text-dev to 3139

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3136'
-  sha256 '8792e8cf88eef5270cdff79242933f854a81440b3c04f96b24f3de787a4f5cd3'
+  version '3139'
+  sha256 'c043e391558f7d0c2fab45a34f1f8af6835224256a42c2e83b9f42279d153b62'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: 'e7996807ae04c7548d41dd076506afa01d983a8eb859a2ddf4b3fa35eb3aed15'
+          checkpoint: 'a2e370441a5c7de9ae9bb5b5e980c06202769cafb6bfd12e5cb6c02c4d4e0876'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}