### PR TITLE
Rename android-studio-canary to android-studio-preview

### DIFF
--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -7,9 +7,7 @@ cask 'android-studio-canary' do
   name 'Android Studio Canary'
   homepage 'https://developer.android.com/studio/preview/'
 
-  conflicts_with cask: 'android-studio'
-
-  app 'Android Studio.app'
+  app 'Android Studio.app', target: 'Android Studio Preview.app'
 
   zap delete: [
                 "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",

--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,12 +1,13 @@
-cask 'android-studio-canary' do
+cask 'android-studio-preview' do
   version '3.0.0.17,171.4402976'
   sha256 'b96a13a25562c44a3b213c25afa0c64eab888e653f71b16b1edf940efecabfdf'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
-  name 'Android Studio Canary'
+  name 'Android Studio Preview'
   homepage 'https://developer.android.com/studio/preview/'
 
+  # Renamed to avoid conflict with android-studio.
   app 'Android Studio.app', target: 'Android Studio Preview.app'
 
   zap delete: [


### PR DESCRIPTION
> https://developer.android.com/studio/preview/index.html
> The Android Studio Preview can run side-by-side with your stable version, so you can work on the same projects in both versions.

Upstream seems to call this "Preview". canary, beta, rc are just different releases.

> https://developer.android.com/studio/preview/install-preview.html
> If you download version 2.3 or lower, the application name does not include the version number, so you must first rename it before moving the new version into your apps directory. Otherwise, you might override your existing version of Android Studio.

Supersedes https://github.com/caskroom/homebrew-versions/pull/4656