### PR TITLE
Update royal-tsx-beta to 3.2.1.1000

### DIFF
--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -1,10 +1,10 @@
 cask 'royal-tsx-beta' do
-  version '3.2.1.9'
-  sha256 '0a238b5c6a8db3e55c76daec4bc9ef95ed4c3f88ab23d3e42f960952832aa0b3'
+  version '3.2.1.1000'
+  sha256 'f0477253d7f6238ead49d0ae16ebde768c0ef9ec9037a5c2c7680e517d4ac66d'
 
   url "https://royaltsx-v3.royalapplications.com/updates/royaltsx_#{version}.dmg"
   appcast 'https://royaltsx-v3.royalapplications.com/updates_beta.php',
-          checkpoint: '4ea7f5d565e90207b623309a41bc62a47a3863fdc134d5a1567b5080610daf6b'
+          checkpoint: 'd4bfabbcb8db9b19b4c13ea64f456ffc415638a68e5dea85a982adf8ac0ea212'
   name 'Royal TSX'
   homepage 'https://www.royalapplications.com/ts/mac/features'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}