### PR TITLE
Update dotnet-preview casks - remove openssl

### DIFF
--- a/Casks/dotnet-preview.rb
+++ b/Casks/dotnet-preview.rb
@@ -6,7 +6,6 @@ cask 'dotnet-preview' do
   name '.NET Core Preview'
   homepage 'https://www.microsoft.com/net/core/preview#macos'
 
-  depends_on formula: 'openssl'
   depends_on macos: '>= :sierra'
 
   pkg "dotnet-runtime-#{version}-osx-x64.pkg"

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -6,7 +6,6 @@ cask 'dotnet-sdk-preview' do
   name '.NET Core SDK Preview'
   homepage 'https://www.microsoft.com/net/core/preview#macos'
 
-  depends_on formula: 'openssl'
   depends_on macos: '>= :sierra'
 
   pkg "dotnet-sdk-#{version}-osx-x64.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.