### PR TITLE
Update torbrowser-alpha to 7.5a6

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,12 +1,11 @@
 cask 'torbrowser-alpha' do
-  version '7.5a5'
-  sha256 'd6dd4420a6b3c9700c300aa1fb19604b22633d571bfd3506ff160afe8bfd6714'
+  version '7.5a6'
+  sha256 '8c5efca1fef27fa74f2feea0f1208244876cd9d55ed941ed348364a0b514ef0e'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
-  gpg "#{url}.asc",
-      key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
+  gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
 
   app 'TorBrowser.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.