### PR TITLE
Update 4 adobe cs6 Casks: preflight / uninstall_preflight

### DIFF
--- a/Casks/adobe-cs6-design-standard.rb
+++ b/Casks/adobe-cs6-design-standard.rb
@@ -19,6 +19,12 @@ cask 'adobe-cs6-design-standard' do
   # and https://github.com/caskroom/homebrew-versions/pull/296
 
   preflight do
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     language = case MacOS.language
                when %r{^de} then 'de_DE'
                when 'en-GB' then 'en_GB'
@@ -31,8 +37,6 @@ cask 'adobe-cs6-design-standard' do
                  'en_US'
                end
 
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
     system_command "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design Standard/deploy/install-#{language}.xml"
@@ -43,8 +47,12 @@ cask 'adobe-cs6-design-standard' do
   end
 
   uninstall_preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Adobe CS6 Design Standard/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/uninstall.xml"

--- a/Casks/adobe-cs6-design-web-premium.rb
+++ b/Casks/adobe-cs6-design-web-premium.rb
@@ -19,6 +19,12 @@ cask 'adobe-cs6-design-web-premium' do
   # and https://github.com/caskroom/homebrew-versions/pull/296
 
   preflight do
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     language = case MacOS.language
                when %r{^de} then 'de_DE'
                when 'en-GB' then 'en_GB'
@@ -31,8 +37,6 @@ cask 'adobe-cs6-design-web-premium' do
                  'en_US'
                end
 
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
     system_command "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Design and Web Premium/deploy/install-#{language}.xml"
@@ -43,8 +47,12 @@ cask 'adobe-cs6-design-web-premium' do
   end
 
   uninstall_preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Adobe CS6 Design and Web Premium/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/uninstall.xml"

--- a/Casks/adobe-cs6-master-collection.rb
+++ b/Casks/adobe-cs6-master-collection.rb
@@ -19,6 +19,12 @@ cask 'adobe-cs6-master-collection' do
   # and https://github.com/caskroom/homebrew-versions/pull/296
 
   preflight do
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     language = case MacOS.language
                when %r{^de} then 'de_DE'
                when 'en-GB' then 'en_GB'
@@ -31,8 +37,6 @@ cask 'adobe-cs6-master-collection' do
                  'en_US'
                end
 
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
     system_command "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/install-#{language}.xml"
@@ -43,8 +47,12 @@ cask 'adobe-cs6-master-collection' do
   end
 
   uninstall_preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Adobe CS6 Master Collection/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Master Collection/deploy/uninstall-en_US.xml"

--- a/Casks/adobe-cs6-production-premium.rb
+++ b/Casks/adobe-cs6-production-premium.rb
@@ -19,6 +19,12 @@ cask 'adobe-cs6-production-premium' do
   # and https://github.com/caskroom/homebrew-versions/pull/296
 
   preflight do
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     language = case MacOS.language
                when %r{^de} then 'de_DE'
                when 'en-GB' then 'en_GB'
@@ -31,8 +37,6 @@ cask 'adobe-cs6-production-premium' do
                  'en_US'
                end
 
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
     system_command "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/Adobe CS6 Production Premium/deploy/install-#{language}.xml"
@@ -43,8 +47,12 @@ cask 'adobe-cs6-production-premium' do
   end
 
   uninstall_preflight do
-    system_command '/usr/bin/killall',
-                   args: ['-kill', 'SafariNotificationAgent']
+    processes = system_command '/bin/launchctl', args: ['list']
+
+    if processes.stdout.lines.any? { |line| line =~ %r{^\d+\t\d\tcom.apple.SafariNotificationAgent$} }
+      system_command '/usr/bin/killall', args: ['-kill', 'SafariNotificationAgent']
+    end
+
     system_command "#{staged_path}/Adobe CS6 Production Premium/Install.app/Contents/MacOS/Install",
                    args: [
                            '--mode=silent', "--deploymentFile=#{staged_path}/uninstall.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Check `SafariNotificationAgent`