### PR TITLE
Update charles-applejava to 3.12.1

### DIFF
--- a/Casks/charles-applejava.rb
+++ b/Casks/charles-applejava.rb
@@ -1,6 +1,6 @@
 cask 'charles-applejava' do
-  version '3.12'
-  sha256 'c1bdd06c6c429d12638d55c4f368758be458a8b7df4b7867b16c4e56d86b05c6'
+  version '3.12.1'
+  sha256 'ab55738645c84e7364547076412a7a131253220a21878750a06204caead00921'
 
   url "https://www.charlesproxy.com/assets/release/#{version.gsub(%r{b\d$}, '')}/charles-proxy-#{version}-applejava.dmg"
   name 'Charles'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.