### PR TITLE
Update docker-edge to 17.09.0-ce-rc1-mac28,19152

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.07.0-ce-mac26,19053'
-  sha256 'efc7132e87b6b5bae6ed3dd3e91f8d91662357871a177c0487cad484ca82dd47'
+  version '17.09.0-ce-rc1-mac28,19152'
+  sha256 '5c3a997d8a87262faf4679c3a63a1095166c2df347df6f2913f2155d8d7b9ad9'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: 'cee435301a22583aa3cb889ce7a74a5340cfd5cc24129a9cd7635130f0a8482d'
+          checkpoint: '2ec2871b51687ac85b5228741747ac91b7c2d124d5444fa3d2017d562c1f6ddd'
   name 'Docker Community Edition for Mac (Edge)'
   name 'Docker CE for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.