### PR TITLE
Update telegram-alpha to 3.0.97867,437

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.97843,433'
-  sha256 'f3380e1ea30a27f84dcf7fb317dc3a059ae5f71b16c3340195a2db493cade892'
+  version '2.99.1.97856,435'
+  sha256 '04a7d9a14394d87758750d4118b237675dbf6379902e1808df87131d804c93d3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '29e1f48e36ce49cb3400e478f7f0ddb1025e8f9180592b8b96b24e962fd42c68'
+          checkpoint: 'dc08fd8b5e3d3dceb2040a56cac9ef35222e614f56dc4908d7b97d1dbe10953a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '2.99.1.97856,435'
-  sha256 '04a7d9a14394d87758750d4118b237675dbf6379902e1808df87131d804c93d3'
+  version '3.0.97856,43'
+  sha256 '4b02beed2160c35784f3aba0d4f964ced537cfb2ebe23ab9a6d761188a956e61'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'dc08fd8b5e3d3dceb2040a56cac9ef35222e614f56dc4908d7b97d1dbe10953a'
+          checkpoint: '20d25f5ac3d5ee672c4608f9c1cbfcb36bb6e4c1c9610c611945de5236caebcf'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.97856,43'
-  sha256 '4b02beed2160c35784f3aba0d4f964ced537cfb2ebe23ab9a6d761188a956e61'
+  version '3.0.97867,437'
+  sha256 '9e328af66a881d821b796c76dfd557bc1498127bfa64f51bc1af345403338837'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '20d25f5ac3d5ee672c4608f9c1cbfcb36bb6e4c1c9610c611945de5236caebcf'
+          checkpoint: 'c97ebfc1c1466eca80df05392e49190ee19091a2c44e0e593388e87054959b32'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}