### PR TITLE
Update firefox-beta to 55.0b9

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -1,77 +1,77 @@
 cask 'firefox-beta' do
-  version '55.0b3'
+  version '55.0b9'
 
   language 'cs' do
-    sha256 '034630bd82cf2fa0374721fbd03f5ccb830c9b065a8d561ae64ccf597bb7f8d1'
+    sha256 'e48bd18be98fa2c57545ccf9dc845729637ab2c55d998d452fb168d1ee1d281b'
     'cs'
   end
 
   language 'de' do
-    sha256 'afc9f79a8f674e477c8db451981ecb880475f9dd50c907a216324bfc264e3e12'
+    sha256 '5ef6219a92388a192488a3e105dd977d9f14c059d514356f223cc90090dd49a4'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'a25097b84b7b1099e45338de1d9a7f9e3e3a6840351245d9c86493905004d1d4'
+    sha256 '66d129e78c46ef330eaaff36c809e082d323c1df9350718ddf8b88ac0309db22'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '3e4f099b8b24f0a7db1e36577a75574ed3364f5159b0c1927fedaff4e779dcc8'
+    sha256 'f6609700d62d9953f11205a03f9ee3fb16230a85793be224c33c869d54d7ab64'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '022ae088361e8ecfac15a7937d0073fa4d2d288729bc0116fc32f4c75c0a6247'
+    sha256 'caf212221e936ea27b8e38d838ce4a8ab24b22780452d5f749b9fbd5e04b2fe2'
     'fr'
   end
 
   language 'gl' do
-    sha256 '490a117526b05ad344640f6e9bdbcf446109c2f7e58bb4332af0cf826b1cc53a'
+    sha256 '247b2457894e3c0ccee4d2c06ea16b60378373a70b70e147cfdc3ce5ea3215e4'
     'gl'
   end
 
   language 'it' do
-    sha256 '538b6c81cbed8bedf77cf48afedcf0c64a7b62cd9185f6cf15ad9548604ee0cf'
+    sha256 'fb628bac19a9d725f83ccb1f0dc7025d8fde8310bb0e25eb8e66eb553ddae1ff'
     'it'
   end
 
   language 'ja' do
-    sha256 '925ae24fe812be3fe86d9613c4b6478f70613c8abf774ba6c1c831237c983385'
+    sha256 'a8bcbef86586093f65baa186fe8f001211998af9e2ff680f61d9ffebf42673a2'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '998e53bde9e85457a02d177e878a388962819f559e531f6a3b607d1d0d57c52a'
+    sha256 '7a9f37d766dd4e2b8474e43d4066fecea63a32cb0c792f5cde7b3d5bb686e059'
     'nl'
   end
 
   language 'pl' do
-    sha256 'deccac5ce54e0ea57587ecf674921f0a8c5032525ef0d033d4d5c4740ed2cd96'
+    sha256 '511bf2d6e37d452fe219e552907500b220da67f64ddb9f4b6356e3a67308fc23'
     'pl'
   end
 
   language 'pt' do
-    sha256 'c5822dc5da8886a0416f004cd49e9bbf857477955203c425b4bcdaf50e5ebd22'
+    sha256 'e244a76b3f2945f8a7c009960e88c5445e91db480b6ed6bcefb1fe6981c0b34a'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '95fea84d7ae7fe8ed53c8e3890041ab747818d6e449de2c8bd581741fc863c20'
+    sha256 'a4d4f6d29c6509ea8e73035ebe9a51d4552bc6a996c32d8b1f669f5801438112'
     'ru'
   end
   language 'uk' do
-    sha256 '7c4c79494045e5d38e552fb03f5309e9e551235fb9596699aa1f0e736a17c8a6'
+    sha256 '5e9b2d8def40b6fb9cc9c8888cfb4d36b89f10f39c92e6332a995ab60aec55b1'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '8fe0c8884490fa6dadf6ca2a5773ac7c74d923ed2d09fd068bd82f77e51733d7'
+    sha256 '63a52381583adcc5feddac686d9f38c8fb2073e74dfe37129d7fb1ccc392cedc'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '31ed7e812af44f37b3cdb17bfa466fb8167515205d6e350955f3aef1cf76a15b'
+    sha256 '9bc66e197f6fc6fdc7e741e72e39e56c37a60cd005f51ebf55526e377d28189b'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.