### PR TITLE
Update docker-edge with zaps from cask/docker

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -6,9 +6,11 @@ cask 'docker-edge' do
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
           checkpoint: '7cd068249af8f3035a76fa2e9f2a8bd9b647d552d59cd1930443d3e057d2849b'
   name 'Docker Community Edition for Mac (Edge)'
+  name 'Docker CE for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'
 
   auto_updates true
+  depends_on macos: '>= :yosemite'
 
   app 'Docker.app'
 
@@ -21,9 +23,17 @@ cask 'docker-edge' do
 
   zap delete: [
                 '~/.docker',
+                '~/Library/Application Scripts/com.docker.helper',
+                '~/Library/Caches/KSCrashReports/Docker',
                 '~/Library/Caches/com.docker.docker',
+                '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.docker.docker',
                 '~/Library/Containers/com.docker.docker',
-                '~/Library/Preferences/com.docker.docker.plist',
+                '~/Library/Containers/com.docker.helper',
                 '~/Library/Group Containers/group.com.docker',
+                '~/Library/Preferences/com.docker.docker.plist',
+              ],
+      rmdir:  [
+                '~/Library/Caches/KSCrashReports',
+                '~/Library/Caches/com.plausiblelabs.crashreporter.data',
               ]
 end

--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -22,7 +22,6 @@ cask 'docker-edge' do
             quit:      'com.docker.docker'
 
   zap delete: [
-                '~/.docker',
                 '~/Library/Application Scripts/com.docker.helper',
                 '~/Library/Caches/KSCrashReports/Docker',
                 '~/Library/Caches/com.docker.docker',
@@ -30,8 +29,8 @@ cask 'docker-edge' do
                 '~/Library/Containers/com.docker.docker',
                 '~/Library/Containers/com.docker.helper',
                 '~/Library/Group Containers/group.com.docker',
-                '~/Library/Preferences/com.docker.docker.plist',
               ],
+      trash:  '~/Library/Preferences/com.docker.docker.plist',
       rmdir:  [
                 '~/Library/Caches/KSCrashReports',
                 '~/Library/Caches/com.plausiblelabs.crashreporter.data',


### PR DESCRIPTION
docker-edge version 17.07.0-ce-rc2-mac22,18909

This change adds additional files to be zapped.
Additions come from [caskroom/homebrew-cask/Casks/docker.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/docker.rb).

Note that, this change keeps the zap for `~/.docker`.
Looking through the stable cask's history, I don't see that `~/.docker` is ever zapped.
This may need to be updated over there.

I've also added the additional name (Docker CE) to make it match the stable cask.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

