### PR TITLE
Update firefox-esr to 52.3.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '52.2.1'
+  version '52.3.0'
 
   language 'cs' do
-    sha256 'cf5d873f0c57ede9b8af0b34e8b08a84a062e28979ebb5620353fbb768053423'
+    sha256 '22c8b184d0e69d5384ce5e877a7400924fe3229b5c63a7b6c5a76c658e041fe3'
     'cs'
   end
 
   language 'de' do
-    sha256 'd0b6a28d5a5d5b26fe94e6d60a9b6d07f4ed8c8bee7e53dd5374ae6c8250f845'
+    sha256 '2d9ed91e7b5df92879038ebf098db06eae755d2e69550503e64a9bcc3dbb9b83'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '3de727139710d9dae3075fc13a74a2f43d9826f04c30a4857b6cc59c8fabf47f'
+    sha256 'd6f82401ffad320f4cfb8a34c493d2ead3760c271c0df4641001bfd8842cc2c0'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '4cba32486f9cdae8f3b22ac3d5d1e66ea66e061743217a3cef20d9e45808952e'
+    sha256 'd4681323b7d315a88b0e0c0d8d28d806969e8a91d7f490891fcb7a40d8e8c1e6'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '93bb959327827523f885f35e5f69a18ab68cd87e524729f955bdbca094baad9a'
+    sha256 'cf2fef76461ec01c7bbe8135782c97458b3f09bc0c3d7b89388332fe85b03e78'
     'fr'
   end
 
   language 'gl' do
-    sha256 '9ce98f0eb8441eebed9d598ba94a57a4b721bb9650ce3c6e4892eb4af8e5a708'
+    sha256 '76f711e53ffaeafa7c09fb0b359a469b5bc93013c85fecd609da48847485ef1c'
     'gl'
   end
 
   language 'it' do
-    sha256 '6a71d2d52b3bcd7df7681ba5c8458a7a8d703df6f4e646a3eb30e4237d8db568'
+    sha256 '4139cbb24a7630451af1546e436a2928fd0480616cb9419e18897a4a4bae6d3b'
     'it'
   end
 
   language 'ja' do
-    sha256 '7375670c5780f7fb4bdc79214ff26de96c6eb58a0cd5d99ac339c7300aca71b1'
+    sha256 'abc4d179b08dbe41d01715d996835d611babce166517136583cfa2670c96f1e3'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '5559febb9b8f3e189f34f79e7ecf3a68e9b6533c8611b789257efc811f723eaa'
+    sha256 '4e86d90f8739481b0e4ba9a55cc21cc6b460ecf2c9dc8b14fa5299a32140dfc3'
     'nl'
   end
 
   language 'pl' do
-    sha256 '05d9bbffa16d876e600249d5cecc13221ada37f57ad8c04361503019758c58e1'
+    sha256 '5c8c1a1233288732ae13bdfc1ba57478089e1868f0949a22d359c1569ff68a0c'
     'pl'
   end
 
   language 'pt' do
-    sha256 '2ead915c382f24c256cb6f5c17be320fb6bafaf37d7b3246679285523c6ba098'
+    sha256 '2dbdfbbe2cacec9d98deab53e09c96f2a24c74a8a21cbda3022f60ff447f3f2a'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '20d358d0c867ce63023b77628ed997c25c205eb9072d6e0652130ed2e63093fa'
+    sha256 'b886ba5a8c56da4363454b93297e045026eddf290412fc1816cd3c4b12c37e27'
     'ru'
   end
 
   language 'uk' do
-    sha256 'a1e5ea4fd7ca9aac812b4a3352d00644f79a4f321b24cc05b8149ace78e8c113'
+    sha256 '8501d34eaae1a3289e343e6b8705cf8d2bc0a1b4ac550c78805b10d1e60e645f'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '389cc87012866d01b68307a47a78f52ca1de19c7ac86cd1a58256eb17a68e1c5'
+    sha256 '2b213269a3096e4f7560f6bfa27a9df43a0f4e2369ae162ed264deed3cbd4b20'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '259c1a59b52893d7c13d5b53b408fcbba0003d79cca507cb4ed9471159c51e5a'
+    sha256 '7b119b859a179c4de8b72c4ae2d835e8ef7e28ded7f403d9b1906c17431e2a28'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
