### PR TITLE
Update processing2 to 3.3.5

### DIFF
--- a/Casks/processing2.rb
+++ b/Casks/processing2.rb
@@ -1,10 +1,10 @@
 cask 'processing2' do
-  version '3.3.4'
-  sha256 '65aaa629b04b37976b456e8834de1c5c7f19fb92cb94b6496b0a8222f627e6b2'
+  version '3.3.5'
+  sha256 '8fae957b6ccb62254e3e4cdf04b025bee238c3c56da609ce22206b37122f3501'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
   appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: '60699238aa599f5c023d6f8d485a2f72f6c85e468b95183d069eb79a9361a7c9'
+          checkpoint: '0880e0113f935c0ee0591cc7051d662f8fbb640de72a3dcac0d68f3b4e9445a1'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}