### PR TITLE
Update telegram-alpha to 3.00.1.100410,508

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.00.1.100253,503'
-  sha256 '59fb0dd7285a4d1d1e9728209fe3d1ca20be9f9394565faf5003a1c835d62d40'
+  version '3.00.1.1.100370,506'
+  sha256 'b5ec919a2d1ff2e03a66b6a06ea83d6145381f41041c6b2020e08c3fe29e47d5'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b78dd43529b64aeca08fab6fbe42a1650ac42afc3dd6b702ad02f513380beafc'
+          checkpoint: 'bf9c33bd138191fca47a3887ffecf7b72722bc57f5565e8e66aa6696d2099d78'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.00.1.1.100370,506'
-  sha256 'b5ec919a2d1ff2e03a66b6a06ea83d6145381f41041c6b2020e08c3fe29e47d5'
+  version '3.00.1.100410,508'
+  sha256 '98c0f884d4e9c356f0db3be4b2ee22fe1cadcb904c81c2af3b46177497fab066'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bf9c33bd138191fca47a3887ffecf7b72722bc57f5565e8e66aa6696d2099d78'
+          checkpoint: '46277f5f22dfd5475925ea0e99dbae7ccfcbe82d8941b2df296bda8c63ec97d1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}