### PR TITLE
Update telegram-alpha to 3.2.1-104804,603

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104540,601'
-  sha256 'f382e96c1bd1f2b50141f1f76af6f21d9a6ee036e617860ecb92b73dec6c2ad1'
+  version '3.2.1-104804,603'
+  sha256 '64512d8efb1317760db8420eec39ad01bac48b6bc3b9515ceb5b4ad56589085a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6fc5e2fb8d58b54e0f81625efa8aa066a000598f99c0015e710d8c9041df8f8e'
+          checkpoint: '67f9ec68a26abaa4197070936c94685744b231271bd1ff8ff17603870783495d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.