### PR TITLE
Update telegram-alpha to 104054,583

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '104021,581'
-  sha256 'fda7a13bf68ba778ad0b1c561ec41506dfecff3d5b67b846568656cc19c6b023'
+  version '104054,583'
+  sha256 'c3829eab4d495dc367430b4b01437e3c0846a8b05662e7b0bf91e9c2e048f812'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '74b7a49e6ba13daf9fa705ac70fa036c99de32a4d0549059ba1e9fee5aabca1c'
+          checkpoint: '1295fb3991a49f0393b743774590c1d45a2ecfd1d2063d37cdeef54103053450'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.