### PR TITLE
Update royal-tsx-beta to 3.2.1.6

### DIFF
--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -1,10 +1,10 @@
 cask 'royal-tsx-beta' do
-  version '3.2.1.5'
-  sha256 'dce1ea72f925f01c44577d808c09bd1aefbd031a0f4c92a3498fb8b5c07b6947'
+  version '3.2.1.6'
+  sha256 '5235fc45adcff42bc27aad9d67da95e65baaccaf44de71553d47f3f1e43e26cb'
 
   url "https://royaltsx-v3.royalapplications.com/updates/royaltsx_#{version}.dmg"
   appcast 'https://royaltsx-v3.royalapplications.com/updates_beta.php',
-          checkpoint: '5cc40b0c139fcc831139645897b1d8d0a3b75fd79d9438dfb5d85db577f5eb70'
+          checkpoint: 'a88f37d8571ca52e438c9aa8299c172a387884009096af9f83ab93d7e5d3470e'
   name 'Royal TSX'
   homepage 'https://www.royalapplications.com/ts/osx/features'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}