### PR TITLE
Update zulu7 to 7.0_141,7.18.0.3

### DIFF
--- a/Casks/zulu7.rb
+++ b/Casks/zulu7.rb
@@ -1,8 +1,8 @@
 cask 'zulu7' do
-  version '7.0_131,7.17.0.5'
-  sha256 'b2bc63bdd24432820982101e82568071c8cedfed62da2ae5c69bfe378800b643'
+  version '7.0_141,7.18.0.3'
+  sha256 'f72ecbb7c34a190718eb4d222328dfdf81fbd4fecee847bada28285cf12f58e7'
 
-  url "http://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma.underscores_to_dots}-macosx_x64.dmg",
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma.underscores_to_dots}-macosx_x64.dmg",
       referer: 'http://www.azul.com/downloads/zulu/zulu-mac/'
   name 'Azul Zulu Java Standard Edition Development Kit'
   homepage 'http://www.azul.com/downloads/zulu/zulu-mac/'


### PR DESCRIPTION
Update zulu7 to 7.0_141,7.18.0.3. Also switches download URL to HTTPS.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t][version-checksum],  
      provide public confirmation by the developer: {{link}}