### PR TITLE
Fix #4547 (palemoon 27.5.0)

### DIFF
--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -3,8 +3,8 @@ cask 'palemoon' do
   sha256 '019686a754204f0691722d332d28678509a32cbfadbde17a0d005435ff9da369'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
-  name 'Pale Moon'
+  name 'Palemoon'
   homepage 'https://www.palemoon.org/'
 
-  app 'PaleMoon.app'
+  app 'Palemoon.app'
 end


### PR DESCRIPTION
The app dir name in latest DMG is **Palemoon.app**.
Also, the name should be **Palemoon** instead of **Pale Moon**.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
