### PR TITLE
Update telegram-alpha to 3.5-107760,666

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5-107602,664'
-  sha256 'a405290962c02c8eb460be98b0431ab97d4d90c7ef1db62a81028ad93588850f'
+  version '3.5-107760,666'
+  sha256 '46f0a9708418c33458b485fb3c02baab1990fc04ee521baa700c0c1fabc4abb8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '393cfdafed822aa828b33d7410c9ba45fcd5777204e27f6e81d6f0e1478d300d'
+          checkpoint: '7fe4b5ef74003d67430377696ffad6f7d99310cf86f17be9d4b10276b729f367'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: