### PR TITLE
Update sketch-beta to 47,45396

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '47,45392'
-  sha256 'b29a96a135453ba9b551d67c400c272b032e3c89538691bf11130a066a6f2855'
+  version '47,45396'
+  sha256 'b5493b4d2e2ad755633e440e2c85abd513a424f6199c244f74c1dc31eca4190e'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'c942afd30a773865d3f0d38c367d6144bb9bd7433aec97c1486a28a82f618993'
+          checkpoint: '6b95803f6f52214dc3a551320287e2eebf912d55426e05ae4d6d6a7d43e86517'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).