### PR TITLE
Add mi beta 3.0.0b14

### DIFF
--- a/Casks/mi-beta.rb
+++ b/Casks/mi-beta.rb
@@ -1,0 +1,17 @@
+cask 'mi-beta' do
+  version '3.0.0b14'
+  sha256 '149c76f64963e72e569f7acf862690cf6ace8169eadd0261392d0462422161b4'
+
+  url "https://www.mimikaki.net/download/mi#{version}.dmg"
+  appcast 'https://www.mimikaki.net/download/appcast_beta.xml',
+          checkpoint: '8bdfa6654c195347c081f8e3ad37e53f9e8ede1818b902c00a6b5c1eedc03431'
+  name 'mi'
+  homepage 'https://www.mimikaki.net/download/beta.html'
+
+  depends_on macos: '>= 10.7'
+
+  app 'mi.app'
+
+  zap delete: '~/Library/Caches/net.mimikaki.mi',
+      trash:  '~/Library/Preferences/net.mimikaki.mi.plist'
+end

--- a/Casks/mi-beta.rb
+++ b/Casks/mi-beta.rb
@@ -8,7 +8,7 @@ cask 'mi-beta' do
   name 'mi'
   homepage 'https://www.mimikaki.net/download/beta.html'
 
-  depends_on macos: '>= 10.7'
+  depends_on macos: '>= :lion'
 
   app 'mi.app'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

---

This is the beta version of the text editor [_mi_](http://support.mimikaki.net/en/).
The stable version 2 is already [in the main repository](https://github.com/caskroom/homebrew-cask/blob/master/Casks/mi.rb).
The [web page about the beta version](https://www.mimikaki.net/download/beta.html) (which I used as the `homepage` stanza) is currently provided only in Japanese.

> Named the cask according to the [token reference].

The reference tells to remove "beta", but I rather followed the practice in this tap.

Thanks in advance.