### PR TITLE
Update virtualbox-extension-pack-beta to 5.2.0_BETA2,117563

### DIFF
--- a/Casks/virtualbox-extension-pack-beta.rb
+++ b/Casks/virtualbox-extension-pack-beta.rb
@@ -1,10 +1,10 @@
 cask 'virtualbox-extension-pack-beta' do
-  version '5.2.0_BETA1,117406'
-  sha256 'f06841783e44b07469f6338099dd2ee53bddd47e848df8f286d3d639b2e21687'
+  version '5.2.0_BETA2,117563'
+  sha256 '30711e0aa417910cf26e1abc1da08d575d45c330fd593decf35b7d04d87f7ca7'
 
   url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST-BETA.TXT',
-          checkpoint: '2af71b046d16a13f3bb3e0e34e668b2acdc6cab8a4041113076d6c705a492546'
+          checkpoint: '4e9ae5d62ebfe2ab6e9fc1d7bd64c69f0c25b601b1c08ba92711adda7c6c0049'
   name 'Oracle VirtualBox Extension Pack'
   homepage 'https://www.virtualbox.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.