### PR TITLE
Update electron-beta to 1.7.7

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.7.6'
-  sha256 '825497d494b31a9ef26d0a67bc5bb61bacc1f9b8cb83db9339bd5c8aec053431'
+  version '1.7.7'
+  sha256 '06ff3d43474c8cbe5b500a763a83480e2f0b8f526548b567201cbb0f8cb6d200'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '2b214042cdbdec75e6fbaf31ede22c68845bfa150f2ef9588e81cb40af2c5a18'
+          checkpoint: '5f2251ae385cabc399b1ab07a95bee0281d7fe894f875749191c6c99d7a5d862'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.