### PR TITLE
Update telegram-alpha to 3.4-107218,640

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.4-106348,636'
-  sha256 'aee9b6809e261c467ea1ad4c2be76acd54b45f93f30685be081cb5a81985da14'
+  version '3.4-107218,640'
+  sha256 '1b7e65cbdae5b752337b77ccecbcd2c57b6b78f83a1ffe55bd6785ca701ed67d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '805178644e640b6cc18f8dc29df5b02ca20d69c3de83048204fc56ca5d4ea352'
+          checkpoint: '3bb048ccc66ceb192e8e91918eb01398fe3cf58ee39b34795137946fadfb812c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.