### PR TITLE
Update telegram-alpha to 3.5.3-109255,689

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-108464,681'
-  sha256 '043a28bb6561791b9c17b92487671ceff59fb07513612cf47401e71f055f8213'
+  version '3.5.3-109255,689'
+  sha256 'e58b571a9aa39e5a0b9b582fc153b8b30fe362c0fb9b96c652fc7591ded5cac2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f39e371a56c7e1ad383ff01d1ee48be0f64df1a1c00f832e5fa4a3e66ce8e66f'
+          checkpoint: '1f62ff6a873d4b7691083af92e09118b4a48ff8135d9eadf8753b8880c2fbba0'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.