### PR TITLE
Update airmail-beta to 3.3.3.451,316

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.450,315'
-  sha256 '29a3fe9afb3e050553de226b38735b8dbb74090d1dab1d003530e16863f46c0a'
+  version '3.3.3.451,316'
+  sha256 'bf27b4d52adb0a03f4f6a71dcea1538cc2da07c69c77e57f4a54322c8431573a'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'ad9d1ce5a838fff3caca8c0d68cf7d6acd2a3e599c409d1c17f0d5016a051eb2'
+          checkpoint: '47f773b48e1fc436855d275a0212b1de53cbece644ed533f46d86d8a58b5cb42'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.