### PR TITLE
Update telegram-alpha to 3.2.1-104112,592

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2-104081,590'
-  sha256 'f61378e78264d45deca5f67e00bcf539d82099c25457f6ad4662ac2887bfb5eb'
+  version '3.2.1-104112,592'
+  sha256 'a7813c19e79e5975979167c4d76850f5c64cc138b72d0501eeea9bee1663f627'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b8fcd08abd1b86c7c8ad1dc3edd7a7b9d3132ba08b17b48f5acff9effc9da084'
+          checkpoint: '2993dc5430a7607e4888ed083bc367be70299c06f43db8ffa537d68f6cad8d77'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.