### PR TITLE
Update telegram-alpha to 3.1.101198,536

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.101181,531'
-  sha256 'd16ff660271a5a57d5ebb3ccf2a5e1dd0f240a03f9c6d585d5de9973e8656115'
+  version '3.1.101198,536'
+  sha256 '3a1e8ad5f5c1fe160b07cbc8589bdc854f7e5ef3992e7adf7f66080a7fc5f166'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '43b2b66a2ee2094087005744c9209b0b16cd7ceaf2ee1c52a688ef7b30c8e35d'
+          checkpoint: '73aa336027d9b376f29706131b6ef1faa750a3c4dad09745229e71870d89ff00'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}