### PR TITLE
Clementine latest

### DIFF
--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -7,13 +7,12 @@ cask 'clementine-latest' do
     last_modified_query = '?C=M;O=D'
     base_url = 'https://builds.clementine-player.org/mac/'
     file = open("#{base_url}#{last_modified_query}")
-             .read
-             .scan(%r{href="(clementine-[^"]+.dmg)"})
-             .flatten
-             .first
+           .read
+           .scan(%r{href="(clementine-[^"]+.dmg)"})
+           .flatten
+           .first
     "#{base_url}#{file}"
   end
-
   name 'Clementine'
   homepage 'https://www.clementine-player.org/'
 

--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -28,10 +28,6 @@ cask 'clementine-latest' do
     set_permissions "#{staged_path}/Clementine.app", '0755'
   end
 
-  postflight do
-    set_permissions "#{appdir}/Clementine.app", '0555'
-  end
-
   zap delete: [
                 '~/Library/Caches/org.clementine-player.Clementine',
                 '~/Library/Saved Application State/org.clementine-player.Clementine.savedState',

--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -1,8 +1,19 @@
 cask 'clementine-latest' do
-  version '1.3.1-388'
-  sha256 'd34a9ab5c71c3e84420d6ce7e2f7426455a125a3a9aa86b86806188b2ecc0eac'
+  version :latest
+  sha256 :no_check
 
-  url 'https://builds.clementine-player.org/mac/clementine-1.3.1-388-gf1b767f.dmg'
+  url do
+    require 'open-uri'
+    last_modified_query = '?C=M;O=D'
+    base_url = 'https://builds.clementine-player.org/mac/'
+    file = open("#{base_url}#{last_modified_query}")
+             .read
+             .scan(%r{href="(clementine-[^"]+.dmg)"})
+             .flatten
+             .first
+    "#{base_url}#{file}"
+  end
+
   name 'Clementine'
   homepage 'https://www.clementine-player.org/'
 

--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -6,7 +6,10 @@ cask 'clementine-latest' do
   name 'Clementine'
   homepage 'https://www.clementine-player.org/'
 
-  conflicts_with cask: 'caskroom/cask/clementine'
+  conflicts_with cask: [
+                         'clementine',
+                         'clementine-rc',
+                       ]
 
   app 'Clementine.app'
 
@@ -19,9 +22,11 @@ cask 'clementine-latest' do
   end
 
   zap delete: [
-                '~/Library/Application Support/Clementine',
                 '~/Library/Caches/org.clementine-player.Clementine',
-                '~/Library/Preferences/org.clementine-player.Clementine.plist',
                 '~/Library/Saved Application State/org.clementine-player.Clementine.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/Clementine',
+                '~/Library/Preferences/org.clementine-player.Clementine.plist',
               ]
 end

--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -1,0 +1,19 @@
+cask 'clementine-latest' do
+  version '1.3.1-388'
+  sha256 'd34a9ab5c71c3e84420d6ce7e2f7426455a125a3a9aa86b86806188b2ecc0eac'
+
+  url 'https://builds.clementine-player.org/mac/clementine-1.3.1-388-gf1b767f.dmg'
+  name 'Clementine'
+  homepage 'https://www.clementine-player.org/'
+
+  conflicts_with cask: 'caskroom/cask/clementine'
+
+  app 'Clementine.app'
+
+  zap delete: [
+                '~/Library/Application Support/Clementine',
+                '~/Library/Caches/org.clementine-player.Clementine',
+                '~/Library/Preferences/org.clementine-player.Clementine.plist',
+                '~/Library/Saved Application State/org.clementine-player.Clementine.savedState',
+              ]
+end

--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -10,6 +10,14 @@ cask 'clementine-latest' do
 
   app 'Clementine.app'
 
+  preflight do
+    set_permissions "#{staged_path}/Clementine.app", '0755'
+  end
+
+  postflight do
+    set_permissions "#{appdir}/Clementine.app", '0555'
+  end
+
   zap delete: [
                 '~/Library/Application Support/Clementine',
                 '~/Library/Caches/org.clementine-player.Clementine',


### PR DESCRIPTION
This version differs from clementine-rc as it is using the latest build within https://builds.clementine-player.org/

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
