### PR TITLE
Update telegram-alpha to 3.1.101106,525

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.01.101042,520'
-  sha256 '81b8cf1f65f2541423e43c1e9ecb49d024fdab16d6037943813dbe62cbc7ae3e'
+  version '3.1.101106,525'
+  sha256 '42dd97a3302c7daca12b7f480303c7ee1e8c557b20f0c85cc2c1f16008a5cbc9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7040da7608ef8daa9a4dbf8d7190da4d7f04c780fa187d75dc3108ee68badfbc'
+          checkpoint: '322cee5109070499bccd0b6728d9eadaa3ab2f36745a5b30703d24a6dabe02fb'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}