### PR TITLE
Update java6 to 1.6.0_65-b14-468

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -13,4 +13,6 @@ cask 'java6' do
                        'com.apple.pkg.JavaMDNS',
                        'com.apple.pkg.JavaEssentials',
                      ]
+
+  zap trash: "/Library/Java/JavaVirtualMachines/#{version.major_minor_patch}.jdk"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.