### PR TITLE
Update slicer-nightly to 4.9.0.26551,709294

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.26504,702030'
-  sha256 'd2867bec0bbebe7683f7ffdf63329393b85b2a7e1110c8c2b062e13176137fe8'
+  version '4.9.0.26551,709294'
+  sha256 '8cd9ba7374796455ef4badc854246a89e0fc8c2d4e8b5c83ecc5a361955d6c7f'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.