### PR TITLE
Update android-studio-canary to 3.0.0.17,171.4402976

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -4,9 +4,11 @@ cask 'android-studio-canary' do
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'
-  homepage 'https://sites.google.com/a/android.com/tools/download/studio/canary'
+  homepage 'https://developer.android.com/studio/preview/'
 
-  app "Android Studio #{version.major_minor}.app"
+  conflicts_with cask: 'android-studio'
+
+  app 'Android Studio.app'
 
   zap delete: [
                 "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",

--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-canary' do
-  version '3.0.0.16,171.4392136'
-  sha256 '5ffba5bec8b8795ccacfe6f7116822b2dbb865f3e536d711e60d1b3575d930f7'
+  version '3.0.0.17,171.4402976'
+  sha256 'b96a13a25562c44a3b213c25afa0c64eab888e653f71b16b1edf940efecabfdf'
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'

--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -2,6 +2,7 @@ cask 'android-studio-canary' do
   version '3.0.0.17,171.4402976'
   sha256 'b96a13a25562c44a3b213c25afa0c64eab888e653f71b16b1edf940efecabfdf'
 
+  # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name 'Android Studio Canary'
   homepage 'https://developer.android.com/studio/preview/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.