### PR TITLE
Update opera-developer to 48.0.2679.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,10 +1,10 @@
 cask 'opera-developer' do
-  version '48.0.2670.0'
-  sha256 '285095adf85be110593d304eb57016d2e7e9a676278530be4a1e49ebd9a9be71'
+  version '48.0.2679.0'
+  sha256 '4c0f57a9639612e70f0618d5d82bcd601c3ff44fbcc3f79e09f877c52b8f8920'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'
-  homepage 'http://www.opera.com/developer'
+  homepage 'https://www.opera.com/computer/beta'
 
   app 'Opera Developer.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.