### PR TITLE
Update telegram-alpha to 3.5.2-107950,671

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5-107796,667'
-  sha256 '5e0c4e7a47de22e2ce85410a0769373bfce188c985f7ef17ed3cd4e8ab57685e'
+  version '3.5.2-107950,671'
+  sha256 '867dd51fe8b424cd830ca31c3378e817baf9f77cae2490899a9a92d11866d7af'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'e4f2b259dd3ca75027ff28dfdf76e2b8efa3d835be1e97dc1b77114b2fb3bcaf'
+          checkpoint: '3e87ff9665ef9de1a9410b96fe376c8792470171dcab4e6558059fbd8a63b8da'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: