### PR TITLE
Update telegram-alpha to 3.5.2-107952,672

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5-107796,667'
-  sha256 '5e0c4e7a47de22e2ce85410a0769373bfce188c985f7ef17ed3cd4e8ab57685e'
+  version '3.5.2-107952,672'
+  sha256 '2f2833f28c9dc4991684a4615f0b5e85615ba5a9f66aded653447ac56d4c8490'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'e4f2b259dd3ca75027ff28dfdf76e2b8efa3d835be1e97dc1b77114b2fb3bcaf'
+          checkpoint: '6c06d6adb7056dc993cde42a9827ec0cc8c606541ad90fa9b02fb7652dffd92e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.