### PR TITLE
Update vivaldi-snapshot to 1.13.1008.18

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.13.1008.14'
-  sha256 '73985038301a079e165f7f42dae79b2856befab3a8f7f834bf1836295cd0fcdc'
+  version '1.13.1008.18'
+  sha256 'fad75256b1b9e0a8021ab6e5b7bf3c3361d0ac416668b5343614889cf1fdc1b3'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '8a7a55e32efe774e4811749220e57ee7ce8afcf1472587b084cdad44dbbf461a'
+          checkpoint: '0a46f657269c4351a5a483418c1e7ab28a2129ae8507bae9630ce8d3d5ae6060'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.