### PR TITLE
Update java9-beta to 1.9,179

### DIFF
--- a/Casks/java9-beta.rb
+++ b/Casks/java9-beta.rb
@@ -1,6 +1,6 @@
 cask 'java9-beta' do
-  version '1.9,178'
-  sha256 '06aac8c76f868bc6880e3a94623ede2067e9c82b2b7a8fc07dd5eed21646b814'
+  version '1.9,179'
+  sha256 'ef0e11b3c598759727633d8b545cdeeea600b2d7925aeca08c4b9221db5e9dac'
 
   url "http://download.java.net/java/jdk#{version.before_comma.minor}/archive/#{version.after_comma}/binaries/jdk-#{version.before_comma.minor}+#{version.after_comma}_osx-x64_bin.dmg",
       cookies: { 'oraclelicense' => 'accept-securebackup-cookie' }


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}