### PR TITLE
Update opera-beta to 50.0.2762.4

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '49.0.2725.31'
-  sha256 '04a71b387c613f1dae5c091a1b8029e4c8236f3e50086344fe1f7a6b9a1fe715'
+  version '50.0.2762.4'
+  sha256 'cb0393fca8ce46f1d70c879451f2dd8cd2dfe14b6d6512fd269a21cfea6aaaf8'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.