### PR TITLE
Update omegat-dev to 4.1.2,02

### DIFF
--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,15 +1,15 @@
 cask 'omegat-dev' do
-  version '4.1.2'
-  sha256 '75fd2a04296a4e3d8571d294b897c9e923d50a61ee695a65daa530650cedb054'
+  version '4.1.2,02'
+  sha256 '8a3574d97de621da21b99749a8af67edee0ac414ecec357d7098f93423fd1238'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version.before_comma}%20update%2#{version.after_comma}/OmegaT_#{version.gsub(',', '_')}_Beta_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
-          checkpoint: 'c59a91a5dda1847d1b6bb9ee9fa5590082fa9fec11f5c5993131c0844a5abc15'
+          checkpoint: '4128fd774ac85dcb6ed7d433f72a0b6b2b1db9f8ba9198bb56630a562ffde0ce'
   name 'OmegaT Development'
   homepage 'https://omegat.org/'
 
-  app "OmegaT_#{version}_Beta_Mac_Signed/OmegaT.app"
+  app "OmegaT_#{version.gsub(',', '_')}_Beta_Mac_Signed/OmegaT.app"
 
   caveats do
     depends_on_java('8+')


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/40614