### PR TITLE
Update dropbox-beta to 39.3.48

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -10,6 +10,7 @@ cask 'dropbox-beta' do
   app 'Dropbox.app'
 
   uninstall login_item: 'Dropbox'
+            launchctl:  'com.dropbox.DropboxMacUpdate.agent.plist'
 
   zap delete: [
                 '/Library/DropboxHelperTools',
@@ -22,7 +23,6 @@ cask 'dropbox-beta' do
                 '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.dropbox.DropboxMacUpdate',
                 '~/Library/Containers/com.getdropbox.dropbox.garcon',
                 '~/Library/Group Containers/com.getdropbox.dropbox.garcon',
-                '~/Library/LaunchAgents/com.dropbox.DropboxMacUpdate.agent.plist',
                 '~/Library/Logs/Dropbox_debug.log',
               ],
       trash:  [

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -9,7 +9,7 @@ cask 'dropbox-beta' do
 
   app 'Dropbox.app'
 
-  uninstall login_item: 'Dropbox'
+  uninstall login_item: 'Dropbox',
             launchctl:  'com.dropbox.DropboxMacUpdate.agent.plist'
 
   zap delete: [

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -10,7 +10,7 @@ cask 'dropbox-beta' do
   app 'Dropbox.app'
 
   uninstall login_item: 'Dropbox',
-            launchctl:  'com.dropbox.DropboxMacUpdate.agent.plist'
+            launchctl:  'com.dropbox.DropboxMacUpdate.agent'
 
   zap delete: [
                 '/Library/DropboxHelperTools',

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -14,7 +14,6 @@ cask 'dropbox-beta' do
 
   zap delete: [
                 '/Library/DropboxHelperTools',
-                '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/SidebarDropBoxFolder.icns',
                 '~/Library/Application Scripts/com.getdropbox.dropbox.garcon',
                 '~/Library/Caches/CloudKit/com.apple.bird/iCloud.com.getdropbox.Dropbox',
                 '~/Library/Caches/com.dropbox.DropboxMacUpdate',

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '37.3.25'
-  sha256 'cd1bf14d2f01e1652ae55d9e6b68fa070ca182ece20710ab9a3fb3c99a3adecd'
+  version '39.3.48'
+  sha256 '02a8a0e00c0f94fa286900aee7fd39eedf5b4ad372f5c8f4cb5904fdcf8f3739'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"
@@ -13,13 +13,16 @@ cask 'dropbox-beta' do
 
   zap delete: [
                 '/Library/DropboxHelperTools',
+                '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/SidebarDropBoxFolder.icns',
                 '~/Library/Application Scripts/com.getdropbox.dropbox.garcon',
                 '~/Library/Caches/CloudKit/com.apple.bird/iCloud.com.getdropbox.Dropbox',
                 '~/Library/Caches/com.dropbox.DropboxMacUpdate',
                 '~/Library/Caches/com.getdropbox.dropbox',
                 '~/Library/Caches/com.getdropbox.DropboxMetaInstaller',
+                '~/Library/Caches/com.plausiblelabs.crashreporter.data/com.dropbox.DropboxMacUpdate',
                 '~/Library/Containers/com.getdropbox.dropbox.garcon',
                 '~/Library/Group Containers/com.getdropbox.dropbox.garcon',
+                '~/Library/LaunchAgents/com.dropbox.DropboxMacUpdate.agent.plist',
                 '~/Library/Logs/Dropbox_debug.log',
               ],
       trash:  [
@@ -27,6 +30,7 @@ cask 'dropbox-beta' do
                 '~/Library/Application Support/Dropbox',
                 '~/Library/Dropbox',
                 '~/Library/Preferences/com.dropbox.DropboxMacUpdate.plist',
+                '~/Library/Preferences/com.dropbox.DropboxMonitor.plist',
                 '~/Library/Preferences/com.dropbox.tungsten.helper.plist',
                 '~/Library/Preferences/com.getdropbox.dropbox.plist',
               ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.