### PR TITLE
Update docker-edge - uninstall

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -12,7 +12,12 @@ cask 'docker-edge' do
 
   app 'Docker.app'
 
-  uninstall quit: 'com.docker.docker'
+  uninstall delete:    '/Library/PrivilegedHelperTools/com.docker.vmnetd',
+            launchctl: [
+                         'com.docker.helper',
+                         'com.docker.vmnetd',
+                       ],
+            quit:      'com.docker.docker'
 
   zap delete: [
                 '~/.docker',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Update to match `docker`