### PR TITLE
Update telegram-alpha to 3.00.1.100143,477

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.0.100066,463'
-  sha256 '1e1ac7277c0ccd2bce58bba38fc2c9c390b3e995d780e6b7726cf0cb03a02d82'
+  version '3.00.1.100143,477'
+  sha256 '47324c49ee6dbdeb9a3eafb05f31c3fb3c7de92181768b9498e8546ddfc8b24d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '101e68bde2f0c6ad56b673553e314bafe2296545689083afaecda5769d67f987'
+          checkpoint: '80934a1f498ffa7a94ddbb15b2854da03213ba25e275228f63dc355de906812d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}