### PR TITLE
Update kodi-development to 17.4-Krypton_rc1

### DIFF
--- a/Casks/kodi-development.rb
+++ b/Casks/kodi-development.rb
@@ -1,8 +1,8 @@
 cask 'kodi-development' do
-  version '20170514-a5f9821'
-  sha256 '97e0d447a7f645d7c19c3020a0fa6a1b0c60c38a7843fb83f28227b8f62a83b4'
+  version '17.4-Krypton_rc1'
+  sha256 'acae9335463d4e67aef3455ee7642a025ec1029e44a16222344e1d98d5e58976'
 
-  url "http://mirrors.kodi.tv/nightlies/osx/x86_64/Krypton/kodi-#{version}-Krypton-x86_64.dmg"
+  url "http://mirrors.kodi.tv/releases/osx/x86_64/kodi-#{version}-x86_64.dmg"
   name 'Kodi-Development'
   homepage 'https://kodi.tv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

This reverts the cask back to RC releases.