### PR TITLE
Updating firefox developer edition to 57.0b3

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,50 +1,50 @@
 cask 'firefoxdeveloperedition' do
-  version '57.0b2'
+  version '57.0b3'
 
   language 'cs' do
-    sha256 '8d78fc7cc9ef189854fa15cac41ef6ff83c373a262a2d5017f4ab59cfc841b61'
+    sha256 '6b3aa3ab0f2bf56e82f95559bf0f8ebd68e3094a084fdc34d544dcc3a02f7fe3'
     'cs'
   end
 
   language 'de' do
-    sha256 '1ef0d3beb41d42e1fece1f68987454c4317319591612e440659e34b5758b2add'
+    sha256 '7138612d50d55806dede7de55dedeae5669afaa51bed0826d789262fc1a4980a'
     'de'
   end
 
   language 'en', default: true do
-    sha256 '5386f16f6b0b39ed0a54142994004a638139ae5d464ce08903bc0d710fac5c16'
+    sha256 'f7e92f31e2eea01baf145bd1cf263d73831bfc40b15e5fc89de36ef8634ab728'
     'en-US'
   end
 
   language 'ja' do
-    sha256 '96c071dca60289c84cc9316a083b6f40eda06bd7bc84c93a42388302de3f0c5e'
+    sha256 '5a55e087335e191f8a73ddc535805a89587867a9cf16255ef2aca8d00975b655'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 'ddfe548f4b7696e670087f18a5c1474028f05526e279b8b63d87bd73d0337034'
+    sha256 '602f87bc88ae988a2cd89f856b903ff8e1b8bd58adbfc2002ec5114b85872519'
     'ru'
   end
 
   language 'uk' do
-    sha256 '6f212cd8c9c4bb50113652ccb1de43b86e55c26bf77dd7c51885b2bbf19d1df0'
+    sha256 '09ab818edf00d06dd52eb51178cd80c84a3d2c0b8dbcd375bde8e2cc9a511e77'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'b3025f85e12c0e173678fe9691c4d464e8b90b6da17567db975bfdf2d2b30ef9'
+    sha256 '40dfa404e8b6093fa8b466417dc3da9eea226aa1a16dd82f3d688e4ec3adf4cd'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'a31c8ae8bd2f7b7690afead286e3cd97b8c0ae77f4560c10cb10ebfebec76dec'
+    sha256 'bcce0a37eacb811995b4d58009af181df6c7a827a65d91b26ec9572fcea70184'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/devedition/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/',
-          checkpoint: 'f4d84144b72ab0ae3bafd1bb92039bd2f2c338091a6c98d0bed1ed50fa84bc1b'
+          checkpoint: 'afceb008922b57728876b87c128ee8bd88824a851ec730fd1ad84e42e390e2cd'
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
 


### PR DESCRIPTION
Updating the developer version of firefox to the current version that you would download from their main website

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
