### PR TITLE
Update github-desktop-beta to 1.0.2-beta0-86bff21e

### DIFF
--- a/Casks/github-desktop-beta.rb
+++ b/Casks/github-desktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'github-desktop-beta' do
-  version '1.0.1-beta0-e1b95d2d'
-  sha256 'c14de67276c0bba88153b1217e54a0afe7de5875279e822d387234d73e595f6e'
+  version '1.0.2-beta0-86bff21e'
+  sha256 'abf0002f45fe8377144965e50f73e55dee2d48b9566d05e168b6cce7315f2807'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: 'bdaa9a05920b09f4b9f258dde1f9a88eab56f1e48233dcbc83f5113afce29013'
+          checkpoint: '3f7b1c8caaaa0f8dc41e2291540271b4c3d4a4b8ce32577c5a3eac836a240daa'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.