### PR TITLE
Update telegram-alpha to 3.6-109684,712

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.5.3-109597,706'
-  sha256 '27fe67485abf84784ff9c16e1c1a514f667e772211822cc7ffd3d8da8e15f855'
+  version '3.6-109684,712'
+  sha256 'fc3d7d0ce0eb1e1b9bb6b673d6c9ef88e28b8b544ef241efc5b8a3c0c05e9323'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '5bd4c1857c0791ff45775d859e9af2581edee15c467a886b283b1a54d525932f'
+          checkpoint: 'c59e8709b7d8357c06fc04586db3b873a8c6e7ace772cee9e9c672848c877960'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.