### PR TITLE
Update telegram-alpha to 3.1.2.102351,554

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.101736,545'
-  sha256 'd4e2cdfa1640f64e340072a97b800cbd75e09c96a6c68351f47a890c9bdad8b5'
+  version '3.1.2.102351,554'
+  sha256 'db57d9f73286281ee9d864f727a1655ec6d02ce4ee11e0500a733731c8c48f45'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1f618299b8f692a65a7616479f361afcfb283245c301d4622e7183b814b6fa8a'
+          checkpoint: 'eb5f2b9f0dc0b17017ef7f1680a66aa6308a7eb8c893f60983d1f37f3fd25bc3'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}