### PR TITLE
Update vivaldi-snapshot to 1.12.936.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.12.933.3'
-  sha256 '2c283652b1bf78ba7e1e1a8d14cdcea0142ce8914cbbcb41d0906983df0b5f47'
+  version '1.12.936.3'
+  sha256 'e17847e682cd866ffc6af2386e0ab528e823c730339f3e8a03e4425bdfbf29fd'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '1584d5b3bcb35d8017ae2818db6959a3ce93a415bbdb24a075f59c0f85640ac3'
+          checkpoint: '88d2d96f9cbeb0210b9d9282c570e8b901cfc7a02fa9b99424d040930e7a8b2c'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.