### PR TITLE
Update wine-devel to 2.14

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '2.13'
-  sha256 'b7cb41ccb31db12cb5229191ff5a67e098d074087f349c4e2a650f192563aad2'
+  version '2.14'
+  sha256 '2fc814d4b3fe9815690ccb77275ef7263fe75b102ef60daf931e1a4ad3db7c9a'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   name 'WineHQ-devel'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}