### PR TITLE
Update telegram-alpha to 3.1.2.103348,564

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.2.102745,557'
-  sha256 'ea3d09aff288cea700e6c46f995b63b3cb3bb7d2280c45a6c1df7dc1a6038fe0'
+  version '3.1.2.103348,564'
+  sha256 'dd00fccbdf5740df456b7f40f9fe8d712eb1b1d56c79898833152e7d32be1a9b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6a3e773f34171de5f1a780cf4288d8bac854b8fbd390792071cb34620692cf7a'
+          checkpoint: '1f7995791976bde20e9cbf11663c43b706a602e6f8e5d2b2abc27b6a29dadc30'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.