### PR TITLE
Update telegram-alpha to 3.1.2.102745,557

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.2.102726,555'
-  sha256 'd9121d0a4a9b4cd737743c4179da813297d41e918ee0f5be0dc611e47874ab66'
+  version '3.1.2.102745,557'
+  sha256 'ea3d09aff288cea700e6c46f995b63b3cb3bb7d2280c45a6c1df7dc1a6038fe0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '63112960791e313291575e8de31fb95598183b13c3c5c7fbdd62632128659ab1'
+          checkpoint: '6a3e773f34171de5f1a780cf4288d8bac854b8fbd390792071cb34620692cf7a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}