### PR TITLE
Update palemoon to 27.5.1

### DIFF
--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,6 +1,6 @@
 cask 'palemoon' do
-  version '27.3.0'
-  sha256 '423ec593ba6e8c5d2ccc034b3240e5bc783e46ce0ab9b01c87806b04aa0b2f28'
+  version '27.5.0'
+  sha256 '019686a754204f0691722d332d28678509a32cbfadbde17a0d005435ff9da369'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Pale Moon'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: