### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.38.822,145

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.37.808,136'
-  sha256 '3fef70692b75b48b02ebc82184d70ab54c2e7b0c149959d4b7dacfaef12310a8'
+  version '8.2.38.822,145'
+  sha256 '10ec83eb067dc2075980148e14340c22b74f6c486ba38e59177ba125f0811ee7'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '07a1e92e2d22706ec5decf53451d01f469eef74002726a658c576669e776aa9d'
+          checkpoint: '1e2bf245ed38ed3b1439ba13cd1797d1505ffdc43d481ee10a0ad0442918fced'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.