### PR TITLE
Update libreoffice-still.rb: convert to zap trash

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -36,12 +36,10 @@ cask 'libreoffice-still' do
     EOS
   end
 
-  zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl*',
-                '~/Library/Saved Application State/org.libreoffice.script.savedState',
-              ],
-      trash:  [
-                '~/Library/Application Support/LibreOffice',
-                '~/Library/Preferences/org.libreoffice.script.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/LibreOffice',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl*',
+               '~/Library/Preferences/org.libreoffice.script.plist',
+               '~/Library/Saved Application State/org.libreoffice.script.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.