### PR TITLE
firefoxdeveloperedition.rb: update to 58.0b4

### DIFF
--- a/Casks/firefoxdeveloperedition.rb
+++ b/Casks/firefoxdeveloperedition.rb
@@ -1,50 +1,50 @@
 cask 'firefoxdeveloperedition' do
-  version '58.0b2'
+  version '58.0b4'
 
   language 'cs' do
-    sha256 'd4a9cc40416efaabe584b09c1b32e6b6c90f6fffa98c8b35d4fe6b574943ba4c'
+    sha256 '04355dfd72a325fc286cb42db64c6242eb2f1fdbc510d66995bbdd6303ab867e'
     'cs'
   end
 
   language 'de' do
-    sha256 'eee4e09c32c6a4eb9a83a8c6af15d369903df826b00799c872d6cac69110938b'
+    sha256 'bea959cbca077cf6281fb2961f399d49304ebaa48c42d6073b683addf32c5d33'
     'de'
   end
 
   language 'en', default: true do
-    sha256 '2ae2e94b9c8b1ee4a066b6d4bad6a695a1ab493044879d8c015f9aece21b5007'
+    sha256 '05f05d523ff7f8417d3e89782be45b515f6e892519e7a56844ed8638e86611d1'
     'en-US'
   end
 
   language 'ja' do
-    sha256 '6004b8ca8971c784b0a221bbe27bb4fe56ceee370c833af54d7db9c93c6dc32f'
+    sha256 '3b3dc7bbba08281c6c375afd6f04854a38ff6a23bb50d2023c76cdb7857be335'
     'ja-JP-mac'
   end
 
   language 'ru' do
-    sha256 '141b959e565df9ff2c6afbdcac09a417f92b20e474abf776c0b96f22fe762049'
+    sha256 'f00dbe87d2d9951f466aa92c12bcb83cb5784391bfd21c668da49e4b599ff6ca'
     'ru'
   end
 
   language 'uk' do
-    sha256 'dc0da526c9ddb95fd7a564dcce77349959de908dac10f1e832b0f53a6cb1f170'
+    sha256 'e8657345d04a9eb8c0e9179d67df83b91ce1d5cf06b78ec2f38586b4dec5cea5'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '9ea0de65de8363bfa2538b74207d49d2982f138e172ce37e241f67c90b56235a'
+    sha256 '1c8c1489169094cb8437ca1e9a6e3fbb06396df06b843908f58ec9cc84718142'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '597034b440f7715b4e173c6e1d4c6e9a3063f84462182c431e7b0b62933d4daf'
+    sha256 'ca6bca5c21736e5dd276b3415d57173ea8f1384256c2bc756abdb7936bcc609f'
     'zh-CN'
   end
 
   # download-installer.cdn.mozilla.net/pub/devedition/releases was verified as official when first introduced to the cask
   url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/',
-          checkpoint: '4843d5b6e9fe641161ee8e474bbeb1351b1d2c5561ca0f62078ab487b44a4f5a'
+          checkpoint: '7320780bf03b056ab149d6868cd3ef108a7eb2b0afe1a2ac365b61c05ec7a676'
   name 'Mozilla Firefox Developer Edition'
   homepage 'https://www.mozilla.org/firefox/developer/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
