### PR TITLE
Update android-studio-canary to 3.0.0.6,171.4182969

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '3.0.0.0,171.4010489'
-  sha256 '863849c56ea4ac1d788e8a5c30cb7bf88b80f552fcc72c4cef24c016e148a3b8'
+  version '3.0.0.6,171.4182969'
+  sha256 '455134beeac2b1ca8f0a58f39ca4ccc5724c22525980db3094c34d4c606d753b'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.