### PR TITLE
Update adobe-photoshop-cs6: preflight

### DIFF
--- a/Casks/adobe-photoshop-cs6.rb
+++ b/Casks/adobe-photoshop-cs6.rb
@@ -14,6 +14,7 @@ cask 'adobe-photoshop-cs6' do
   installer script: {
                       executable: "#{staged_path}/#{name.join}/Install.app/Contents/MacOS/Install",
                       args:       ['--mode=silent', "--deploymentFile=#{staged_path}/#{name.join}/Deployment/en_US_Deployment.xml"],
+                      sudo:       true,
                     }
 
   preflight do
@@ -36,6 +37,7 @@ cask 'adobe-photoshop-cs6' do
             script: {
                       executable: "#{name.join}/Install.app/Contents/MacOS/Install",
                       args:       ['--mode=silent', "--deploymentFile=#{staged_path}/#{name.join}/Deployment/en_US_Uninstall.xml"],
+                      sudo:       true,
                     }
 
   caveats 'Installation or Uninstallation may fail with Exit Code 19 (Conflicting Processes running) if Browsers, Safari Notification Service or SIMBL Services (e.g. Flashlight) are running or Adobe Creative Cloud or any other Adobe Products are already installed. See Logs in /Library/Logs/Adobe/Installers if Installation or Uninstallation fails, to identifify the conflicting processes.'

--- a/Casks/adobe-photoshop-cs6.rb
+++ b/Casks/adobe-photoshop-cs6.rb
@@ -17,8 +17,11 @@ cask 'adobe-photoshop-cs6' do
                     }
 
   preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
   end
 
   uninstall_preflight do


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-versions/issues/4641

Check `SafariNotificationAgent` and run with `sudo`