### PR TITLE
Update sketch-beta to 46.2,44496

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '46.2,44476'
-  sha256 '7201d619a174c880a3101a7491d16a1220ba0771c40e18446b304b86a98494ad'
+  version '46.2,44496'
+  sha256 '09e8ff416bf7eb7601478902a6143b3c23c2ffa920afb2f4788f2d30504d12c9'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '64f7fad4de82e19850eb506f7a3d2949117f105c311b359f1d2b1a6dc96a0a20'
+          checkpoint: 'cf3c2eb8f5fb7eea1b5b74d6e3414651e5ff41a9f808aadaba39f536cd7f397f'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.