### PR TITLE
Update emacs-pretest to 26.0.90

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,10 +1,10 @@
 cask 'emacs-pretest' do
-  version '25.2-rc2'
-  sha256 '1f5cc002a706915551d406f9bd465229fee749538a54f10fc52b27add597304d'
+  version '26.0.90'
+  sha256 '85ed39cda9795ca1951b0ecae40d5c965a1f0b13e1cc4691ba5ccb1145ac178f'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: 'ea71786763eedb4198a155cc3f0c7728f0757ea8dc3473c6494d7e8b99ec2ff8'
+          checkpoint: '855d4c518cad52c8b643fb9c39ebcacfd2fcf63b8fd3183cc6a0eb2690440375'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: