### PR TITLE
Update telegram-alpha to 3.5.3-109376,697

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109370,696'
-  sha256 'd5b62e081fc5c3f3d1d8e90f4400208cdcb34b81785f02344c1719c1f8238f91'
+  version '3.5.3-109376,697'
+  sha256 '9f6c3cf0bf4d8cd2ace0dcfccaa5b9357d809d8bd6074e358a5d62c52fb63af1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '4880386ebdd19f241b3f585eef9b88d29ac60e242adb680f822dd831517054b2'
+          checkpoint: '2b537449f817ad42aaedd44cd9ab856e31e657ed569ee91bcd987db99c9bf4c6'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.