### PR TITLE
Update palemoon to 27.6.1

### DIFF
--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,6 +1,6 @@
 cask 'palemoon' do
-  version '27.6.0'
-  sha256 'bbc66f26c422667ce2d33dbf6bfc07d4c4583830a7a1dac5eeef6cb804bd0e9f'
+  version '27.6.1'
+  sha256 '393b22e2ee19f97546abb2a117dd6794d11706e66499d43b9d726c5f6d25a656'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Palemoon'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.