### PR TITLE
update: the official apple  java6

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -2,7 +2,7 @@ cask 'java6' do
   version '1.6.0_65'
   sha256 '8f40dbf821e21410feab4d9e2e533c42518897b7cac5edfad895e91016f918fc'
 
-  url 'https://support.apple.com/downloads/DL1572/en_US/javaforosx.dmg'
+  url 'http://supportdownload.apple.com/download.info.apple.com/Apple_Support_Area/Apple_Software_Updates/Mac_OS_X/downloads/031-29055.20150831-0f779fb2-4bf4-11e5-a8d8-/javaforosx.dmg'
   name 'Java Standard Edition Development Kit'
   homepage 'https://support.apple.com/kb/DL1572'
 

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -1,8 +1,8 @@
 cask 'java6' do
-  version '1.6.0_65'
-  sha256 '8f40dbf821e21410feab4d9e2e533c42518897b7cac5edfad895e91016f918fc'
+  version '1.6.0_65-b14-468'
+  sha256 'a6ea47965542b5c06787f832f3ae5be65da6c6ed91664b0c0ed4994650d98244'
 
-  url 'http://supportdownload.apple.com/download.info.apple.com/Apple_Support_Area/Apple_Software_Updates/Mac_OS_X/downloads/031-29055.20150831-0f779fb2-4bf4-11e5-a8d8-/javaforosx.dmg'
+  url 'https://support.apple.com/downloads/DL1572/en_US/javaforosx.dmg'
   name 'Java Standard Edition Development Kit'
   homepage 'https://support.apple.com/kb/DL1572'
 


### PR DESCRIPTION
correct java6 download url for matching its sha256

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] The commit message includes the cask’s name and version.