### PR TITLE
Update torbrowser-alpha.rb to 7.5a8

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -7,6 +7,8 @@ cask 'torbrowser-alpha' do
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'
 
+  conflicts_with cask: 'torbrowser'
+
   app 'TorBrowser.app'
 
   zap delete: '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.tor browser.sfl*',

--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'torbrowser-alpha' do
-  version '7.5a7'
-  sha256 '190b8490bcd53ece1ace759f1b1f7f7f1b5502ed84186e262a66177531a08188'
+  version '7.5a8'
+  sha256 'e45c7b6e10202e9e1f6f03e55c16bd70a6690568a47eab6470054a7a7c3b2a0f'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   name 'Tor Browser'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.