### PR TITLE
Update 1password-beta to 6.8.BETA-8

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '6.8.BETA-7'
-  sha256 '0317da57d8b7a328389ce024bc2052ea61870d3a5f0d4dab07c1f1a51bff1d60'
+  version '6.8.BETA-8'
+  sha256 'd83bc4ee39fbcbc9d20e8b898635ebe8d810a8eae1df92560b249859c6e57dda'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}