### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.33,773

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.32,760'
-  sha256 '470c7e0e1353f1ef021e8a530dc63b00a55d7d65fdebb423fc800c9ca974e15e'
+  version '8.2.33,773'
+  sha256 '252e548ef3c243772a8863f3cc98b8d291f19947223f7942997b81f5c78eed83'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'bb71a103e49432f0a3a31ca4af8a24c38e40c811afc08cef1edcf821af749d1e'
+          checkpoint: '17fa31522c9096e160055c9f9094d33dc48f2f98638c8f4dd16e07c55d74cd0a'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}