### PR TITLE
Update telegram-alpha to 3.2.4-105219,624

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.2.4-105069,621'
-  sha256 'f5dd487bc2bbb22e60e356ca3f8495b888d4b8ee88817b2980d208ea295fc274'
+  version '3.2.4-105219,624'
+  sha256 '7a92344876209a5ab3d0f8a921da0d1715673a7c5ed7a6b1fc80d6cba7ac2a40'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6a3cc4d8505e9e48c9fcc78eb48c5099990faca40c42fe889aca76b392dda18a'
+          checkpoint: '472cdd1c9996d961d3520b7fa55d739285e087c9f482c0b39c5858c4cac749a8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.