### PR TITLE
Update telegram-alpha to 3.2-104075,588

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.1.2.104070,585'
-  sha256 '8460d4c6dd06d3dcfc0f0a2c76086deff97fa046567aa9deb08ce1c0934dbf35'
+  version '3.2-104075,588'
+  sha256 'f8c90aa2f194bd6a33867647528c70d69c5deb111758af50b1db197b32faae9a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'af515455843bef34d72b680d576522d8098f9ea56fbadbb20b1a8ab7e35dd7f5'
+          checkpoint: 'a0f0601430baa4bcc2d328c318571814c106aa4820b41023d53c5eaae79408d3'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.