### PR TITLE
Update DOSBox SVN formula

### DIFF
--- a/Casks/dosbox-svn.rb
+++ b/Casks/dosbox-svn.rb
@@ -2,6 +2,7 @@ cask 'dosbox-svn' do
   version :latest
   sha256 :no_check
 
+  # dropbox.com was verified as official when first introduced to the cask
   url 'http://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg?dl=1'
   name 'DOSBox SVN'
   homepage 'https://www.dosbox.com/wiki/SVN_Builds#Plain.2Fvanilla.2Fclean_SVN_builds/'

--- a/Casks/dosbox-svn.rb
+++ b/Casks/dosbox-svn.rb
@@ -2,8 +2,8 @@ cask 'dosbox-svn' do
   version :latest
   sha256 :no_check
 
-  # dropbox.com/s/kbrf5elbcu66kst was verified as official when first introduced to the cask
-  url 'http://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg'
+  # dl.dropboxusercontent.com/s/kbrf5elbcu66kst was verified as official when first introduced to the cask
+  url 'http://dl.dropboxusercontent.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg'
   name 'DOSBox SVN'
   homepage 'https://www.dosbox.com/wiki/SVN_Builds#Plain.2Fvanilla.2Fclean_SVN_builds/'
 

--- a/Casks/dosbox-svn.rb
+++ b/Casks/dosbox-svn.rb
@@ -2,8 +2,7 @@ cask 'dosbox-svn' do
   version :latest
   sha256 :no_check
 
-  # Snapshot, automatically rebuilt from trunk, created by user Dominus (#dosbox irc.freenode.org)
-  url 'https://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg?dl=1'
+  url 'http://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg?dl=1'
   name 'DOSBox SVN'
   homepage 'https://www.dosbox.com/wiki/SVN_Builds#Plain.2Fvanilla.2Fclean_SVN_builds/'
 

--- a/Casks/dosbox-svn.rb
+++ b/Casks/dosbox-svn.rb
@@ -2,8 +2,8 @@ cask 'dosbox-svn' do
   version :latest
   sha256 :no_check
 
-  # dl.dropbox.com/u/7737184 was verified as official when first introduced to the cask
-  url 'http://dl.dropbox.com/u/7737184/Dosbox/Dosbox-Snapshot.dmg'
+  # Snapshot, automatically rebuilt from trunk, created by user Dominus (#dosbox irc.freenode.org)
+  url 'https://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg?dl=1'
   name 'DOSBox SVN'
   homepage 'https://www.dosbox.com/wiki/SVN_Builds#Plain.2Fvanilla.2Fclean_SVN_builds/'
 

--- a/Casks/dosbox-svn.rb
+++ b/Casks/dosbox-svn.rb
@@ -2,8 +2,8 @@ cask 'dosbox-svn' do
   version :latest
   sha256 :no_check
 
-  # dropbox.com was verified as official when first introduced to the cask
-  url 'http://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg?dl=1'
+  # dropbox.com/s/kbrf5elbcu66kst was verified as official when first introduced to the cask
+  url 'http://www.dropbox.com/s/kbrf5elbcu66kst/Dosbox-Snapshot.dmg'
   name 'DOSBox SVN'
   homepage 'https://www.dosbox.com/wiki/SVN_Builds#Plain.2Fvanilla.2Fclean_SVN_builds/'
 


### PR DESCRIPTION
The URL for the snapshots has changed (in part because of a policy change by Dropbox). The new URL is a direct link to new builds generated from trunk automatically.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}