### PR TITLE
Update torbrowser-alpha to 7.5a2

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'torbrowser-alpha' do
-  version '7.5a1'
-  sha256 '949d6cc117c93733e3dd175c2b3647321fd7cf0f7bd741a8c877d6c50a53881a'
+  version '7.5a2'
+  sha256 '96410c354726a703883c7605fbd3d521cc951efe3b1403217b0039dd7b3cc458'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   name 'Tor Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}