### PR TITLE
Update rhinoceroswip to 5E236w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E199w'
-  sha256 'f4a3d99e7cd8271655cca78909f1a7b20b532f4897fb30e9c939fbf580f5019c'
+  version '5E236w'
+  sha256 'e54af789067e22d0fb1a982f667754571339af0275a2e5f2d261d92229c85cad'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: 'f1d2afa7a8b7de17bf782aabef1285613ec628b719885d21286a43595cc9721c'
+          checkpoint: '4bc74c44c725f2f2b187c621ba4d09b41c1dec2d5ccf889bb4ec93433250c591'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: