### PR TITLE
Update telegram-alpha to 103655,567

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.2.103390,565'
-  sha256 '4028a620391008f17aefc9a093e2944d0d3d332b29cd098cb37f9da27d4b7cdc'
+  version '103655,567'
+  sha256 'f3f3d4f514fec3b8ecb30b9be512c03a32a3da926c52d172bdbe4a99f09a4b87'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'e43025193d540e5a57dfa1dfecf360f3d47c790ba799afb22ba54460d1488c9b'
+          checkpoint: 'f246f4d6cdbff6a1ce3967b42e4276af25f3f061b8892d548fcc7df3ffb2ba79'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.