### PR TITLE
Update telegram-alpha to 3.5.3-109597,706

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109546,704'
-  sha256 'acbeef8da11d7e7d4a7c949d9f90e6e7c70386720c61222260af299ee0d65413'
+  version '3.5.3-109597,706'
+  sha256 '27fe67485abf84784ff9c16e1c1a514f667e772211822cc7ffd3d8da8e15f855'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '21843fbc711fcdec6ed06196c0d92f8c15b69d071bcd994281c9e5a1022a70c9'
+          checkpoint: '5bd4c1857c0791ff45775d859e9af2581edee15c467a886b283b1a54d525932f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.