### PR TITLE
Update telegram-alpha to 2.99.1.97804,426

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.97752,423'
-  sha256 'a560bdf487746be7ebfc82548ba7f2705953555fc8c78fa1553b4e91b49ab492'
+  version '2.99.1.97804,426'
+  sha256 '8fa39474ec9b84bd606f56fb4c3173e74c8f1244dddbe0db983d81d982287c2b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '78367175e2dbf9e76d7fc657d997074eb861abce54a9a555292e5e9f33fe31b4'
+          checkpoint: 'd73c2c81e26f62cabad1cacf3645890c5cca6537b6bdedf3849d0c112b838eec'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}