### PR TITLE
Update github-beta to 1.0.5-beta1-fd971fb7

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,11 +1,11 @@
 cask 'github-beta' do
-  version '1.0.5-beta0-93cfe3bf'
-  sha256 '23ab2df5749bf882180e053444abbca48c17b3d7f63aca0096f7f2ae488ef7fa'
+  version '1.0.5-beta1-fd971fb7'
+  sha256 '98968c3af7ffbbd4caf32c9bc3ba5421568984e310ee77b0121a9571edce9fb6'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '552ef7130866a5149974e9232452dd34f9b483b40195a01b080073c52f1cfc71'
+          checkpoint: '03e38f6eba88d3a75d498cf9050f71885d2568457d08db320369b777e2d1e5a1'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.