### PR TITLE
Update sketch-beta to 47,45392

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '47,45359'
-  sha256 'd33b7f348ee2e931b39b262bf536f9b1f72dd92f8cff1304952d3c7e0516cc1c'
+  version '47,45392'
+  sha256 'b29a96a135453ba9b551d67c400c272b032e3c89538691bf11130a066a6f2855'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '036d03892f6e7a13147239d2f4cbec8b0985062b5c852a511e5f5e5e7909b7df'
+          checkpoint: 'c942afd30a773865d3f0d38c367d6144bb9bd7433aec97c1486a28a82f618993'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.