### PR TITLE
Update 1password-beta to 6.8.BETA-7

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,10 +1,10 @@
 cask '1password-beta' do
-  version '6.8.BETA-6'
-  sha256 'ca6661c552747c31daf39454b9131ed3968d3b66c83fedee7132fe5e3174ab01'
+  version '6.8.BETA-7'
+  sha256 '0317da57d8b7a328389ce024bc2052ea61870d3a5f0d4dab07c1f1a51bff1d60'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: 'f4b3dc445d251d6c5b21faee91972248cfd5bca8a80dc5b56a02d4943df9df15'
+          checkpoint: '2283991a75b5693d796850546a238be9250cdfba90acb76cace39ae66acb318f'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}