### PR TITLE
Update transmission-nightly to 1e9b805b4d

### DIFF
--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -1,6 +1,6 @@
 cask 'transmission-nightly' do
-  version '7a1a1acd22'
-  sha256 'aefaf9d97235375ba9b99e4866eb03963eba580845f7c7320fb239cbeef0e82c'
+  version '1e9b805b4d'
+  sha256 '17fe83206386a4de0bb6a372cffd8a255e2d151e586102526e149c26fbda68fd'
 
   url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
   name 'Transmission'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.