### PR TITLE
Update telegram-alpha to 3.4-106218,632

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.4-106195,631'
-  sha256 '3fa75ad964fe4c8df1453aa255afc2089ca0dfe59f584e3c2b6cbf2da6579ade'
+  version '3.4-106218,632'
+  sha256 '69bf0b295c8315345be76ccfc53821bca4040d92170008ee842ad2d506bafd9a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6cfd1fb95244d38b24e08abbcb02b2cb071818906b0ebe19eb0f060bc3bbb917'
+          checkpoint: '6e3edb8284f87a6cbbc5140a087059098720b1e017c436bee4cdd689e1eda443'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.