### PR TITLE
Update airmail-beta to 3.5.3.459,321

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.458,320'
-  sha256 '41dbadae0d585e488ace4837914b8422cc3f5cd46e7d16507eb567d73768cb8e'
+  version '3.5.3.459,321'
+  sha256 '4c7013761e99e2d7a436798bb69c9069ceda100ccda05301ae5930a71b44e18d'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'd96693a9e70419f36754c7dd42ac2f93debc9d96227f6c79092f17eeafd2ad90'
+          checkpoint: 'ab55c0e1a2e014a1cd4bd1db888c30a7688671e1287dcbb09cbd0fffc1405d13'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.