### PR TITLE
Update slicer-nightly to 4.9.0.26504,702030

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.7.0.26481,699048'
-  sha256 '6bd5ed2a55fc63f05b661e0a1711e601e19938de0a7164eeeb143a4a55fd5cf8'
+  version '4.9.0.26504,702030'
+  sha256 'd2867bec0bbebe7683f7ffdf63329393b85b2a7e1110c8c2b062e13176137fe8'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating the `sha256` only**:

- [ ] I verified this change is legitimate [<sup>how do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: