### PR TITLE
Update virtualbox-beta to 5.1.23-116627

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-beta' do
-  version '5.1.23-116469'
-  sha256 'a6bbfcbef90391499a36a81f4b6b23888e4ed08a72f734e9354ec76dbebbbcaf'
+  version '5.1.23-116627'
+  sha256 'c88e2969461eff199947bda055965d2e05c802d2afd3beec32d05da800ced3f0'
 
   url "https://www.virtualbox.org/download/testcase/VirtualBox-#{version}-OSX.dmg"
   name 'Oracle VirtualBox'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}