### PR TITLE
Update atom-beta to 1.22.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -18,15 +18,15 @@ cask 'atom-beta' do
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
+                '~/Library/Application Support/ShipIt_stderr.log',
+                '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Caches/com.github.atom',
                 '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Saved Application State/com.github.atom.savedState',
               ],
       trash:  [
                 '~/.atom',
-                '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
-                '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Application Support/com.github.atom.ShipIt',
                 '~/Library/Preferences/com.github.atom.helper.plist',
                 '~/Library/Preferences/com.github.atom.plist',

--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -17,16 +17,18 @@ cask 'atom-beta' do
   binary "#{appdir}/Atom Beta.app/Contents/Resources/app/atom.sh", target: 'atom-beta'
 
   zap delete: [
-                '~/.atom',
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl',
+                '~/Library/Caches/com.github.atom',
+                '~/Library/Caches/com.github.atom.ShipIt',
+                '~/Library/Saved Application State/com.github.atom.savedState',
+              ],
+      trash:  [
+                '~/.atom',
                 '~/Library/Application Support/ShipIt_stderr.log',
                 '~/Library/Application Support/Atom',
                 '~/Library/Application Support/ShipIt_stdout.log',
                 '~/Library/Application Support/com.github.atom.ShipIt',
-                '~/Library/Caches/com.github.atom',
-                '~/Library/Caches/com.github.atom.ShipIt',
                 '~/Library/Preferences/com.github.atom.helper.plist',
                 '~/Library/Preferences/com.github.atom.plist',
-                '~/Library/Saved Application State/com.github.atom.savedState',
               ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.