### PR TITLE
Update sketch-beta to 48,47110

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48,47092'
-  sha256 '636c99427c828bd25d3210376ca99aca675d312dd3af06bdad208e85a162a0d1'
+  version '48,47110'
+  sha256 'b241d6a79dd9ef77516b74e3e3efb6e77e6d8ef98f32f195628e0a39f90421ab'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '5001c56d23daa46c33c3e45732145c8de02c8292b02d71cfcc74fc65c97f9370'
+          checkpoint: 'e4d650dfd2599b27cde72385d162eefde26c81d372934cf10c3939d01c57cd8f'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.