### PR TITLE
Update adobe-air-beta - sha :no_check

### DIFF
--- a/Casks/adobe-air-beta.rb
+++ b/Casks/adobe-air-beta.rb
@@ -1,6 +1,6 @@
 cask 'adobe-air-beta' do
   version '26.0'
-  sha256 '916ce21b6180133de686f553c7fa492edc67541aebb657301859a3d0ce1195dc'
+  sha256 :no_check # required as upstream package is updated in-place
 
   # fpdownload.macromedia.com was verified as official when first introduced to the cask
   url 'https://fpdownload.macromedia.com/pub/labs/flashruntimes/air/AdobeAIR.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`sha256 :no_check` - upstream package is updated in-place

`audit` fails because the `sha256` has been removed.