### PR TITLE
Update sublime-text-dev to 3150

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3149'
-  sha256 '839f032d7c5a63bdec124a681306ef622a9720563fa01fef19e46b8533b5faed'
+  version '3150'
+  sha256 '5668be7f1ae78882d38ac60c95d499658516ea66e7d7436869508545f2cff400'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: '9230dfc358bdf67e81dc7228fcae26da851f5e3d54be41b3af89c74fb7053002'
+          checkpoint: '81e9d0519cd2f54ab47ea14fa7f009748633b7533ef4c0f26feb47e12a6837aa'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.