### PR TITLE
Update telegram-alpha to 3.4-107390,644

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.4-107274,641'
-  sha256 '722d2a1d9cb215a7431eaeaa0d3129b5db2990e3ad59960c99fd665b7d715391'
+  version '3.4-107390,644'
+  sha256 'f894ac07e254798e1d9d7b89ffd631a38487b2e1ee6cbd0b1f1b08cf1681bea8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '52885cb563ba490b9aa3130fa590c7812ac3a17703a91e4ff72e6bc64b813489'
+          checkpoint: 'f1a044508256d33720abc94605f9ba6de1de165070f0e1bdfe3eaf0363e4cbd1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.