### PR TITLE
Update telegram-alpha to 3.00.1.100852,517

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.00.1.100549,514'
-  sha256 'da0813226d570cca1314fffe2f4dd6f516f812984e809b01c64649379311763a'
+  version '3.00.1.100852,517'
+  sha256 '9035dfecc590624a91af6e2da420e4d7a9712c6471d835954332cbf3d64528a4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '31eefe65fa3a3ad4beff4e751702790cebfdad837e15d879286d1262780faee7'
+          checkpoint: '91ddc91e5cd1635e1cfde6c7884ca3d6819d552238158e5b16e5d39f0da49d80'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.