### PR TITLE
Update royal-tsx-beta to 3.2.1.8

### DIFF
--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -1,10 +1,10 @@
 cask 'royal-tsx-beta' do
-  version '3.2.1.7'
-  sha256 '6582fe81e25ce274d8a181aedf17b9fc7db422f6a7dcbd4fbc0fd62e096284d7'
+  version '3.2.1.8'
+  sha256 '17aeb91413cddb4e362f34d54b4fe0f70ba4280d00029410a61ec6641f683b49'
 
   url "https://royaltsx-v3.royalapplications.com/updates/royaltsx_#{version}.dmg"
   appcast 'https://royaltsx-v3.royalapplications.com/updates_beta.php',
-          checkpoint: '924239968b94a97e4a53259d654fced160b62c3cacd0245c37d4e15a9ffe40ff'
+          checkpoint: 'c45d63eb2011f68d7d11162c28617ac17d123c794da694a659d77cddcabd1850'
   name 'Royal TSX'
   homepage 'https://www.royalapplications.com/ts/mac/features'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}