### PR TITLE
Update skype-preview to 8.8.76.60544

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,9 +1,9 @@
 cask 'skype-preview' do
-  version '8.7.76.59440'
-  sha256 '269edb273e643518fdf227bfdad2e2960486d6aa41038683c3132806d361ee48'
+  version '8.8.76.60544'
+  sha256 '48beb93785716693ca542bfcd2c0fcaa3551b5a3a24717d56dcb794ea6c2db9f'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
-  url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-Preview-#{version}.dmg"
+  url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
   name 'Skype Preview'
   homepage 'https://www.skype.com/en/insider/'
 

--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -7,5 +7,5 @@ cask 'skype-preview' do
   name 'Skype Preview'
   homepage 'https://www.skype.com/en/insider/'
 
-  app 'Skype Preview.app'
+  app 'Skype.app'
 end

--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -7,5 +7,7 @@ cask 'skype-preview' do
   name 'Skype Preview'
   homepage 'https://www.skype.com/en/insider/'
 
+  conflicts_with cask: 'skype'
+
   app 'Skype.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.