### PR TITLE
Update telegram-alpha to 3.01.100952,518

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.00.1.100852,517'
-  sha256 '9035dfecc590624a91af6e2da420e4d7a9712c6471d835954332cbf3d64528a4'
+  version '3.01.100952,518'
+  sha256 '5a40e9f5dd4b5ecb607f246dbb2c74d72ceb49fa83552990b28aa6ffaf9d031a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '91ddc91e5cd1635e1cfde6c7884ca3d6819d552238158e5b16e5d39f0da49d80'
+          checkpoint: '904543cdcd73f3eb3a2e0854dacc285ceb0ff6b6919c0c376818b2f476da79c8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.