### PR TITLE
Update sketch-beta to 45,43473

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '45,43458'
-  sha256 'b0494b36bd63bfda5467d488f85dc0acec4a141b0cf8da676ef7d27b6be86c73'
+  version '45,43473'
+  sha256 '5ce251ab9b3ca86422b08f41f2ce7cdf4900eb25dfe0d10af5f76a4c99ee880f'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '35c1c2ac7e2c74d2d972ab44717134a85372fb7f7579f7897c15dbfe52a5d9c2'
+          checkpoint: 'ebeb77a1f54a1c490190959555bf931aabc629af4cda1c9b5c0a2c3b06eb5959'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}