### PR TITLE
Update charles-beta to 4.2b7

### DIFF
--- a/Casks/charles-beta.rb
+++ b/Casks/charles-beta.rb
@@ -1,6 +1,6 @@
 cask 'charles-beta' do
-  version '4.2b6'
-  sha256 '1a162d8b519cff51dc5b73d63e78c9df06763fe37a6a842ac3e7d662cabc1924'
+  version '4.2b7'
+  sha256 '345c6ace73e0f241578be0bddf4f1450e3d671d3a70a51b30d91a1a314bb0091'
 
   url "https://www.charlesproxy.com/assets/release/#{version.gsub(%r{b\d$}, '')}/charles-proxy-#{version}.dmg"
   name 'Charles'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.