### PR TITLE
Update airmail-beta to 3.5.3.460,322

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.459,321'
-  sha256 '4c7013761e99e2d7a436798bb69c9069ceda100ccda05301ae5930a71b44e18d'
+  version '3.5.3.460,322'
+  sha256 '4cee9a709ecac635d20704fef17b4c51df411ece9535d7357be6b9b71e047862'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'ab55c0e1a2e014a1cd4bd1db888c30a7688671e1287dcbb09cbd0fffc1405d13'
+          checkpoint: 'a98ce6665526595e935236bd3c405d08225ab078ffa1d8e945ee9ddb3792d6f7'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.