### PR TITLE
Update atom-beta.rb: convert to zap trash

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -16,19 +16,17 @@ cask 'atom-beta' do
   binary "#{appdir}/Atom Beta.app/Contents/Resources/app/apm/node_modules/.bin/apm", target: 'apm-beta'
   binary "#{appdir}/Atom Beta.app/Contents/Resources/app/atom.sh", target: 'atom-beta'
 
-  zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl*',
-                '~/Library/Application Support/ShipIt_stderr.log',
-                '~/Library/Application Support/ShipIt_stdout.log',
-                '~/Library/Caches/com.github.atom',
-                '~/Library/Caches/com.github.atom.ShipIt',
-                '~/Library/Saved Application State/com.github.atom.savedState',
-              ],
-      trash:  [
-                '~/.atom',
-                '~/Library/Application Support/Atom',
-                '~/Library/Application Support/com.github.atom.ShipIt',
-                '~/Library/Preferences/com.github.atom.helper.plist',
-                '~/Library/Preferences/com.github.atom.plist',
-              ]
+  zap trash: [
+               '~/.atom',
+               '~/Library/Application Support/Atom',
+               '~/Library/Application Support/ShipIt_stderr.log',
+               '~/Library/Application Support/ShipIt_stdout.log',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl*',
+               '~/Library/Application Support/com.github.atom.ShipIt',
+               '~/Library/Caches/com.github.atom',
+               '~/Library/Caches/com.github.atom.ShipIt',
+               '~/Library/Preferences/com.github.atom.helper.plist',
+               '~/Library/Preferences/com.github.atom.plist',
+               '~/Library/Saved Application State/com.github.atom.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.