### PR TITLE
Update royal-tsx-beta to 3.2.1.5

### DIFF
--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -1,10 +1,10 @@
 cask 'royal-tsx-beta' do
-  version '3.2.1.4'
-  sha256 'da56bf2ae18760fd0d31d940c3cfc290f8c5603c41381a617b64193794fe6e95'
+  version '3.2.1.5'
+  sha256 'dce1ea72f925f01c44577d808c09bd1aefbd031a0f4c92a3498fb8b5c07b6947'
 
   url "https://royaltsx-v3.royalapplications.com/updates/royaltsx_#{version}.dmg"
   appcast 'https://royaltsx-v3.royalapplications.com/updates_beta.php',
-          checkpoint: 'f11934dbf8da8555526d51d8bdacd6190c08063114e4940fd073ee3d362a3095'
+          checkpoint: '5cc40b0c139fcc831139645897b1d8d0a3b75fd79d9438dfb5d85db577f5eb70'
   name 'Royal TSX'
   homepage 'https://www.royalapplications.com/ts/osx/features'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}