### PR TITLE
Update skype-preview to latest

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,8 +1,9 @@
 cask 'skype-preview' do
-  version :latest
-  sha256 :no_check
+  version '8.9.76.64297'
+  sha256 'db0fde68ea1a8c3b45783135d4b5deece8928bcce6ce2adbafc8755cf149ef41'
 
-  url 'https://go.skype.com/mac.preview.download'
+  # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
+  url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
   name 'Skype Preview'
   homepage 'https://www.skype.com/en/insider/'
 

--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,12 +1,12 @@
 cask 'skype-preview' do
-  version '8.9.76.62644'
-  sha256 '4bc10dd391f093b76585669389d953e70fff65c15e1b999591f6779e0e627cf1'
+  version :latest
+  sha256 :no_check
 
-  # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
-  url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"
+  url 'https://go.skype.com/mac.preview.download'
   name 'Skype Preview'
   homepage 'https://www.skype.com/en/insider/'
 
+  auto_updates true
   conflicts_with cask: 'skype'
 
   app 'Skype.app'


### PR DESCRIPTION
It's self-updating more often I can possibly keep up, so let's leave it to it.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.