### PR TITLE
Update thunderbird-beta to 56.0b3

### DIFF
--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -1,23 +1,23 @@
 cask 'thunderbird-beta' do
-  version '53.0b2'
+  version '56.0b3'
 
   language 'cs' do
-    sha256 '0f6266af5f436ecfa52493e227cc2dd2bfa2cf10093d52f7e28a5c5efa3a7e0b'
+    sha256 'c6158f144573f20cf3b389ad37ac317dfc54c52512996664047a00a62653a50f'
     'cs'
   end
 
   language 'en', default: true do
-    sha256 'd55bfa4c6422dd820ee14a826d2705cfb7a90e37503d10bbd195c296e87e7a08'
+    sha256 '48c353b966c3dc534250e78f80a7e5680870d065f633de4ecf4b7669f5289da1'
     'en-US'
   end
 
   language 'ru' do
-    sha256 '0e4398ef8dbc68bdf593b243008ad13055b3effb8dd5feba480cb2b0984ce446'
+    sha256 'd75dcd7d1b8ef3b9d0a5af70313af784a41e146c33e5036e084d3611cd52edbb'
     'ru'
   end
 
   language 'uk' do
-    sha256 'd6b0929753ad90a8af9a86e7d1f1c508d9c15b7bc3417cd41c1a198d0dc7605d'
+    sha256 '7ca26f68c83fc3b49366d6206ed1f881176b1d04aade6d59a407999a1e669c75'
     'uk'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
