### PR TITLE
Update telegram-alpha to 3.5.2-108222,677

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.2-108192,676'
-  sha256 '8393e863179e5a96bc86ff35650f9470800b1a277551a39be1f64be8bc8c36a4'
+  version '3.5.2-108222,677'
+  sha256 '5eea5ec29e8d45ff558a7e6e4056ea72439664940f055e7fbcf95f539816318c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '13e0bd324f659b3ddd44d660fb870ec093def1a203f556921108546da76ad626'
+          checkpoint: 'a3bca6f907218b8bce1a13ddabc1f7a35375f8016e09215bb25719afd4e56149'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.