### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.35,779

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.34,776'
-  sha256 '5b3080b6466c15980ff6cb90228244d7b49f6833d43f2e9886fdec8ec33d6ef1'
+  version '8.2.35,779'
+  sha256 '33f6b870263a1392a7202866b58df2e81320fcaeb8bb8a8e6794ef7b7cdad209'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '9fe067a4a3ec82aad4249cc420221571028122d307f46d89b6f349569f142a47'
+          checkpoint: '8e2fe90c1baa94e334e2d8704b8bdf5eea22f410dba18eda17a0be948f95af66'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.