### PR TITLE
Update torbrowser-alpha to 7.5a7

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -8,4 +8,11 @@ cask 'torbrowser-alpha' do
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
 
   app 'TorBrowser.app'
+
+  zap delete: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.tor browser.sfl',
+      trash:  [
+                '~/Library/Application Support/TorBrowser-Data',
+                '~/Library/Preferences/org.mozilla.tor browser.plist',
+                '~/Library/Preferences/org.torproject.torbrowser.plist',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.