### PR TITLE
Update slicer-nightly to 4.7.0.26374,689893

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.7.0.26338,684799'
-  sha256 'ab7abf63c1de4f98a41845f7aa4e3e52aabce5e537717cbcdf34830d6d94412a'
+  version '4.7.0.26374,689893'
+  sha256 'e3d800bd652bd70f9d3906e2b1092e72c1b22aefef4b8ae25bc719664e33892d'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.