### PR TITLE
Update github-beta to 1.0.10-beta1-a52dde78

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,11 +1,11 @@
 cask 'github-beta' do
-  version '1.0.10-beta0-5b1f6aec'
-  sha256 'a6be0951d4c62866a6d3ca259937315f9b2c46d862b055f55a7d3999f77f4fa2'
+  version '1.0.10-beta1-a52dde78'
+  sha256 'e5d5c104afa3aaaeb084b68a4a5f4816bd1f61b532898b593f1096361c8df2c1'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"
   appcast 'https://github.com/desktop/desktop/releases.atom',
-          checkpoint: '4324bb9dc78728d711b91872622bb2a178505f31acd4c8980edc67c5bf5aa901'
+          checkpoint: '8d15f6b22c3f6be50728dbccf414dfb170ec1d545cc378f26e456ed9c510e75a'
   name 'GitHub Desktop'
   homepage 'https://desktop.github.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.