### PR TITLE
Update anaconda2 to 5.0.1

### DIFF
--- a/Casks/anaconda2.rb
+++ b/Casks/anaconda2.rb
@@ -1,6 +1,6 @@
 cask 'anaconda2' do
-  version '5.0.0'
-  sha256 'd85198c63657924fae11b6ea5961f50d81d09a1185d6f0a9a9d5bc69eb788ccc'
+  version '5.0.1'
+  sha256 'e3a9a5c84cb89ff079b0781ba773a3433d490fe0cfc24042c613a5674748d87b'
 
   # repo.continuum.io/archive was verified as official when first introduced to the cask
   url "https://repo.continuum.io/archive/Anaconda2-#{version}-MacOSX-x86_64.sh"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.