### PR TITLE
Update airmail-beta to 3.3.3.446,311

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.445,309'
-  sha256 '04669fdc15ff1b6be66ef369bea55b3cc17f385673adaa94565d15ff2e4bc044'
+  version '3.3.3.446,311'
+  sha256 'bdb180dc5005ddfc5d7158b947446c5ce4a6191d6407775e9a9a9b294f3f92b6'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '4721a3ffb702fac31f4ca74420819ddc0bde92a676f52fb1cb0a05ddcae7c633'
+          checkpoint: 'fd3d80f29205536425a531eec669754febe2fc366bce3bd9f7f30fbfa184e1f3'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}