### PR TITLE
Update java6 to 1.6.0_65-b14-468

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -8,5 +8,9 @@ cask 'java6' do
 
   pkg 'JavaForOSX.pkg'
 
-  uninstall pkgutil: 'com.apple.pkg.JavaForMacOSX107'
+  uninstall pkgutil: [
+                       'com.apple.pkg.JavaForMacOSX107',
+                       'com.apple.pkg.JavaMDNS',
+                       'com.apple.pkg.JavaEssentials',
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.