### PR TITLE
Update opera-developer to 51.0.2776.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '50.0.2759.0'
-  sha256 '2ca9e577fb8d3de35c282911e8b5bfdd687b40bd7bd88e235b477b46d249a466'
+  version '51.0.2776.0'
+  sha256 'db1843a074bfb42528c514350d3ebd2ff7b1ca1a0c67a027d2594759c64ebbdc'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.