### PR TITLE
Update telegram-alpha to 3.5.2-107970,675

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.2-107952,672'
-  sha256 '2f2833f28c9dc4991684a4615f0b5e85615ba5a9f66aded653447ac56d4c8490'
+  version '3.5.2-107970,675'
+  sha256 '953702af36f61a92ec4d8fca3ecb94e69f67d28172ce090970a4b22b48c585a6'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6c06d6adb7056dc993cde42a9827ec0cc8c606541ad90fa9b02fb7652dffd92e'
+          checkpoint: '8a5a01d445820128bd0d68f7f1ac76bf1f9a7882c6d129ff2bcfae65957690b2'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: