### PR TITLE
Update opera-beta to 47.0.2631.31

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '47.0.2631.28'
-  sha256 '0220b3a5a437b6c41efbc66c1f201a99c3ad01fa71e11a1f16046387bf0592f8'
+  version '47.0.2631.31'
+  sha256 '6290f2204aba99566d9f74c03433340e19380f9ad9e17fcc3df46e6387a0ce4d'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}