### PR TITLE
Update processing2 to 2.2.1

### DIFF
--- a/Casks/processing2.rb
+++ b/Casks/processing2.rb
@@ -1,10 +1,8 @@
 cask 'processing2' do
-  version '3.3.5'
-  sha256 '8fae957b6ccb62254e3e4cdf04b025bee238c3c56da609ce22206b37122f3501'
+  version '2.2.1'
+  sha256 '8c237b3eb50626e8ffc648bfdeddaa18ceffbd6a48f8fec77a8eab5b774971fc'
 
   url "http://download.processing.org/processing-#{version}-macosx.zip"
-  appcast 'https://github.com/processing/processing/releases.atom',
-          checkpoint: '0880e0113f935c0ee0591cc7051d662f8fbb640de72a3dcac0d68f3b4e9445a1'
   name 'Processing'
   homepage 'https://processing.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.