### PR TITLE
Update android-studio-preview to 3.1.0.0,171.4415322

### DIFF
--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '3.0.0.18,171.4408382'
-  sha256 'f75c99356259c42e00b05af1627bc06c74819850b02b95e7ff4c28e9b397120f'
+  version '3.1.0.0,171.4415322'
+  sha256 'a1945308fd7b01ab3360a6d1b7570cf1e48cb5788f09783b9851d1d54246558d'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
@@ -8,7 +8,7 @@ cask 'android-studio-preview' do
   homepage 'https://developer.android.com/studio/preview/'
 
   # Renamed to avoid conflict with android-studio.
-  app 'Android Studio.app', target: 'Android Studio Preview.app'
+  app "Android Studio #{version.major_minor} Preview.app", target: 'Android Studio Preview.app'
 
   zap delete: [
                 "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",

--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -7,8 +7,7 @@ cask 'android-studio-preview' do
   name 'Android Studio Preview'
   homepage 'https://developer.android.com/studio/preview/'
 
-  # Renamed to avoid conflict with android-studio.
-  app "Android Studio #{version.major_minor} Preview.app", target: 'Android Studio Preview.app'
+  app "Android Studio #{version.major_minor} Preview.app"
 
   zap delete: [
                 "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.