### PR TITLE
Update opera-beta to 50.0.2762.14

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '50.0.2762.9'
-  sha256 'e08c5854d87f25e9ce8a045710447b48631f3625cd0f6ce4980ea7284b1e6783'
+  version '50.0.2762.14'
+  sha256 '7d84266d3deea60ed147c5c31dc236b161997c7eb84e99fc2c1e7d5a555569d3'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.