### PR TITLE
Update vivaldi-snapshot to 1.11.915.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.11.904.3'
-  sha256 'a540c345625643a1a4fdbbe32a690ef847733173f045d6f4a8991e6b031f2d8c'
+  version '1.11.915.3'
+  sha256 'a7b87fb88a15e20a91c26c99b52088fce078d29a14c5c364a7bd2747327b045a'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '446dafcfdbe27ee63733254cad8446b85df015ce47c4ad1e72bef5a3b7167f12'
+          checkpoint: '3bb060af9a1a610c491246361bae43e24b8440a76c06b0d4490e0b47536e2b89'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}