### PR TITLE
Update android-studio-canary to 3.0.0.14,171.4333198

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,5 +1,5 @@
 cask 'android-studio-canary' do
-  version '3.0.0.10,171.4333198'
+  version '3.0.0.14,171.4333198'
   sha256 '386dafc2846542acbd8280ed89fe41434d2de5347d5ae41548e8d7c508e94e09'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"

--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '3.0.0.10,171.4263559'
-  sha256 'b2acdc0f9a13052d4e2870b302fe259fd710519ac4d90b0c1c928633a1b52b4f'
+  version '3.0.0.10,171.4333198'
+  sha256 '386dafc2846542acbd8280ed89fe41434d2de5347d5ae41548e8d7c508e94e09'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
Update Android Studio beta to Beta 6 (version 3.0.0.10, 171.4333198)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.


[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
