### PR TITLE
Update telegram-alpha to 3.0.97886,439

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.97867,437'
-  sha256 '9e328af66a881d821b796c76dfd557bc1498127bfa64f51bc1af345403338837'
+  version '3.0.97886,439'
+  sha256 'e6f22c7fb837ee4cf7ffd525e9c5f0656689514422d5557c6a4b4b036df94bf9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c97ebfc1c1466eca80df05392e49190ee19091a2c44e0e593388e87054959b32'
+          checkpoint: 'abde3d5cf8a0addbeaf9b98cad569d4744612b169310f60168c5d1058aac2500'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}