### PR TITLE
Update vivaldi-snapshot to 1.11.890.4

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.11.882.4'
-  sha256 'df6eb75a091f348cd1c9d33834aed972c807d00be7d34839c2d7c93f654ceab7'
+  version '1.11.890.4'
+  sha256 'e93772e0b5122681663c2b9ac87f63bb7e483a9b5ad2356cf8fb41727da9bf4f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '517cfe868ae70118120165425f702b8b5ae920423526014702094729cd9fb2bd'
+          checkpoint: '447b01086d75e284be60ae8383eae624ddf082d3c95b3ee9a6bf24cc932d96b7'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}