### PR TITLE
Update telegram-alpha to 3.5.3-109335,695

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109294,693'
-  sha256 '1f97a677df82757a4c7952f664174dd88f9387a5073fd852835d175a6a86ea1e'
+  version '3.5.3-109335,695'
+  sha256 '08a575aa0b6274d25ac987fe67904acaa06be084a69c82fce5ca99acabd2b560'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '42d4bfc44f7f35ea7277204642ba295d4f9dfe47f65f5728b9c07c0fb32491d9'
+          checkpoint: '2cfd1282f4014032c08fac718429202e272c0e40ae3c0fdcf9cc6924bb3a1d31'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.