### PR TITLE
Update hyper-canary to 2.0.4

### DIFF
--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,11 +1,11 @@
 cask 'hyper-canary' do
-  version '2.0.3'
-  sha256 '63e7b794ad30ed2d8f20fbdff62a7d5c924d12fa7d7acf947b5b6e326fc9d9b7'
+  version '2.0.4'
+  sha256 'db2540215f1aaaa164f992c9c7f58c76bd6a35c7e5ea662e06b00825e42a3b2f'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '3e6904e6ace6c8b67292010e3a8651f04d55142399409ab663b7997168ab23ed'
+          checkpoint: 'e9ffa6b15e4033dacd8a4fe8fdfb8de8cdec5354cdd35a61087fee5af64b48f4'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.