### PR TITLE
Update slicer-nightly to 4.7.0.26393,691993

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.7.0.26393,691654'
-  sha256 'bf73014ce201013213b451cab088f7cc03d427d7cbcc599d297a3ab3a32c6d1a'
+  version '4.7.0.26393,691993'
+  sha256 '6e2434c871b18e917c6e2884c2b899c2f8ca0a9fe64e8a9a4d726b144d6f8bce'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.