### PR TITLE
Update iterm2-beta to 3.1.beta.8

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -5,7 +5,7 @@ cask 'iterm2-beta' do
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '1f5f58e0134568646392e173eff1974cf0044c8b561a913e742516e84cc1c1fd'
+          checkpoint: '3e72538422bcf49dacaf62123e72b279306689b3ee29cc72d9ebce7e7d05af76'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 

--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.beta.7'
-  sha256 '98f7cbfbe3ca7babae137338522a5535622ef33c06d2363c81850128822b48d5'
+  version '3.1.beta.8'
+  sha256 '336d1aa3aa8cde24e9efd8eb9adba0c2f894e965c93ae5d9a0217fdbeaae8b3f'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.