### PR TITLE
Add "Latest build" version of Prince XML

### DIFF
--- a/Casks/prince-latest.rb
+++ b/Casks/prince-latest.rb
@@ -1,4 +1,4 @@
-cask 'prince' do
+cask 'prince-latest' do
   version '20170907'
   sha256 '3c882cbbcdd646e27263105fce8079391d703c8243ad640b4b2db3364dadce5f'
 

--- a/Casks/prince-latest.rb
+++ b/Casks/prince-latest.rb
@@ -1,0 +1,19 @@
+cask 'prince' do
+  version '20170907'
+  sha256 '3c882cbbcdd646e27263105fce8079391d703c8243ad640b4b2db3364dadce5f'
+
+  url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
+  name 'Prince'
+  homepage 'https://www.princexml.com/'
+
+  installer script: "prince-#{version}-macosx/install.sh"
+
+  uninstall delete: [
+                      '/usr/local/bin/prince',
+                      '/usr/local/lib/prince',
+                    ]
+
+  caveats do
+    files_in_usr_local
+  end
+end

--- a/Casks/prince-latest.rb
+++ b/Casks/prince-latest.rb
@@ -3,6 +3,8 @@ cask 'prince-latest' do
   sha256 '3c882cbbcdd646e27263105fce8079391d703c8243ad640b4b2db3364dadce5f'
 
   url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
+  appcast 'https://www.princexml.com/latest/',
+          checkpoint: '53edcc6bb96a56e42143629a6cc380229ef1f27ed372e550f012e3f71a10f548'
   name 'Prince'
   homepage 'https://www.princexml.com/'
 


### PR DESCRIPTION
These downloads can be found at https://www.princexml.com/latest/. The download URLs match the same pattern as the regular https://github.com/caskroom/homebrew-cask/blob/master/Casks/prince.rb downloads, so this just needed a different version/sha256.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
