### PR TITLE
Update xquartz-beta to 2.7.11

### DIFF
--- a/Casks/xquartz-beta.rb
+++ b/Casks/xquartz-beta.rb
@@ -34,7 +34,6 @@ cask 'xquartz-beta' do
                          '/opt/X11',
                          '/private/etc/manpaths.d/40-XQuartz',
                          '/private/etc/paths.d/40-XQuartz',
-                         '/Applications/Utilities/XQuartz.app',
                        ]
 
   zap delete: [

--- a/Casks/xquartz-beta.rb
+++ b/Casks/xquartz-beta.rb
@@ -31,18 +31,18 @@ cask 'xquartz-beta' do
                        ],
             pkgutil:   'org.macosforge.xquartz.pkg',
             delete:    [
-                         '/opt/X11/',
+                         '/opt/X11',
                          '/private/etc/manpaths.d/40-XQuartz',
                          '/private/etc/paths.d/40-XQuartz',
+                         '/Applications/Utilities/XQuartz.app',
                        ]
 
   zap delete: [
                 '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.macosforge.xquartz.x11.sfl',
                 '~/Library/Caches/org.macosforge.xquartz.X11',
                 '~/Library/Cookies/org.macosforge.xquartz.X11.binarycookies',
-                '~/Library/Logs/X11',
-                '~/Library/Logs/X11.org.macosforge.xquartz.log',
-                '~/Library/Logs/X11.org.macosforge.xquartz.log.old',
+                '~/Library/Logs/X11/org.macosforge.xquartz.log',
+                '~/Library/Logs/X11/org.macosforge.xquartz.log.old',
                 '~/Library/Saved Application State/org.macosforge.xquartz.X11.savedState',
               ],
       trash:  [
@@ -50,5 +50,8 @@ cask 'xquartz-beta' do
                 '~/Library/Preferences/org.macosforge.xquartz.X11.plist',
                 '~/.Xauthority',
               ],
-      rmdir:  '~/.fonts'
+      rmdir:  [
+                '~/.fonts',
+                '~/Library/Logs/X11',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.