### PR TITLE
Update earlybird to 56.0a1

### DIFF
--- a/Casks/earlybird.rb
+++ b/Casks/earlybird.rb
@@ -1,8 +1,8 @@
 cask 'earlybird' do
-  version '54.0a2'
+  version '56.0a1'
   sha256 :no_check # required as upstream package is updated in-placea
 
-  url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-aurora/thunderbird-#{version}.en-US.mac.dmg"
+  url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central/thunderbird-#{version}.en-US.mac.dmg"
   name 'Earlybird'
   name 'Thunderbird Nightly'
   homepage 'https://www.mozilla.org/en-US/thunderbird/channel/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.