### PR TITLE
Update mongodb-compass-beta to 1.9.0-beta.2

### DIFF
--- a/Casks/mongodb-compass-beta.rb
+++ b/Casks/mongodb-compass-beta.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-beta' do
-  version '1.8.0-beta.1'
-  sha256 '39c8eb78ffcce72b25b6d3c3fb84a27498ed35cb320913e5bda1ee311efb0b59'
+  version '1.9.0-beta.2'
+  sha256 '7d4a213efb4e9b7b29d5f556c09109b2c236d3a82b7394ab209ef6404935c81b'
 
   url "https://downloads.mongodb.com/compass/beta/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.