### PR TITLE
Update skype-preview to 8.5.76.55323

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,6 +1,6 @@
 cask 'skype-preview' do
-  version '8.4.76.54035'
-  sha256 '61b23c45e3dbcce43d187079edbaf1be0b5e7d0ca633e883aa04ee805bb492ea'
+  version '8.5.76.55323'
+  sha256 'e4f170ef60f4e82e0e0230279a7cbae8178ebf9343df0cdc3c0703139b3103da'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-Preview-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.