### PR TITLE
Update 1password-beta to 6.8.3.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,10 +1,10 @@
 cask '1password-beta' do
-  version '6.8.1.BETA-4'
-  sha256 'f361e014bd4f64c0eb65b02087140665c2f208cf2bb76d37e0355968f83fe5d1'
+  version '6.8.3.BETA-1'
+  sha256 '55111a261a77a56cb7c6197efb0968fe1389e26ede18031ee6337e2d7836c8e5'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: 'e3d0809dd28b05cbff4213481cb697e2fa40bde2110f9d410d13dc1ae1458abf'
+          checkpoint: '64e8484c045ca25ff2bbe13b129f2cdad09827162349ed85ef855c174a6eb9ce'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.