### PR TITLE
Add legacy TextExpander.app v5.1.4

### DIFF
--- a/Casks/textexpander5.rb
+++ b/Casks/textexpander5.rb
@@ -2,6 +2,7 @@ cask 'textexpander5' do
   version '5.1.4'
   sha256 'a299cdd809c3a5822375eec18a4644a785d7c442d6357a3a6f141c2e2b92a657'
 
+  # dl.smilesoftware.com/com.smileonmymac.textexpander was verified as official when first introduced to the cask
   url 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
   name 'TextExpander'
   homepage 'https://textexpander.com/textexpander-standalone-apps/'

--- a/Casks/textexpander5.rb
+++ b/Casks/textexpander5.rb
@@ -3,7 +3,7 @@ cask 'textexpander5' do
   sha256 'a299cdd809c3a5822375eec18a4644a785d7c442d6357a3a6f141c2e2b92a657'
 
   # dl.smilesoftware.com/com.smileonmymac.textexpander was verified as official when first introduced to the cask
-  url 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
+  url 'https://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
   name 'TextExpander'
   homepage 'https://textexpander.com/textexpander-standalone-apps/'
 

--- a/Casks/textexpander5.rb
+++ b/Casks/textexpander5.rb
@@ -19,7 +19,6 @@ cask 'textexpander5' do
   name 'TextExpander 5'
   homepage 'https://textexpander.com/textexpander-standalone-apps/'
 
-  auto_updates false
   accessibility_access true
   conflicts_with cask: 'textexpander'
 

--- a/Casks/textexpander5.rb
+++ b/Casks/textexpander5.rb
@@ -1,22 +1,9 @@
 cask 'textexpander5' do
-  if MacOS.version <= :snow_leopard
-    version '3.4.2'
-    sha256 '87859d7efcbfe479e7b78686d4d3f9be9983b2c7d68a6122acea10d4efbb1bfa'
+  version '5.1.4'
+  sha256 'a299cdd809c3a5822375eec18a4644a785d7c442d6357a3a6f141c2e2b92a657'
 
-    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
-  elsif MacOS.version <= :mavericks
-    version '4.3.6'
-    sha256 'ec90d6bd2e76bd14c0ca706d255c9673288f406b772e5ae6022e2dbe27848ee9'
-
-    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
-  else
-    version '5.1.4'
-    sha256 'a299cdd809c3a5822375eec18a4644a785d7c442d6357a3a6f141c2e2b92a657'
-
-    url 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
-  end
-
-  name 'TextExpander 5'
+  url 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
+  name 'TextExpander'
   homepage 'https://textexpander.com/textexpander-standalone-apps/'
 
   accessibility_access true

--- a/Casks/textexpander5.rb
+++ b/Casks/textexpander5.rb
@@ -1,0 +1,31 @@
+cask 'textexpander5' do
+  if MacOS.version <= :snow_leopard
+    version '3.4.2'
+    sha256 '87859d7efcbfe479e7b78686d4d3f9be9983b2c7d68a6122acea10d4efbb1bfa'
+
+    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
+  elsif MacOS.version <= :mavericks
+    version '4.3.6'
+    sha256 'ec90d6bd2e76bd14c0ca706d255c9673288f406b772e5ae6022e2dbe27848ee9'
+
+    url "https://cdn.smilesoftware.com/TextExpander_#{version}.zip"
+  else
+    version '5.1.4'
+    sha256 'a299cdd809c3a5822375eec18a4644a785d7c442d6357a3a6f141c2e2b92a657'
+
+    url 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
+  end
+
+  name 'TextExpander 5'
+  homepage 'https://textexpander.com/textexpander-standalone-apps/'
+
+  auto_updates false
+  accessibility_access true
+  conflicts_with cask: 'textexpander'
+
+  app 'TextExpander.app'
+
+  uninstall login_item: 'TextExpander'
+
+  zap trash: '~/Library/Application Support/TextExpander/'
+end


### PR DESCRIPTION
As TextExpander v6.0.0 and above are cloud-only, there are users who
won't be migrating and will continue to use the 'standalone' version.

The reason the CDN URL isn't used like for other versions is because
the latest v5 version (5.1.4) does not exist on that CDN. The latest
is v5.1.1.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].
