### PR TITLE
Update electron-beta to 1.8.2-beta.1

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.8.1'
-  sha256 '399e10b31b47ae1dc382148df6dc420764eef63f724a3a25cd6c72ba705c1f64'
+  version '1.8.2-beta.1'
+  sha256 '05087eb5b6c364b582bbef78ab67f4c3eb399c23a37588ce20a9daad19358a53'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '0c040fe8196d988aeea8c3480da1aab3b62c57c3eee29fbf7a637f3cfa206479'
+          checkpoint: 'b19de57a1ee83b1757dcd701312df54e8670dda43185361da5b57b1f18c69c0f'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: