### PR TITLE
Update telegram-alpha to 3.4-106132,630

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.4-106110,629'
-  sha256 '75d2ebc257da9808fb2a2744cef6675596d5b4cdff68cabf3356252efb89ec28'
+  version '3.4-106132,630'
+  sha256 '886051293d88bd2923bd1b2ab73302e132cc73659fe26444fc1f39ed57ceae3c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'd2781ff03c5398484d50b8994bbd683cf3a3b9bac43651e42bc0d87b1a93b669'
+          checkpoint: 'c0b752076cc46e17a52ee692f1b093d292f8e1a3eacd482494f483054a876a47'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.