### PR TITLE
Update electron-beta to 1.8.2-beta.2

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.8.2-beta.1'
-  sha256 '05087eb5b6c364b582bbef78ab67f4c3eb399c23a37588ce20a9daad19358a53'
+  version '1.8.2-beta.2'
+  sha256 'f92e4691cf5a9c64127e334c689c4721fdcfc8eaeeaaf901566783ccd28f75f1'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'b19de57a1ee83b1757dcd701312df54e8670dda43185361da5b57b1f18c69c0f'
+          checkpoint: '6db5fed371e230b90ec45b8a92183f6c5f86bf8cf5cac88f431b9c3bf395937c'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.