### PR TITLE
Update iterm2-beta to 3.1.2.beta.1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.beta.10'
-  sha256 '90d1f289f736a1b13fa1be9a6ffc6df61a0f1aa1e517eb50c5f105792398390d'
+  version '3.1.2.beta.1'
+  sha256 'daadf704120569e87f76139ca4e7d292c57a0fe3285557bbd188c1a2c467b28d'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '7feee695b0f34456062b13c52ff0e9a367121a41855091f422f318fcf64c9f86'
+          checkpoint: '9cc29dd3bc6a20c8116e60617b285046d7e44e9ce4c959bf9fd12eaaf23483c3'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.