### PR TITLE
Update telegram-alpha to 104045,582

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '104021,581'
-  sha256 'fda7a13bf68ba778ad0b1c561ec41506dfecff3d5b67b846568656cc19c6b023'
+  version '104045,582'
+  sha256 '9aeeae0a347589881e87079af2cb5608497a278e447b7379e838117c9b2b97c3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '74b7a49e6ba13daf9fa705ac70fa036c99de32a4d0549059ba1e9fee5aabca1c'
+          checkpoint: '2e0a7df14d9bf66bd575c0214404e1e7ea2c34a0cacf101c4a464e7eabfeef10'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -5,7 +5,7 @@ cask 'telegram-alpha' do
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2e0a7df14d9bf66bd575c0214404e1e7ea2c34a0cacf101c4a464e7eabfeef10'
+          checkpoint: '1295fb3991a49f0393b743774590c1d45a2ecfd1d2063d37cdeef54103053450'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.