### PR TITLE
Update iterm2-beta to 3.1.beta.6

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.beta.5'
-  sha256 '9b16a793b9f7001dfd190bb3318f79622b5bb590f3d423ea4cd5d17256df92ce'
+  version '3.1.beta.6'
+  sha256 '6c44f5433d37f4b481f31151fc9b96766c0559ea99a181bb9c1f867bfd9a2339'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '8a198b466129d5221834404f8553a6818801415de19e1bfedb34bcba94014824'
+          checkpoint: '492b4e108051e054d5015d6cf6ed957a8c429da5b27279c3add8945d08017291'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}