### PR TITLE
Update qt-creator-dev to 4.4.0-rc1

### DIFF
--- a/Casks/qt-creator-dev.rb
+++ b/Casks/qt-creator-dev.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator-dev' do
-  version '4.3.0-rc1'
-  sha256 '33feeeec0e06455e8c072d7026d3fb3fd78d6e90252bc902fac788f157bdc563'
+  version '4.4.0-rc1'
+  sha256 'c4194ff3b9109f71e7fbedac35b27883d65476610cee6a3e9adfe26a9dff2e39'
 
   url "http://download.qt.io/development_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator Dev'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.