### PR TITLE
Update airmail-beta to 3.5.3.458,320

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.3.3.456,319'
-  sha256 '69201dc0fc70a4fc45f5d0c78f2066357ab7d00e01941467ad7a1bbb24c37d1e'
+  version '3.5.3.458,320'
+  sha256 '41dbadae0d585e488ace4837914b8422cc3f5cd46e7d16507eb567d73768cb8e'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '2755bcee529afbad674241f8600d3d90889bbf3e0dfa223891631b448c47dd5d'
+          checkpoint: 'd96693a9e70419f36754c7dd42ac2f93debc9d96227f6c79092f17eeafd2ad90'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: