### PR TITLE
Update android-studio-canary to 3.0.0.15,171.4365657

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '3.0.0.14,171.4333198'
-  sha256 '386dafc2846542acbd8280ed89fe41434d2de5347d5ae41548e8d7c508e94e09'
+  version '3.0.0.15,171.4365657'
+  sha256 'a1845cac07e4b53eff9c1dc51fc202bf3ee4dacc7aba2238280c2bdd784c0420'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.