### PR TITLE
Update sketch-beta to 48,47218

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48,47142'
-  sha256 '8b3e24fe165e5dd3f008980df0074baae45ae43ce51198233d94a46168d729d5'
+  version '48,47218'
+  sha256 'ed10efb1aa724805e12aebb828d5672dc6cf8c7202cf1c1f5ca1428e042f582a'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'c2a4bac14efce3f17988dfb07c607ad61a80e80219eedcca41fc00c4488c1d2d'
+          checkpoint: 'b51cb114ee03c572efe2e41337a696306fb0c28264ea09b0bcdd9088c1356669'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.