### PR TITLE
Update blender-daily to 2.79-0398ee10a1b

### DIFF
--- a/Casks/blender-daily.rb
+++ b/Casks/blender-daily.rb
@@ -1,6 +1,6 @@
 cask 'blender-daily' do
-  version '2.78-e982ebd6d4f'
-  sha256 '2b084b08a33d51551a594425d2249d9213a385135b90b549af044b9ba39501ec'
+  version '2.79-0398ee10a1b'
+  sha256 'eaa856073f0a91777ed0cc1347aba10849f73ecdda653304c114b6e1b65887b2'
 
   url "https://builder.blender.org/download/blender-#{version}-OSX-10.6-x86_64.zip"
   name 'Blender'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}