### PR TITLE
Update telegram-alpha to 3.5.3-109403,698

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109376,697'
-  sha256 '9f6c3cf0bf4d8cd2ace0dcfccaa5b9357d809d8bd6074e358a5d62c52fb63af1'
+  version '3.5.3-109403,698'
+  sha256 '3983e47e77449af22fd0d0006290b6cc44bd3f651e1b2217d6afecd1e35b8be9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2b537449f817ad42aaedd44cd9ab856e31e657ed569ee91bcd987db99c9bf4c6'
+          checkpoint: '7becf38f9a570558a1c8646530eef154f69732c2b96661b3fd08d53d662b692a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.