### PR TITLE
Update iterm2-beta: zaps and appcast

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,8 +1,11 @@
 cask 'iterm2-beta' do
+  # note: "2" is not a version number, but an intrinsic part of the product name
   version '3.1.beta.5'
   sha256 '9b16a793b9f7001dfd190bb3318f79622b5bb590f3d423ea4cd5d17256df92ce'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
+  appcast 'https://iterm2.com/appcasts/testing3.xml',
+          checkpoint: '8a198b466129d5221834404f8553a6818801415de19e1bfedb34bcba94014824'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 
@@ -11,5 +14,12 @@ cask 'iterm2-beta' do
 
   app 'iTerm.app'
 
-  zap delete: '~/Library/Preferences/com.googlecode.iterm2.plist'
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl',
+                '~/Library/Application Support/iTerm',
+                '~/Library/Application Support/iTerm2',
+                '~/Library/Caches/com.googlecode.iterm2',
+                '~/Library/Preferences/com.googlecode.iterm2.plist',
+                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
+              ]
 end


### PR DESCRIPTION
Just bringing this formula in line with the [iTerm2 stable formula](https://github.com/caskroom/homebrew-cask/blob/master/Casks/iterm2.rb), mostly so that a zap will remove all files. Also added the appcast url.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
