### PR TITLE
Update rhinoceroswip to 5E292w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E236w'
-  sha256 'e54af789067e22d0fb1a982f667754571339af0275a2e5f2d261d92229c85cad'
+  version '5E292w'
+  sha256 'e78bc7249a0384767c53d90c03f606161bc077e2832508dd7303987fc2aadf02'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '4bc74c44c725f2f2b187c621ba4d09b41c1dec2d5ccf889bb4ec93433250c591'
+          checkpoint: '7115f6ed6773a66a0f922ba8ee396cb1da5e5fcf76531c6062800c27ee6ca2d7'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.