### PR TITLE
Update telegram-alpha to 3.5.3-109501,702

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109484,701'
-  sha256 '6a26040f25adbf87af1512152c57a4f36797c0e1cd1bc88bf92055d6e40ef118'
+  version '3.5.3-109501,702'
+  sha256 '3cd39da4d05ce90b185ebf1583575776a5d060d80bd373aa977c56eb27662c63'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bbdcf941dfb8f53f2a4c79d108a104519c36cd742efa438b373aaffefbefba5f'
+          checkpoint: 'cde399f4bd4eefa3c52ab6c403688d270370d36e1769f285c75a19dd18f33f23'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.