### PR TITLE
Update vivaldi-snapshot to 1.12.955.14

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.12.955.3'
-  sha256 '9c728bbb6b6325ba5cfc18938bbb60ed2fbea7f7126827069e6157d1aff9891b'
+  version '1.12.955.14'
+  sha256 '87c7066a8341856db023879da6b9fab125490de383884d3446cdbb192aca3b9c'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '919e94b02624625df4f8e96e9962c2fcbfa0f26d9f21094760c128607bc27452'
+          checkpoint: '73233d86c6733841ac1a1c8e7c81f5dc6071f4a4fc3b67d21ed84e599df35e77'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.