### PR TITLE
Update docker-edge to 17.07.0-ce-mac26,19053

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.07.0-ce-rc4-mac25,18986'
-  sha256 'a99e091de1daaa5a7c079b40149e637a7c7934f8ac2fed5cd39026de4e9893ad'
+  version '17.07.0-ce-mac26,19053'
+  sha256 'efc7132e87b6b5bae6ed3dd3e91f8d91662357871a177c0487cad484ca82dd47'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: 'c4f5f20a9811a4aa162bb2c3c46d0ed2639f746b58e4e01a0723fe8238540464'
+          checkpoint: 'cee435301a22583aa3cb889ce7a74a5340cfd5cc24129a9cd7635130f0a8482d'
   name 'Docker Community Edition for Mac (Edge)'
   name 'Docker CE for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.