### PR TITLE
Update airmail-beta to 3.3.3.448,313

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.447,312'
-  sha256 'b40a8214695eb182c5d51ddada0da9cae20b2df76d7db84590139f3b260349cf'
+  version '3.3.3.448,313'
+  sha256 '86222d1c53ab3cf677e11b5399106917e18edc9399300d40f5e85daa84c282cc'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'abba926a0993b87360ec4ada3e54273a8d4dfdd52f981fb71a5a937345f8018b'
+          checkpoint: '79a803ec42951f09c99142baeea8ce4996fc0677bdae0fd91c8022ba4d28ec43'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.