### PR TITLE
Update toggldesktop-beta to 7.4.71

### DIFF
--- a/Casks/toggldesktop-beta.rb
+++ b/Casks/toggldesktop-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggldesktop-beta' do
-  version '7.4.68'
-  sha256 '02ca17e1d4655a9076173eab8b04b64d768c8cc9ed5fa9e771ee1eea044b3f92'
+  version '7.4.71'
+  sha256 'bfab01fe4f09017828d0c69bd3e4f11efc96abb417e1a1a766b92a218452f44a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: '99a687ee8d259cdde8bc259b84bffcc85e3599a7a377cd0e319a3131ef8b5159'
+          checkpoint: '98fd3640c1c821617f63d30998fe6929913c033dfe734119820bffbeae7a22d8'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: