### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.34,776

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.34,775'
-  sha256 '8bca26e4a16fecd68e58890d14e9177390afbb534746359b2c1f272f98da3f14'
+  version '8.2.34,776'
+  sha256 '5b3080b6466c15980ff6cb90228244d7b49f6833d43f2e9886fdec8ec33d6ef1'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'c6052c1ead60ae409d2f63ae43263e2b8236b0fa58e5f4305e1580cf461eec0e'
+          checkpoint: '9fe067a4a3ec82aad4249cc420221571028122d307f46d89b6f349569f142a47'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.