### PR TITLE
Update iterm2-nightly - remove appcast

### DIFF
--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -4,8 +4,6 @@ cask 'iterm2-nightly' do
   sha256 :no_check
 
   url 'https://www.iterm2.com/nightly/latest'
-  appcast 'https://iterm2.com/appcasts/nightly.xml',
-          checkpoint: 'e794f198e02f5cf454ee4fc892c37f2bed8d453579a4adce756602c1b8507fd8'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`version` is `:latest`