### PR TITLE
Update telegram-alpha to 2.99.1.97752,423

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.97710,421'
-  sha256 '1a79e42611937e55aad198595455cf504260d63b89a36da3e24586c24ab4470d'
+  version '2.99.1.97752,423'
+  sha256 'a560bdf487746be7ebfc82548ba7f2705953555fc8c78fa1553b4e91b49ab492'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '877140c5f003dbc0c974df66944f1456c55ff577bbeb86bca0679331f2bea04c'
+          checkpoint: 'eddadd297e452b4b5836ef2c93d3c40d2748e372fcf8d70fed319abb1cfe43b1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}