### PR TITLE
Transfer legacy Twitterrific 4.5.1 from main repo

### DIFF
--- a/Casks/twitterrific4.rb
+++ b/Casks/twitterrific4.rb
@@ -1,0 +1,19 @@
+cask 'twitterrific4' do
+  version '4.5.1'
+  sha256 '1b43504307e8a541c97a93ecd4c56bc443f66cdd622d319db965e7e0eb760b46'
+
+  # iconfactory.com was verified as official when first introduced to the cask
+  url "https://iconfactory.com/assets/software/twitterrific/Twitterrific-#{version}.zip"
+  appcast 'https://iconfactory.com/appcasts/Twitterrific/appcast.xml',
+          checkpoint: '8e2fde68cabcb874dd06ca8ff92b98cc07f759dca4c99828e25c35bb0074a289'
+  name 'Twitterrific'
+  homepage 'http://twitterrific.com/mac/'
+
+  app 'Twitterrific.app'
+
+  zap delete: [
+                '~/Library/Application Support/Twitterrific',
+                '~/Library/Caches/com.iconfactory.Twitterrific',
+                '~/Library/Preferences/com.iconfactory.Twitterrific.plist',
+              ]
+end


### PR DESCRIPTION
Twitterrific 4 is no longer updated. Twitterrific 5 is [Mac App Store-only](http://support.iconfactory.com/kb/twitterrific/can-i-upgrade-from-twitterrific-a-previous-version-to-version-5-mac). 

Ref: caskroom/homebrew-cask#39480

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256