### PR TITLE
Added Acorn 4.5.8 acorn4.rb

### DIFF
--- a/Casks/acorn4.rb
+++ b/Casks/acorn4.rb
@@ -1,0 +1,14 @@
+cask 'acorn4' do
+  version '4.5.8'
+  sha256 '102ec9b772cda43558044c7108684e8136e9acb184f856515de5548584567e90'
+
+  url 'http://flyingmeat.com/download/Acorn-4.5.8.zip'
+  appcast "http://www.flyingmeat.com/download/acorn#{version.major}update.xml",
+          checkpoint: 'c76c5507d33e8ef93b3910e91b2cfc513cf35bb6cd59daacf55462deaa40d400'
+  name 'Acorn'
+  homepage 'https://flyingmeat.com/acorn/docs/faq.html'
+
+  auto_updates true
+
+  app 'Acorn.app'
+end


### PR DESCRIPTION

Acorn 4 perfectly fine and works on modern macOS versions. For some people there is no reason to upgrade

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256