### PR TITLE
Update telegram-alpha to 3.5.3-109433,699

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109403,698'
-  sha256 '3983e47e77449af22fd0d0006290b6cc44bd3f651e1b2217d6afecd1e35b8be9'
+  version '3.5.3-109433,699'
+  sha256 '2fa494ae639da9b1fe8ab56692cd46cdd1420e4f4faff5e8a7acf1170df5746d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7becf38f9a570558a1c8646530eef154f69732c2b96661b3fd08d53d662b692a'
+          checkpoint: '077df0569b4ba1963a0a91f41a0b3229d2cfbd895e34ac13ddefd1cc5fac7e2c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.