### PR TITLE
Update airmail-beta to 3.3.3.449,314

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.448,313'
-  sha256 '86222d1c53ab3cf677e11b5399106917e18edc9399300d40f5e85daa84c282cc'
+  version '3.3.3.449,314'
+  sha256 'ef20c55934ec700bb83bde293fdf66f2867e63f0bb064b3ceac5c31dabcc3f96'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '79a803ec42951f09c99142baeea8ce4996fc0677bdae0fd91c8022ba4d28ec43'
+          checkpoint: '1883a17711c0e7d25f0ddcb37085495d9b2bd8290a2d63631f0a0cb955e4b4f0'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.