### PR TITLE
Update virtualbox-extension-pack-beta to 5.2.0_BETA3,118015

### DIFF
--- a/Casks/virtualbox-extension-pack-beta.rb
+++ b/Casks/virtualbox-extension-pack-beta.rb
@@ -1,10 +1,10 @@
 cask 'virtualbox-extension-pack-beta' do
-  version '5.2.0_BETA2,117563'
-  sha256 '30711e0aa417910cf26e1abc1da08d575d45c330fd593decf35b7d04d87f7ca7'
+  version '5.2.0_BETA3,118015'
+  sha256 '6801a5ec29eb82b680acbc45e000b6a96f2f38ccd24e6cde53f4a9030dbe578b'
 
   url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST-BETA.TXT',
-          checkpoint: '4e9ae5d62ebfe2ab6e9fc1d7bd64c69f0c25b601b1c08ba92711adda7c6c0049'
+          checkpoint: '1f753c9849a06ca6ad4b2df06d022a2dc42bee734c87d98759f911be52eb537b'
   name 'Oracle VirtualBox Extension Pack'
   homepage 'https://www.virtualbox.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.