### PR TITLE
Update 1password-beta to 6.8.1.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,10 +1,10 @@
 cask '1password-beta' do
-  version '6.8.BETA-12'
-  sha256 '24055c4652c6ef0d4d1d93e40770ff31584aa6a83278dcf62e399e47cffabf6c'
+  version '6.8.1.BETA-1'
+  sha256 '5bb3afcab45c24a7ee3cbc97696fb63ab5e9e44dad399fa532161f75ccf4e9dc'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: '90bf01df42dce670bdc25a5763465f8b94b41ea0404b828f7fd6f2a111c33a68'
+          checkpoint: '95a0d0cb804b381097e9ad50fb22c29593cb86cf13d012779f15ef1191d58c49'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,  
      provide public confirmation ([How?][version-checksum]): {{link}}

Thanks for using 1Password! <3