### PR TITLE
Update firefoxdeveloperedition to 56.0b8

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,50 +1,50 @@
 cask 'firefoxdeveloperedition' do
-  version '56.0b3'
+  version '56.0b8'
 
   language 'cs' do
-    sha256 'f885f90aa9ce4d436706c37ba5c57ec1c6db6e3599392dcd9fb078095b653bb2'
+    sha256 '3e3f01dc1e6a6ef00c720bc95ea8719fe81f7574e87bc16947e5c89ea2261547'
     'cs'
   end
 
   language 'de' do
-    sha256 '94c6ddb05399f3ccd1cbba8d68672ceb465db43ef4f5242910d3d45741d513f1'
+    sha256 'c4c8c8c5ca2fd10fcf941637c07f1623c6cdee78f23d9f7db59d0f7203e1443d'
     'de'
   end
 
   language 'en', default: true do
-    sha256 'ce73bc16f26495ced481fdfdbdff8eb9a092a13e9ea629dc6ce279dac1da25fd'
+    sha256 'fda509f5164dd555472633fa502193de75cbf841465d9d037d1d814f44a9c9ab'
     'en-US'
   end
 
   language 'ja' do
-    sha256 '76f07c6435f2e5c7261bf4cb55d68900d076e3403535de6214f409bce01dcf6c'
+    sha256 'a31f01bb2018c03d0dae222255f1a6dc8b76b10cc41e87e3276e78282877ee57'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 '0eca1a90a3cbf753847a5c861786ab47268855adf5bfff676771c31f6f0eb198'
+    sha256 '16afe13bf1e51181b1873c5c125d22597b3865df283d58cb43934be7fde184c8'
     'ru'
   end
 
   language 'uk' do
-    sha256 '770fc01851fa954062c5b05cd013ef5a00f75379d4f56225e270fcea7ddeec00'
+    sha256 '4d45ddaded6257695e40bc0351c60b92f2bbac901799ab8c22d3d8d911f2dc72'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '681714c5128a07cfd3ba51316444a74411c059a2c6743cd8d5406876ada421ba'
+    sha256 '7e72629031a5353f29e4e0f4dbbd5a56635619f1e28bb53b64eeb644de7e078f'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '145899a88936f8e1b0313b9aabd49d3b3886ba1257518a376f305da1d26993c0'
+    sha256 '5314aa05746acc6df1d28a3953392a605a5905079ccca66a0402446cc423cfb0'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/devedition/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/',
-          checkpoint: '732dddeb1476b75cb37da2b892aba3195c6d26bd61da831fe5a6446e11091f64'
+          checkpoint: 'e805f4fa5a8f5139ea6c053bfb41e35003981356e2e32f229d5edf20a999b30a'
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
