### PR TITLE
Update transmission-nightly.rb: convert to zap trash

### DIFF
--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -15,17 +15,15 @@ cask 'transmission-nightly' do
 
   app 'Transmission.app'
 
-  zap delete: [
-                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.m0k.transmission.sfl*',
-                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/org.m0k.transmission.help',
-                '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/Transmission Help*',
-                '~/Library/Caches/org.m0k.transmission',
-                '~/Library/Cookies/org.m0k.transmission.binarycookies',
-                '~/Library/Preferences/org.m0k.transmission.LSSharedFileList.plist',
-                '~/Library/Saved Application State/org.m0k.transmission.savedState',
-              ],
-      trash:  [
-                '~/Library/Application Support/Transmission',
-                '~/Library/Preferences/org.m0k.transmission.plist',
-              ]
+  zap trash: [
+               '~/Library/Application Support/Transmission',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.m0k.transmission.sfl*',
+               '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/Transmission Help*',
+               '~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/org.m0k.transmission.help',
+               '~/Library/Caches/org.m0k.transmission',
+               '~/Library/Cookies/org.m0k.transmission.binarycookies',
+               '~/Library/Preferences/org.m0k.transmission.LSSharedFileList.plist',
+               '~/Library/Preferences/org.m0k.transmission.plist',
+               '~/Library/Saved Application State/org.m0k.transmission.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.