### PR TITLE
Update telegram-alpha to 3.2.1-104262,593

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104112,592'
-  sha256 'a7813c19e79e5975979167c4d76850f5c64cc138b72d0501eeea9bee1663f627'
+  version '3.2.1-104262,593'
+  sha256 '866541465b8a88a680f4f6628f24d2efe14544aeba0260d5150ed3513c24f58a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2993dc5430a7607e4888ed083bc367be70299c06f43db8ffa537d68f6cad8d77'
+          checkpoint: '35a3a1b604449c5288f3b1c31d9e5292fc6a96bd3ef17192d938b2a5cdd2749c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.