### PR TITLE
Update 2 iterm2 Casks: depends_on / zap

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -10,16 +10,18 @@ cask 'iterm2-beta' do
   homepage 'https://www.iterm2.com/'
 
   auto_updates true
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
 
   app 'iTerm.app'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl',
+                '~/Library/Caches/com.googlecode.iterm2',
+                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
+              ],
+      trash:  [
                 '~/Library/Application Support/iTerm',
                 '~/Library/Application Support/iTerm2',
-                '~/Library/Caches/com.googlecode.iterm2',
                 '~/Library/Preferences/com.googlecode.iterm2.plist',
-                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
               ]
 end

--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -8,16 +8,18 @@ cask 'iterm2-nightly' do
   homepage 'https://www.iterm2.com/'
 
   auto_updates true
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
 
   app 'iTerm.app'
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl',
+                '~/Library/Caches/com.googlecode.iterm2',
+                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
+              ],
+      trash:  [
                 '~/Library/Application Support/iTerm',
                 '~/Library/Application Support/iTerm2',
-                '~/Library/Caches/com.googlecode.iterm2',
                 '~/Library/Preferences/com.googlecode.iterm2.plist',
-                '~/Library/Saved Application State/com.googlecode.iterm2.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.