### PR TITLE
Update forklift-beta to 3.0.8b

### DIFF
--- a/Casks/forklift-beta.rb
+++ b/Casks/forklift-beta.rb
@@ -1,17 +1,33 @@
 cask 'forklift-beta' do
-  version '3.b10'
-  sha256 '159b4c84221a5d5cfa45f192fb29ddbf44aee98fa1fe9c9e59d05b413726c2bf'
+  version '3.0.8b'
+  sha256 '0198d1831d1304515d254d87d44e645bfbdc025f1798f14b5016a2b5c7766349'
 
-  url "http://download.binarynights.com/ForkLift#{version.no_dots}.zip"
+  url "http://download.binarynights.com/ForkLift#{version}.zip"
   name 'ForkLift'
   homepage 'https://www.binarynights.com/forklift/'
 
   app 'ForkLift.app'
 
+  uninstall delete:    '/Library/PrivilegedHelperTools/com.binarynights.ForkLiftHelper',
+            launchctl: [
+                         'com.binarynights.ForkLiftHelper',
+                         'com.binarynights.ForkLiftMini',
+                       ],
+            quit:      [
+                         "com.binarynights.ForkLift-#{version.major}",
+                         'com.binarynights.ForkLiftMini',
+                       ]
+
   zap delete: [
-                "~/Library/Preferences/com.binarynights.ForkLift-#{version.major}.plist",
-                '~/Library/Application Support/ForkLift',
-                "~/Library/Saved Application State/com.binarynights.ForkLift-#{version.major}.savedState",
                 "~/Library/Caches/com.binarynights.ForkLift-#{version.major}",
+                "~/Library/Cookies/com.binarynights.ForkLift-#{version.major}.binarycookies",
+                '~/Library/Logs/ForkLift',
+                '~/Library/Logs/ForkLiftMini',
+                "~/Library/Saved Application State/com.binarynights.ForkLift-#{version.major}.savedState",
+              ],
+      trash:  [
+                '~/Library/Application Support/ForkLift',
+                "~/Library/Preferences/com.binarynights.ForkLift-#{version.major}.plist",
+                '~/Library/Preferences/com.binarynights.ForkLiftMini.plist',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.