### PR TITLE
Update iterm2-nightly.rb: zaps and appcast

### DIFF
--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -1,19 +1,25 @@
 cask 'iterm2-nightly' do
+  # note: "2" is not a version number, but an intrinsic part of the product name
   version :latest
   sha256 :no_check
 
   url 'https://www.iterm2.com/nightly/latest'
   appcast 'https://iterm2.com/appcasts/nightly.xml',
-          checkpoint: '6cf0d7368f02b12bb025ac9561ec82955adc664d1aa850b9e07e852ff70f4825'
+          checkpoint: 'e794f198e02f5cf454ee4fc892c37f2bed8d453579a4adce756602c1b8507fd8'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
+
+  auto_updates true
+  depends_on macos: '>= 10.10'
 
   app 'iTerm.app'
 
   zap delete: [
-                '~/Library/Preferences/com.googlecode.iterm2.plist',
-                '~/Library/Caches/com.googlecode.iterm2',
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl',
                 '~/Library/Application Support/iTerm',
                 '~/Library/Application Support/iTerm2',
+                '~/Library/Caches/com.googlecode.iterm2',
+                '~/Library/Preferences/com.googlecode.iterm2.plist',
+                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
               ]
 end


### PR DESCRIPTION
Just bringing this formula in line with the [iTerm2 stable formula](https://github.com/caskroom/homebrew-cask/blob/master/Casks/iterm2.rb), mostly so that a zap will remove all files. Also added the appcast url.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
