### PR TITLE
Update telegram-alpha to 3.5.3-109294,693

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109255,689'
-  sha256 'e58b571a9aa39e5a0b9b582fc153b8b30fe362c0fb9b96c652fc7591ded5cac2'
+  version '3.5.3-109294,693'
+  sha256 '1f97a677df82757a4c7952f664174dd88f9387a5073fd852835d175a6a86ea1e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1f62ff6a873d4b7691083af92e09118b4a48ff8135d9eadf8753b8880c2fbba0'
+          checkpoint: '42d4bfc44f7f35ea7277204642ba295d4f9dfe47f65f5728b9c07c0fb32491d9'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.