### PR TITLE
Update telegram-alpha to 3.2.1-104540,601

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104303,596'
-  sha256 '169a8a1ad6733f4ec54e2411d19474f48317b7e7f72cb8daec8a4986ad048325'
+  version '3.2.1-104540,601'
+  sha256 'f382e96c1bd1f2b50141f1f76af6f21d9a6ee036e617860ecb92b73dec6c2ad1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6a78c6b89863e6e4c643230e675c3515ff77d4a8c11b109eda8fac8904a8d55e'
+          checkpoint: '6fc5e2fb8d58b54e0f81625efa8aa066a000598f99c0015e710d8c9041df8f8e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.