### PR TITLE
Update vivaldi-snapshot to 1.13.1008.30

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.13.1008.21'
-  sha256 '6eaba395f525413ff8434267e60c2d5ebf9b911677467275c52238183496f62f'
+  version '1.13.1008.30'
+  sha256 'd50d33dac33a75daed59cc2f1bb3004c56dd580f000601923ad67538abe84373'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'ccf3f17841e04d411a14b8d1e174a6aaacb10115796deef25cb30d46b8f71f9b'
+          checkpoint: '4b592e0fbb0b97dc3022c13d09149c79a664ee57f4cd84264849157f5fa888ac'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.