### PR TITLE
Update docker-edge to 17.06.0-ce-mac17,18432

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.06.0-ce-rc5-mac16,18400'
-  sha256 'fcc395fefad724739032108359dff63b82182e05e5804cd4cf796adc96cd3cd3'
+  version '17.06.0-ce-mac17,18432'
+  sha256 'afe78bb9734b2e0cca623418715a0c7b249a18032fa8f658c0307d1d41bc478e'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: '2e5e4b1a07f3aa36df67409c4bc0ab76d693d8455bd0581ded136d4b1038322e'
+          checkpoint: 'd513c640e5da154f9acd23e6144bd8113da2ab65f889a3e76476e760cbc57644'
   name 'Docker Community Edition for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}