### PR TITLE
Update skype-preview to 8.8.76.61628

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,6 +1,6 @@
 cask 'skype-preview' do
-  version '8.8.76.60544'
-  sha256 '48beb93785716693ca542bfcd2c0fcaa3551b5a3a24717d56dcb794ea6c2db9f'
+  version '8.8.76.61628'
+  sha256 '95038d4e3a935e1acbecd8ce4f2c004458b5cc4b3538d00e8310401b103918da'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.