### PR TITLE
Update vivaldi-snapshot to 1.13.1008.21

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.13.1008.18'
-  sha256 'fad75256b1b9e0a8021ab6e5b7bf3c3361d0ac416668b5343614889cf1fdc1b3'
+  version '1.13.1008.21'
+  sha256 '6eaba395f525413ff8434267e60c2d5ebf9b911677467275c52238183496f62f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '0a46f657269c4351a5a483418c1e7ab28a2129ae8507bae9630ce8d3d5ae6060'
+          checkpoint: 'ccf3f17841e04d411a14b8d1e174a6aaacb10115796deef25cb30d46b8f71f9b'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.