### PR TITLE
Update 1password-beta to 6.8.3.BETA-3

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,10 +1,10 @@
 cask '1password-beta' do
-  version '6.8.3.BETA-2'
-  sha256 '921e6ad4174652eb7812cddd3a3bcef1afbea7b269730286976d9e772320dc3f'
+  version '6.8.3.BETA-3'
+  sha256 'def2721173646ff890861dd678f9d125b9b8a4364fa9aeaa65006e7094b5a19f'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: '8b36c77df0e074a4539faeed69332a52a4c1b7346374ab92440c227860ec0246'
+          checkpoint: '98d4bc87533c18ead861a51905e7bb32fb770368ead78338d9462496c694c0d6'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).