### PR TITLE
Update sketch-beta to 46,44423

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '46,44420'
-  sha256 '1c3407f29bc5f512d31c62720fe27d460c461b56a9261ebcd060d9c8cfc7f737'
+  version '46,44423'
+  sha256 'f5696009a52a0f42457bdc7407c3228e510cca9ef1986a61d97de58154a5ee47'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'dc2b57d4b7ecd4cf5d1bbe7184be197d3dd1cc0cb3ec4027b77d4effcaf6ce96'
+          checkpoint: '8b319f71384136eb40db899b89805bd02f26aa57a11d9dde50317167bb8b821d'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}