### PR TITLE
Update airmail-beta to 3.3.3,445,309

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3,309'
-  sha256 '371e04cf74e2cd74a8c007be912bccfec2703f48cf613fde057ab4963ccd13e5'
+  version '3.3.3,445,309'
+  sha256 '04669fdc15ff1b6be66ef369bea55b3cc17f385673adaa94565d15ff2e4bc044'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '5a1977160297cb2bd7548847a8e8b8ff79d643d9c0e353ca8ce1607b63b0aa52'
+          checkpoint: '4721a3ffb702fac31f4ca74420819ddc0bde92a676f52fb1cb0a05ddcae7c633'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,5 +1,5 @@
 cask 'airmail-beta' do
-  version '3.3.3,445,309'
+  version '3.3.3.445,309'
   sha256 '04669fdc15ff1b6be66ef369bea55b3cc17f385673adaa94565d15ff2e4bc044'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}