### PR TITLE
Update sublime-text-dev to 3148

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3147'
-  sha256 '0a9b4da7d19b7b24c1552228441ffd53b82ae3ecbc8f18ba3e694e19cfa8c3cd'
+  version '3148'
+  sha256 '25a0ab22573249e1be1bc034d3bb51ffc54b5f2edb19d70fe422a9786cf3b9e6'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: 'c1c4f4c0ab0d97f71bb577b1050d5b27bf171335592b3a5131a8dfba4f511a84'
+          checkpoint: '8dbc310d337198d5fe6846a49fa596cb68853f6f781ca26cefcbb3c7c4c26234'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).