### PR TITLE
Update android-studio-canary to 3.0.0.16,171.4392136

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,12 +1,12 @@
 cask 'android-studio-canary' do
-  version '3.0.0.15,171.4365657'
-  sha256 'a1845cac07e4b53eff9c1dc51fc202bf3ee4dacc7aba2238280c2bdd784c0420'
+  version '3.0.0.16,171.4392136'
+  sha256 '5ffba5bec8b8795ccacfe6f7116822b2dbb865f3e536d711e60d1b3575d930f7'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'
   homepage 'https://sites.google.com/a/android.com/tools/download/studio/canary'
 
-  app "Android Studio #{version.major_minor} Preview.app"
+  app "Android Studio #{version.major_minor}.app"
 
   zap delete: [
                 "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: