### PR TITLE
Update sketch-beta to 47.1,45415

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '47,45396'
-  sha256 'b5493b4d2e2ad755633e440e2c85abd513a424f6199c244f74c1dc31eca4190e'
+  version '47.1,45415'
+  sha256 'aac36547d7019de3a9bb43fc11bb2c5f54630c220b537f87dba5251dc6351a74'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '6b95803f6f52214dc3a551320287e2eebf912d55426e05ae4d6d6a7d43e86517'
+          checkpoint: '03f9d32444c82919ec135f4432ddb35ab69f83d6fb444a5f410af07af8999ca0'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: