### PR TITLE
Update atom-beta to 1.19.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.19.0-beta1'
-  sha256 '3bb135a1ae6ad10fb8bce9f49a2a7b9a50a3fa9e82c1537fcf44ae0e1b631d08'
+  version '1.19.0-beta2'
+  sha256 'a3c049608655633204094b8610f2652757b3934beb132d391b9916cd168029a4'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: 'a41308774b0a3a467420dc1ff6ecd72e0aaa0aee774b551cb4be6dfb83c45d8d'
+          checkpoint: '6c2cf8265ecc8d6b99459ae473bca18a3c00d86b92c95ba1b3da2b7f5ab5406f'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}