### PR TITLE
Update telegram-alpha to 3.0.100025,446

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.100009,444'
-  sha256 '3e2fd653cc3312dc22c7a22c28bab625bb8c95afafb1543fc6e3b74e9a352a7a'
+  version '3.0.100025,446'
+  sha256 'eaffa19c08817519a3491c8986521a60e386bcb572a27352aa0ec7e6750d8e9b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '3e336bfa71a32c34d2876bccefcf41cd82d9fa5114c2fefbed8bb87ad55b0689'
+          checkpoint: 'b2e0c4eef52d13e4b14e70c5b31ffc7b48435a7d7cedfa337519b468a36f5a10'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}