### PR TITLE
Update virtualbox-beta and virtualbox-extension-pack-beta to 5.2.0_RC1

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-beta' do
-  version '5.2.0_BETA3,118015'
-  sha256 '6092046972b677ac71765967604502adca5c334394b3b8a25a01107a0de306a2'
+  version '5.2.0_RC1,118201'
+  sha256 '893081d852e3376710c2b16e13c17623b290ca1a013e962e8b6d9fd2de8bc911'
 
   url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST-BETA.TXT',

--- a/Casks/virtualbox-extension-pack-beta.rb
+++ b/Casks/virtualbox-extension-pack-beta.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-extension-pack-beta' do
-  version '5.2.0_BETA3,118015'
-  sha256 '6801a5ec29eb82b680acbc45e000b6a96f2f38ccd24e6cde53f4a9030dbe578b'
+  version '5.2.0_RC1,118201'
+  sha256 'fd73ff4e6a1c8677c0252a94d21423d1e59191c3ab2df00891d37d559899f0c2'
 
   url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack"
   appcast 'http://download.virtualbox.org/virtualbox/LATEST-BETA.TXT',
@@ -18,7 +18,7 @@ cask 'virtualbox-extension-pack-beta' do
                    args: [
                            'extpack', 'install',
                            '--replace', "#{staged_path}/Oracle_VM_VirtualBox_Extension_Pack-#{version.before_comma}-#{version.after_comma}.vbox-extpack",
-                           '--accept-license=715c7246dc0f779ceab39446812362b2f9bf64a55ed5d3a905f053cfab36da9e'
+                           '--accept-license=b674970f720eb020ad18926a9268607089cc1703908696d24a04aa870f34c8e8'
                          ],
                    sudo: true
   end


### PR DESCRIPTION
Note that they did not update their LATEST-BETA.txt file.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>][version-checksum] and **am providing confirmation below**: