### PR TITLE
Update airmail-beta to 3.3.3.447,312

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.446,311'
-  sha256 'bdb180dc5005ddfc5d7158b947446c5ce4a6191d6407775e9a9a9b294f3f92b6'
+  version '3.3.3.447,312'
+  sha256 'b40a8214695eb182c5d51ddada0da9cae20b2df76d7db84590139f3b260349cf'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'fd3d80f29205536425a531eec669754febe2fc366bce3bd9f7f30fbfa184e1f3'
+          checkpoint: 'abba926a0993b87360ec4ada3e54273a8d4dfdd52f981fb71a5a937345f8018b'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.