### PR TITLE
Update virtualbox-beta to 5.1.23-116306

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-beta' do
-  version '5.1.23-116259'
-  sha256 'ffd6ebb40d01f49d5d48cf5bdfb3dbc2a515f734495ecf802b1fccad2f5e68df'
+  version '5.1.23-116306'
+  sha256 '12980895779f24ebd451a3d39e02d5870f208b50666efc3c0b023263fe96ee01'
 
   url "https://www.virtualbox.org/download/testcase/VirtualBox-#{version}-OSX.dmg"
   name 'Oracle VirtualBox'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}