### PR TITLE
Update slicer-nightly to 4.9.0.26630,712956

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.26559,711742'
-  sha256 'dafa327fdabb0d271d4371dfbe9d5a344aa717a0a773f76f41c6063f1af5ec3f'
+  version '4.9.0.26630,712956'
+  sha256 'd94810427c2acc82a95f2d3cae0218cd21b1af669e5ef62ce3b26f63fd5bd667'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "http://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.