### PR TITLE
Update iterm2-beta to 3.1.beta.10

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.beta.9'
-  sha256 'ee8e6425a62f7875cde887002c688182d28636d1cc837dbde0d3819600335c55'
+  version '3.1.beta.10'
+  sha256 '90d1f289f736a1b13fa1be9a6ffc6df61a0f1aa1e517eb50c5f105792398390d'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '7009a0e934fcc1f998e77810c1aa88f856c11c6063229e0c0dae71a0e4cd805e'
+          checkpoint: '7feee695b0f34456062b13c52ff0e9a367121a41855091f422f318fcf64c9f86'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.