### PR TITLE
Update virtualbox-extension-pack-beta: uninstall_postflight

### DIFF
--- a/Casks/virtualbox-extension-pack-beta.rb
+++ b/Casks/virtualbox-extension-pack-beta.rb
@@ -24,6 +24,7 @@ cask 'virtualbox-extension-pack-beta' do
   end
 
   uninstall_postflight do
+    next unless File.exist?('/usr/local/bin/VBoxManage')
     system_command '/usr/local/bin/VBoxManage',
                    args: [
                            'extpack', 'uninstall',


### PR DESCRIPTION
https://github.com/caskroom/homebrew-versions/pull/4748

This allows the uninstall step to be skipped if the dependant Cask has been uninstalled, which would have removed the files installed by this Cask.