### PR TITLE
Update firefoxdeveloperedition v57.0b1

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,50 +1,50 @@
 cask 'firefoxdeveloperedition' do
-  version '56.0b8'
+  version '57.0b1'
 
   language 'cs' do
-    sha256 '3e3f01dc1e6a6ef00c720bc95ea8719fe81f7574e87bc16947e5c89ea2261547'
+    sha256 '7f0c7480ffb52535e68b67b082b5f3b9437e0118e8b077a53df738165b7c4058'
     'cs'
   end
 
   language 'de' do
-    sha256 'c4c8c8c5ca2fd10fcf941637c07f1623c6cdee78f23d9f7db59d0f7203e1443d'
+    sha256 'b98755e89860bb2ea242ce98033ba7239d39ace66730edd14a92b8c4829ab260'
     'de'
   end
 
   language 'en', default: true do
-    sha256 'fda509f5164dd555472633fa502193de75cbf841465d9d037d1d814f44a9c9ab'
+    sha256 '363cc37cd814de36dac625fa2724afdc52a163192e4a27980f29f8a08a0a981f'
     'en-US'
   end
 
   language 'ja' do
-    sha256 'a31f01bb2018c03d0dae222255f1a6dc8b76b10cc41e87e3276e78282877ee57'
+    sha256 '67599e99b58f41a0979e4267e31e6be75c0bb8733ab713d6d9b017dab4339fe5'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 '16afe13bf1e51181b1873c5c125d22597b3865df283d58cb43934be7fde184c8'
+    sha256 '3dd7349f9c3dce43f5be269102466308358654c3401b59c54926683b998546de'
     'ru'
   end
 
   language 'uk' do
-    sha256 '4d45ddaded6257695e40bc0351c60b92f2bbac901799ab8c22d3d8d911f2dc72'
+    sha256 'fc9d8e77e4a6dcbd6a3170c700f73b44b1040edb0c3736c42948dfeef53604df'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '7e72629031a5353f29e4e0f4dbbd5a56635619f1e28bb53b64eeb644de7e078f'
+    sha256 '8d7adb051faca700506935133264371591e1f91699e111bb1e0539e19d78d32d'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '5314aa05746acc6df1d28a3953392a605a5905079ccca66a0402446cc423cfb0'
+    sha256 'd94d8421b4d4709049929b2f7d6cd9517620c15ae282ada0999a11de135edc9a'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/devedition/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/',
-          checkpoint: 'e805f4fa5a8f5139ea6c053bfb41e35003981356e2e32f229d5edf20a999b30a'
+          checkpoint: '407e2cacaab71329169aa6caee54dbfcbfe91fa121b5e75e95a1e158a44fab04'
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
