### PR TITLE
Added Acorn 5.6.6 acorn5.rb

### DIFF
--- a/Casks/acorn5.rb
+++ b/Casks/acorn5.rb
@@ -1,0 +1,14 @@
+cask 'acorn5' do
+  version '5.6.6'
+  sha256 '2fda93b116ae910643e1383bf425cf30fa8c09e01edffc41730ee19594cff561'
+
+  url 'http://flyingmeat.com/download/Acorn-5.6.6.zip'
+  appcast "http://www.flyingmeat.com/download/acorn#{version.major}update.xml",
+          checkpoint: '740a11ba7dd12a8d5f34d558f47913f25d50a9fb81c0496a6e7d03a940de15fb'
+  name 'Acorn'
+  homepage 'https://flyingmeat.com/acorn/docs/faq.html'
+
+  auto_updates true
+
+  app 'Acorn.app'
+end


### PR DESCRIPTION
Acorn 5 perfectly fine and works on modern macOS versions. For some people there is no reason to upgrade

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256