### PR TITLE
Update sourcetree-beta to 2.6.2b1

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -1,11 +1,11 @@
 cask 'sourcetree-beta' do
-  version '2.6.1b1'
-  sha256 '51c2cc556c637cb147f1d6b8b8c8a259a735bca8ad3ce75ff0024313f6bfe688'
+  version '2.6.2b1'
+  sha256 'e5f650db0ed41afafde75180114ae30701d32241670b92bb7677a7d6f65b42d6'
 
   # atlassian.com was verified as official when first introduced to the cask
   url "https://downloads.atlassian.com/software/sourcetree/SourceTree_#{version}.zip"
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastBeta.xml',
-          checkpoint: 'd21837fefdfa6f72f08454de4c5f3c54f4856b14dae9c9e49ed9b4285839f8c1'
+          checkpoint: 'bd6cc9a4f00221498884e11dbb17f033ce6f733b7008e42b0703a2fc3f51f832'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.