### PR TITLE
Update toggl-dev to 7.4.73

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.71'
-  sha256 'bfab01fe4f09017828d0c69bd3e4f11efc96abb417e1a1a766b92a218452f44a'
+  version '7.4.73'
+  sha256 '2c99c2913f3b262f98ddfbb34efa0ccbc898248e40af79164b27d0a8a2bacc7b'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '9cf3edf97ff8c09f9eefe03d6b2de8c148701f5c37a6b51c22d329c9153b191c'
+          checkpoint: 'e620a7a0bc666e85abd3bf27d090fd4f848c1b7ec2c0a796b677e0608d7c4f0f'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: