### PR TITLE
Update firefoxdeveloperedition to 57.0b2

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,50 +1,50 @@
 cask 'firefoxdeveloperedition' do
-  version '57.0b1'
+  version '57.0b2'
 
   language 'cs' do
-    sha256 '7f0c7480ffb52535e68b67b082b5f3b9437e0118e8b077a53df738165b7c4058'
+    sha256 '8d78fc7cc9ef189854fa15cac41ef6ff83c373a262a2d5017f4ab59cfc841b61'
     'cs'
   end
 
   language 'de' do
-    sha256 'b98755e89860bb2ea242ce98033ba7239d39ace66730edd14a92b8c4829ab260'
+    sha256 '1ef0d3beb41d42e1fece1f68987454c4317319591612e440659e34b5758b2add'
     'de'
   end
 
   language 'en', default: true do
-    sha256 '363cc37cd814de36dac625fa2724afdc52a163192e4a27980f29f8a08a0a981f'
+    sha256 '5386f16f6b0b39ed0a54142994004a638139ae5d464ce08903bc0d710fac5c16'
     'en-US'
   end
 
   language 'ja' do
-    sha256 '67599e99b58f41a0979e4267e31e6be75c0bb8733ab713d6d9b017dab4339fe5'
+    sha256 '96c071dca60289c84cc9316a083b6f40eda06bd7bc84c93a42388302de3f0c5e'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 '3dd7349f9c3dce43f5be269102466308358654c3401b59c54926683b998546de'
+    sha256 'ddfe548f4b7696e670087f18a5c1474028f05526e279b8b63d87bd73d0337034'
     'ru'
   end
 
   language 'uk' do
-    sha256 'fc9d8e77e4a6dcbd6a3170c700f73b44b1040edb0c3736c42948dfeef53604df'
+    sha256 '6f212cd8c9c4bb50113652ccb1de43b86e55c26bf77dd7c51885b2bbf19d1df0'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '8d7adb051faca700506935133264371591e1f91699e111bb1e0539e19d78d32d'
+    sha256 'b3025f85e12c0e173678fe9691c4d464e8b90b6da17567db975bfdf2d2b30ef9'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'd94d8421b4d4709049929b2f7d6cd9517620c15ae282ada0999a11de135edc9a'
+    sha256 'a31c8ae8bd2f7b7690afead286e3cd97b8c0ae77f4560c10cb10ebfebec76dec'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/devedition/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/',
-          checkpoint: '407e2cacaab71329169aa6caee54dbfcbfe91fa121b5e75e95a1e158a44fab04'
+          checkpoint: 'f4d84144b72ab0ae3bafd1bb92039bd2f2c338091a6c98d0bed1ed50fa84bc1b'
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.