### PR TITLE
Update airmail-beta to 3.5.3.462,323

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.460,322'
-  sha256 '4cee9a709ecac635d20704fef17b4c51df411ece9535d7357be6b9b71e047862'
+  version '3.5.3.462,323'
+  sha256 '973a9ab3e4f7a6bfe1d85904ee1268624991e26805b1dbe0724c0ff331b2ede9'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'a98ce6665526595e935236bd3c405d08225ab078ffa1d8e945ee9ddb3792d6f7'
+          checkpoint: 'f39bd8ebdd35c1e9cae2903eddd4297a19b7ce3f68de611fe0e63d42cf418d22'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.