### PR TITLE
Update safari-technology-preview to 39

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '38'
+  version '39'
 
   if MacOS.version == :sierra
-    sha256 '47a4b530f330ddc62d3bbf744fbebf0c1871d734a11256c0dae70a3c3cdc5d80'
-    url 'https://secure-appldnld.apple.com/STP/091-30032-20170822-5E2F4F8C-8780-11E7-A38E-12ABA0123000/SafariTechnologyPreview.dmg'
+    sha256 '6660e882cba73a27fdf229c770b86addd6749b7171bef0f39a6752b2ca181e34'
+    url 'https://secure-appldnld.apple.com/STP/091-31523-20170906-3B5795DC-927A-11E7-86FA-1CEE0D4B7226/SafariTechnologyPreview.dmg'
   else
-    sha256 '31735759e36f4ad7865bff168df8a844beabb94a878ac207de9d06d1292a87c2'
-    url 'https://secure-appldnld.apple.com/STP/091-30035-20170822-5E2F8C72-8780-11E7-943E-13ABA0123000/SafariTechnologyPreview.dmg'
+    sha256 '88f27a2205976a0fce2d28577dab6a8815fa6b703fe6b47324695ef6a4e6f33a'
+    url 'https://secure-appldnld.apple.com/STP/091-31522-20170906-3B572BF6-927A-11E7-92FC-1DEE0D4B7226/SafariTechnologyPreview.dmg'
   end
 
   name 'Safari Technology Preview'
@@ -21,12 +21,14 @@ cask 'safari-technology-preview' do
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.apple.safaritechnologypreview.sfl',
                 '~/Library/Caches/com.apple.SafariTechnologyPreview',
+                '~/Library/Saved Application State/com.apple.SafariTechnologyPreview.savedState',
+                '~/Library/WebKit/com.apple.SafariTechnologyPreview',
+              ],
+      trash:  [
                 '~/Library/Preferences/com.apple.SafariTechnologyPreview.plist',
                 '~/Library/SafariTechnologyPreview',
-                '~/Library/Saved Application State/com.apple.SafariTechnologyPreview.savedState',
                 '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.UserRequests.plist',
                 '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.WebFeedSubscriptions.plist',
                 '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview.plist',
-                '~/Library/WebKit/com.apple.SafariTechnologyPreview',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.