### PR TITLE
Update telegram-alpha to 3.0.100006,442

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.99999,441'
-  sha256 '09db3ebb5fbda92572ac8d255e2b668589895db5cd96753b6596d70c3a8ff8eb'
+  version '3.0.100006,442'
+  sha256 'eb4eb06f849658980b15f2e5c1d227a2c4389efd05cc8e5203acbab025e88faf'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'abde3d5cf8a0addbeaf9b98cad569d4744612b169310f60168c5d1058aac2500'
+          checkpoint: 'a17de700133d950b6b9a740db83a38d6ca29bc75189f75c353742bf66a51730e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}