### PR TITLE
Update telegram-alpha to 3.00.1.100543,513

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.00.1.100463,512'
-  sha256 '43a389d786e441d46fc7aaca15342590f97cb22dc3b3760afd7b25e7cbe5312a'
+  version '3.00.1.100543,513'
+  sha256 'cc9d391ab6feb9c63305742b55f68558ede95e30240867b9c99fe3f078485a1e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f4b3a8657b287e68fabc6973e239f36623d326ebea2a9e43f0c9a66eb8f5efdc'
+          checkpoint: '31eefe65fa3a3ad4beff4e751702790cebfdad837e15d879286d1262780faee7'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}