### PR TITLE
Update virtualbox-beta: remove uninstall_preflight

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -12,12 +12,6 @@ cask 'virtualbox-beta' do
 
   pkg 'VirtualBox.pkg'
 
-  uninstall_preflight do
-    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack-beta")
-      system_command 'brew', args: ['cask', 'uninstall', 'virtualbox-extension-pack-beta']
-    end
-  end
-
   uninstall script:  {
                        executable: 'VirtualBox_Uninstall.tool',
                        args:       ['--unattended'],


### PR DESCRIPTION
The `uninstall_preflight` will break the `upgrade` of the dependent Cask when https://github.com/Homebrew/brew/pull/3396 is merged.