### PR TITLE
Update toggl-dev to 7.4.84

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.79'
-  sha256 'ea4b12f914acb8377ad2d19da0b9d2660d1b4a315887155ae906cdc0206800fa'
+  version '7.4.84'
+  sha256 '22ef7b89f9ce04a24621f25e4d1f025c6391ec690ec773b74a244e5f8b425466'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'fb4aafcc9805560e7ffb7ee8476497cdbdc87beb70c4fae414c4bc725358e7bd'
+          checkpoint: '02fbe1528eef4f4a740ac940a14ade47f4a4846378b22c264bd37212b21332c1'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.