### PR TITLE
Update docker-edge to 17.09.0-ce-rc2-mac29,19275

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,10 +1,10 @@
 cask 'docker-edge' do
-  version '17.09.0-ce-rc1-mac28,19152'
-  sha256 '5c3a997d8a87262faf4679c3a63a1095166c2df347df6f2913f2155d8d7b9ad9'
+  version '17.09.0-ce-rc2-mac29,19275'
+  sha256 '300fd320f686f195031b0afb78682a0047dbf4a181f45096a97b1378a25348d6'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml',
-          checkpoint: '2ec2871b51687ac85b5228741747ac91b7c2d124d5444fa3d2017d562c1f6ddd'
+          checkpoint: '192c6d417852405bd415659f73218f877fef78ab3d908e60fa2220324213eb1a'
   name 'Docker Community Edition for Mac (Edge)'
   name 'Docker CE for Mac (Edge)'
   homepage 'https://www.docker.com/community-edition'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.