### PR TITLE
Update sourcetree-beta to 2.6b1

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -1,11 +1,11 @@
 cask 'sourcetree-beta' do
-  version '2.5.3b1'
-  sha256 'e2ed396cd9938f247b0231db1e98e9e85205698606cf2b5a9fafe3e910cb23f1'
+  version '2.6b1'
+  sha256 '725940ec3d6a55688934b5380e74ad44bdc8242410e4dc2db56460cf051ec3bb'
 
   # atlassian.com was verified as official when first introduced to the cask
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastBeta.xml',
-          checkpoint: 'acde869179a03e9bc8547e7467d291b5d1f5c1d001f51d9274a9e76ca94ab426'
+          checkpoint: '4510da3b6c7c550256a3b6fcf34fc0f3b8680a0d14989a32c2e9b5e9bc88b940'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}