### PR TITLE
Update sketch-beta to 46.1,44463

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '46,44423'
-  sha256 'f5696009a52a0f42457bdc7407c3228e510cca9ef1986a61d97de58154a5ee47'
+  version '46.1,44463'
+  sha256 '27419a98af0d51de8efa5389dc1d720b68af7122a09e1bcd8ca81e38c8ab0f88'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '8b319f71384136eb40db899b89805bd02f26aa57a11d9dde50317167bb8b821d'
+          checkpoint: '0880f28b6c386c0bcb7facbf5accc723de48f91564fa194b59adcab9e31c6532'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}