### PR TITLE
Update tunnelblick-beta to 3.7.5beta02,4930

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,11 +1,11 @@
 cask 'tunnelblick-beta' do
-  version '3.7.5beta01,4910'
-  sha256 'a7a006228e780c520a14434ea387458798ecd6a1f17f8a334cc0459862991218'
+  version '3.7.5beta02,4930'
+  sha256 '353ff26a41e6d380891092e35d94d66b5c99e14ea6d6260219a72ee9339975ec'
 
   # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"
   appcast 'https://github.com/Tunnelblick/Tunnelblick/releases.atom',
-          checkpoint: '25fed445d9974e8a0450a826a991ee4b79268f0ef072f22ead6f5b50887469d0'
+          checkpoint: 'c9a34948008a7abf8f21434a36aa3b90e0b8e5735a3f2fe7cb94f08fab3e5470'
   name 'Tunnelblick'
   homepage 'https://www.tunnelblick.net/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.