### PR TITLE
Update firefox-beta to 55.0b3

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,77 +1,77 @@
 cask 'firefox-beta' do
-  version '55.0b2'
+  version '55.0b3'
 
   language 'cs' do
-    sha256 '76f9dad8c41a305e5f424b5d9087efdba91e6dc2d43deaa5736c8a49aa7dc925'
+    sha256 '034630bd82cf2fa0374721fbd03f5ccb830c9b065a8d561ae64ccf597bb7f8d1'
     'cs'
   end
 
   language 'de' do
-    sha256 '6e42bb71fe8e650c0219724311ecb8a6229ca16f51d51158066313c0d8ce1f94'
+    sha256 'afc9f79a8f674e477c8db451981ecb880475f9dd50c907a216324bfc264e3e12'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a016b54640de64a06847ec28873aaaf581b526cab22f65c346835001aef0edfb'
+    sha256 'a25097b84b7b1099e45338de1d9a7f9e3e3a6840351245d9c86493905004d1d4'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '2ef42f71185ad24f0f22c8e0b325829836c5bcf96e2c37da075ce5172bd5ce4c'
+    sha256 '3e4f099b8b24f0a7db1e36577a75574ed3364f5159b0c1927fedaff4e779dcc8'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'a0db0943d23a9e0334a2126e65ede98326c4ac3165b1e0984b6de1878c39ac62'
+    sha256 '022ae088361e8ecfac15a7937d0073fa4d2d288729bc0116fc32f4c75c0a6247'
     'fr'
   end
 
   language 'gl' do
-    sha256 '31b7347d2d3dd271d70b6e3e1ac87483f3d8158867cb34814d52f666f0f12cd6'
+    sha256 '490a117526b05ad344640f6e9bdbcf446109c2f7e58bb4332af0cf826b1cc53a'
     'gl'
   end
 
   language 'it' do
-    sha256 '535c561374ca4d1f3daa845e46b37095b270a7ab51026e3c198e96ee892f6587'
+    sha256 '538b6c81cbed8bedf77cf48afedcf0c64a7b62cd9185f6cf15ad9548604ee0cf'
     'it'
   end
 
   language 'ja' do
-    sha256 '507100d6e2b2112cbcf23f1d06a5f7fc1c66cccfa599c40c9f9e6ce19f058483'
+    sha256 '925ae24fe812be3fe86d9613c4b6478f70613c8abf774ba6c1c831237c983385'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '9b3902670d647eb56bc0dd65efed21196e6ed88e5c37716fe49dbc17c67d7b3c'
+    sha256 '998e53bde9e85457a02d177e878a388962819f559e531f6a3b607d1d0d57c52a'
     'nl'
   end
 
   language 'pl' do
-    sha256 'd49fad36611d695342329fd552e5b212a3a5bfd681dca43f5bda56eb6aa47c21'
+    sha256 'deccac5ce54e0ea57587ecf674921f0a8c5032525ef0d033d4d5c4740ed2cd96'
     'pl'
   end
 
   language 'pt' do
-    sha256 'f85ae8f1e47cfaff3999686710bc6bd342dac319c4039a404aab4e4e3d6b9f5b'
+    sha256 'c5822dc5da8886a0416f004cd49e9bbf857477955203c425b4bcdaf50e5ebd22'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '1f5371c1cda55de77c0269c275f4c8aaa4389411d6641d7579c92365ac45457a'
+    sha256 '95fea84d7ae7fe8ed53c8e3890041ab747818d6e449de2c8bd581741fc863c20'
     'ru'
   end
   language 'uk' do
-    sha256 '6d495aacb3d067e1b57711a9a3b4329c8c6280f92fa49e5b537e08883b36d070'
+    sha256 '7c4c79494045e5d38e552fb03f5309e9e551235fb9596699aa1f0e736a17c8a6'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'af292fa0013dee9d36cefc4568dd6f8b1faf4a93cab125d6706765101819c265'
+    sha256 '8fe0c8884490fa6dadf6ca2a5773ac7c74d923ed2d09fd068bd82f77e51733d7'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'a67d59d82aedf4e6fb92dd6664b4a01f672b5cf9eb2472c9069c5f20d9f077e6'
+    sha256 '31ed7e812af44f37b3cdb17bfa466fb8167515205d6e350955f3aef1cf76a15b'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.