### PR TITLE
Update telegram-alpha to 3.2.2-104906,610

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.1-104830,605'
-  sha256 'dc7b43863af0943e891eb61351f1968d3a11c6ee6407e6286bd3a14848af99dd'
+  version '3.2.2-104906,610'
+  sha256 '2501e398c4092222b61d27af8f7d30ceddb576eff2ac9245a7037248f4428303'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6f0d9306e09343e556928483c1324f0a77fde83537e0d3b16fce6f22e3f7c09a'
+          checkpoint: 'bcf48899b4323070d45583dd88c519e6b8b5f1ddc0e976fe90f4368c6ec1e767'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.