### PR TITLE
Update vivaldi-snapshot to 1.12.947.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.12.941.3'
-  sha256 'c0a9d24ccdf05fdb84c80c5f92afdae6d8e9671ea6622304f502293455b31684'
+  version '1.12.947.3'
+  sha256 'eeca5d6d9dd99dc2399a0a6585b69a5664825568e1fa32ff71b19ad71c97ee22'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'b7ddd910a298796a86d0dc8ea66f2712662a24decf11a1a01a42ee3fc35fec70'
+          checkpoint: 'cb736be8d6fbbd99ecf985bbc3a13825a0cb37a6b07600571385653101762ffc'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.