### PR TITLE
Update telegram-alpha to 3.2.1-104303,596

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104112,592'
-  sha256 'a7813c19e79e5975979167c4d76850f5c64cc138b72d0501eeea9bee1663f627'
+  version '3.2.1-104292,595'
+  sha256 'e44dba7a50efc7e8df961c125e6216e923d823a2203a48782464217cad0baa4c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2993dc5430a7607e4888ed083bc367be70299c06f43db8ffa537d68f6cad8d77'
+          checkpoint: '88693899dde6a4b2e9f3dcad4b43a16304cc77961af640ad1b52724078019110'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104292,595'
-  sha256 'e44dba7a50efc7e8df961c125e6216e923d823a2203a48782464217cad0baa4c'
+  version '3.2.1-104303,596'
+  sha256 '169a8a1ad6733f4ec54e2411d19474f48317b7e7f72cb8daec8a4986ad048325'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '88693899dde6a4b2e9f3dcad4b43a16304cc77961af640ad1b52724078019110'
+          checkpoint: '6a78c6b89863e6e4c643230e675c3515ff77d4a8c11b109eda8fac8904a8d55e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}