### PR TITLE
Update jabref-beta to 4.0-beta2

### DIFF
--- a/Casks/jabref-beta.rb
+++ b/Casks/jabref-beta.rb
@@ -1,11 +1,11 @@
 cask 'jabref-beta' do
-  version '4.0-beta'
-  sha256 '0d8c6ff5979027a3c8c5da23b2ff77ae2dc62cdb0baf695e61d5da35fac0e551'
+  version '4.0-beta2'
+  sha256 'c5b764bd74486a5a348a3ae98a3c848867b6608d516801a296d903812a37cd9d'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
-  url 'https://github.com/JabRef/jabref/releases/download/v4.0-beta/JabRef_macos_4_0_0-beta.dmg'
+  url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: '7714d6c5bea930a04dc3caa1c6434b47e40dbae33ec472dca9bae0b10731157d'
+          checkpoint: 'a05f548db846150e797fb5690642b423cb72e83afde629a45ca80774ea99c7a1'
   name 'JabRef Beta'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}