### PR TITLE
Update blender-daily to 2.78-9e08019b74c

### DIFF
--- a/Casks/blender-daily.rb
+++ b/Casks/blender-daily.rb
@@ -1,6 +1,6 @@
 cask 'blender-daily' do
-  version '2.78-18e1c8d9fa6'
-  sha256 'f3199d165f66c249d28283aff14eb39163125eefd6a224b46258b554fcd228c2'
+  version '2.78-9e08019b74c'
+  sha256 '8f1ac625ab231b7a4423954faf594fa491c69c59617a8791f3b7383b407076d5'
 
   url "https://builder.blender.org/download/blender-#{version}-OSX-10.6-x86_64.zip"
   name 'Blender'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}