### PR TITLE
Update github-desktop-beta to 1.0.5-beta0-93cfe3bf

### DIFF
--- a/Casks/github-desktop-beta.rb
+++ b/Casks/github-desktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'github-desktop-beta' do
-  version '1.0.4-beta1-a6e1681b'
-  sha256 '573788529ef8b78fe157d80ff3d7b3dba98b5b2ff375a4e7f1a70dd6618de714'
+  version '1.0.5-beta0-93cfe3bf'
+  sha256 '23ab2df5749bf882180e053444abbca48c17b3d7f63aca0096f7f2ae488ef7fa'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '4accf7eb234d35b0e345bd12ced66e683826ce0071e20d4ea3a23e7f4b327578'
+          checkpoint: '552ef7130866a5149974e9232452dd34f9b483b40195a01b080073c52f1cfc71'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: