### PR TITLE
Update telegram-alpha to 3.4-106348,636

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.4-106296,634'
-  sha256 'a18701acf6e1cdc52f8a558ad8321c38232681181cd540cd65e6551a317193d7'
+  version '3.4-106348,636'
+  sha256 'aee9b6809e261c467ea1ad4c2be76acd54b45f93f30685be081cb5a81985da14'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '53ab3f1f3ff4499014b1fed8cdc4ed851dfc3f25b1c619c998cb24d77333fdac'
+          checkpoint: '805178644e640b6cc18f8dc29df5b02ca20d69c3de83048204fc56ca5d4ea352'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.