### PR TITLE
Update toggldesktop-beta to 7.4.52

### DIFF
--- a/Casks/toggldesktop-beta.rb
+++ b/Casks/toggldesktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-beta' do
-  version '7.4.47'
-  sha256 '1dd41946486763c767aa25ecf425e3cbf529c7bd95060a88776655581df627f7'
+  version '7.4.52'
+  sha256 'e1f3d35a47d0b150f46aba5457833873932e735a232a1b8eeb5995222fa0bed9'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: '488bf8d588a185a9ab048bf0e129a7c13f0f3a1f52611f3a668e7223179eb406'
+          checkpoint: 'b726b959ada19efb3ea5bd2ab6085e6ae55ccb059cba0750226b0e2a6046a96d'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}