### PR TITLE
Update telegram-alpha to 3.1.101111,527

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.101106,525'
-  sha256 '42dd97a3302c7daca12b7f480303c7ee1e8c557b20f0c85cc2c1f16008a5cbc9'
+  version '3.1.101111,527'
+  sha256 'bcf0317f87b8c1a037c6fc72e8ac3f87d55b87ae4ab8abbb68992d4eabc93567'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '322cee5109070499bccd0b6728d9eadaa3ab2f36745a5b30703d24a6dabe02fb'
+          checkpoint: '6bc71200dd8096cc1e7712e7ff930be2431ed8a777a36a004fecdc831f7b8a6c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}