### PR TITLE
Update visual-studio-code-insiders to 1.18.0,e6a76e4bd3f52ab07452bb181e861f5a9bfb6596

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.18.0,3495b0b185acbe8188e821ccb3ae807274703a9c'
-  sha256 '9168ed1029eda73378764a60136cfabec51794447bdcf8cce01a7157a2b6b822'
+  version '1.18.0,e6a76e4bd3f52ab07452bb181e861f5a9bfb6596'
+  sha256 '804e4aebb4fb8cd8212ac717162de8303cb89fe60d2ea281ab423ebdff6a2b30'
 
   # az764295.vo.msecnd.net was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.