### PR TITLE
Update intellij-idea20161 - uninstall / zap

### DIFF
--- a/Casks/intellij-idea20161.rb
+++ b/Casks/intellij-idea20161.rb
@@ -11,15 +11,17 @@ cask 'intellij-idea20161' do
   app 'IntelliJ IDEA.app'
 
   uninstall_postflight do
-    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) }
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'idea') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
   end
 
   zap delete: [
                 "~/Library/Caches/IntelliJIdea#{version.major_minor}",
                 "~/Library/Logs/IntelliJIdea#{version.major_minor}",
+                '~/Library/Saved Application State/com.jetbrains.intellij.savedState',
+              ],
+      trash:  [
                 "~/Library/Application Support/IntelliJIdea#{version.major_minor}",
                 "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
                 '~/Library/Preferences/com.jetbrains.intellij.plist',
-                '~/Library/Saved Application State/com.jetbrains.intellij.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/37371



Updated `uninstall_postflight`

Changed `zap delete` to `zap trash` for `preferences` and `application support`