### PR TITLE
Update vivaldi-snapshot to 1.13.1008.14

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.13.1008.11'
-  sha256 '1a0a98c73134fe93bf7268a26d958779863c122888d3343347dc8a44750d5cf0'
+  version '1.13.1008.14'
+  sha256 '73985038301a079e165f7f42dae79b2856befab3a8f7f834bf1836295cd0fcdc'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '9ecb8c575518e43a8124ec3bcfb40a15af0a3f62918c1decbbecef4217af6111'
+          checkpoint: '8a7a55e32efe774e4811749220e57ee7ce8afcf1472587b084cdad44dbbf461a'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.