### PR TITLE
Update iterm2-beta to 3.1.3.beta.1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.2.beta.2'
-  sha256 '66b167e40819c0e36501cacd61fd2d0e638de35e6d984d827a7467d36af7c722'
+  version '3.1.3.beta.1'
+  sha256 '406073f0cb1a53b48cdffe9fd543942436c69c609ee917c4c1b76c34bf183edb'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '701898de64a6abd9c00f9002be7812c365410ecff9d9d2c90fe95ac0f7e0b609'
+          checkpoint: '36274dae2a549c5b0403c1e80561263f0630f80d61802c6da128203c1c6fd9c7'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.