### PR TITLE
Update slicer-nightly to 4.7.0.26325,683041

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.7.0.26319,682707'
-  sha256 '3e96d4da7e3e5736ebfbdd1137f81927670da9f27bc29ad3b8746c9cdde59845'
+  version '4.7.0.26325,683041'
+  sha256 'b5d9853a879633ca8f4c4ce0f68039736f57d74b6e8f4b8d23149c9cde0d5be4'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.