### PR TITLE
Update telegram-alpha to 3.2.1-104536,600

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104303,596'
-  sha256 '169a8a1ad6733f4ec54e2411d19474f48317b7e7f72cb8daec8a4986ad048325'
+  version '3.2.1-104536,600'
+  sha256 'c298b66311d1146552899fec673f075cbd307891bfbdd7217dde0b23ec4aaa45'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6a78c6b89863e6e4c643230e675c3515ff77d4a8c11b109eda8fac8904a8d55e'
+          checkpoint: '6d2fd92ec08ab498edb3f0615c5872882d92623c5b3b23417bad1b3d3a278929'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.