### PR TITLE
Update libreoffice-dev to 5.4.3.1

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-dev' do
-  version '5.4.0.1'
-  sha256 '385a258b3def7f07a2af5e00430c3c7ae541f4002b8d18e0ba6d9726e588f825'
+  version '5.4.3.1'
+  sha256 'ddaff6f19fee80b862aaf91768ac12e299979ab193c824b9960f9cfb04faf53a'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: '7f72974717d71ce2084df044f33905a2b1000d68c6cd230878bfeee262dca5ca'
+          checkpoint: '60614fd56691d11f76bec0857e3051b862df7b5f64ac61a304feb12b9dd8dfda'
   name 'LibreOffice Fresh Prerelease'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
@@ -13,4 +13,33 @@ cask 'libreoffice-dev' do
   depends_on macos: '>= :mountain_lion'
 
   app 'LibreOffice.app'
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/regmerge"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/regview"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/senddoc"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/ui-previewer"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/uno"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/unopkg"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/urelibs"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
+  binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/soffice.wrapper.sh"
+  binary shimscript, target: 'soffice'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      '#{appdir}/LibreOffice.app/Contents/MacOS/soffice' "$@"
+    EOS
+  end
+
+  zap delete: [
+                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl',
+                '~/Library/Saved Application State/org.libreoffice.script.savedState',
+              ],
+      trash:  [
+                '~/Library/Application Support/LibreOffice',
+                '~/Library/Preferences/org.libreoffice.script.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.