### PR TITLE
Update toggl-dev to 7.4.79

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.76'
-  sha256 '54355cdcb041f8574e8f4698a762130506c400106eeedc864573f7b3424c41a7'
+  version '7.4.79'
+  sha256 '3bd36690042561b360d61ad325b13c56fb8dcaed58ad30e112bfd8e2a593d1cb'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'c79779f0e79b8a023db4495a029dfe099daa4c6eea64d16a765d4f41f16886e3'
+          checkpoint: 'ce2e1866b316b4f6957fb95c6dd6c9a029134ad21649773bbb10ad16af5131fd'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 

--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
   version '7.4.79'
-  sha256 '3bd36690042561b360d61ad325b13c56fb8dcaed58ad30e112bfd8e2a593d1cb'
+  sha256 'ea4b12f914acb8377ad2d19da0b9d2660d1b4a315887155ae906cdc0206800fa'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'ce2e1866b316b4f6957fb95c6dd6c9a029134ad21649773bbb10ad16af5131fd'
+          checkpoint: 'fb4aafcc9805560e7ffb7ee8476497cdbdc87beb70c4fae414c4bc725358e7bd'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.