### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.37.808,136

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.35.798,134'
-  sha256 '223378a1f926d22e1ea941dfd9af1398b4bcd91ef6ce26bd2901f30fe0a11587'
+  version '8.2.37.808,136'
+  sha256 '3fef70692b75b48b02ebc82184d70ab54c2e7b0c149959d4b7dacfaef12310a8'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '076feac1ac363712014a5cdd1904bce60906fe9a74baf06cbcd8706b8e22d8d7'
+          checkpoint: '07a1e92e2d22706ec5decf53451d01f469eef74002726a658c576669e776aa9d'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.