### PR TITLE
Update clementine-rc to 1.3.1

### DIFF
--- a/Casks/clementine-rc.rb
+++ b/Casks/clementine-rc.rb
@@ -1,11 +1,11 @@
 cask 'clementine-rc' do
-  version '1.3.0,rc1'
-  sha256 'dd578a53c7fd47c89ade55eae224b5390590a32de982479ecf73e738d6620249'
+  version '1.3.1'
+  sha256 '825aa66996237e1d3ea2723b24188ead203f298d0bec89f4c3bc6582d9e63e3a'
 
   # github.com/clementine-player/Clementine was verified as official when first introduced to the cask
-  url "https://github.com/clementine-player/Clementine/releases/download/#{version.major_minor}#{version.after_comma}/clementine-#{version.major_minor_patch}#{version.after_comma}.dmg"
+  url "https://github.com/clementine-player/Clementine/releases/download/#{version}/clementine-#{version}.dmg"
   appcast 'https://github.com/clementine-player/Clementine/releases.atom',
-          checkpoint: 'f2e34fdf3d07c9437f30a4119e66d57f6b4dc72c3782e695330a55ab1b865356'
+          checkpoint: 'ced6f215c6a3dcad642b293d880a70dd17d9225f862e09b565ba542bfe8ee9cb'
   name 'Clementine'
   homepage 'https://www.clementine-player.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.