### PR TITLE
VirtualBox @ version 5.1 to have the latest vagrant supported version installable

### DIFF
--- a/Casks/virtualbox-51.rb
+++ b/Casks/virtualbox-51.rb
@@ -1,0 +1,23 @@
+cask 'virtualbox-51' do
+  version '5.1.30,118389'
+  sha256 'bc1c6c341fcc04a8e214f9e4ced44058c6239f30ddd0e1a923f04c8d01c92d91'
+
+  url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
+  name 'Oracle VirtualBox 5.1'
+  homepage 'https://www.virtualbox.org/wiki/Download_Old_Builds_5_1'
+
+  pkg 'VirtualBox.pkg'
+
+  uninstall_preflight do
+    if File.exist?("#{HOMEBREW_PREFIX}/Caskroom/virtualbox-extension-pack")
+      system_command 'brew', args: ['cask', 'uninstall', 'virtualbox-extension-pack']
+    end
+  end
+
+  uninstall script:  {
+                       executable: 'VirtualBox_Uninstall.tool',
+                       args:       ['--unattended'],
+                       sudo:       true,
+                     },
+            pkgutil: 'org.virtualbox.pkg.*'
+end

--- a/Casks/virtualbox51.rb
+++ b/Casks/virtualbox51.rb
@@ -1,9 +1,9 @@
-cask 'virtualbox-51' do
+cask 'virtualbox51' do
   version '5.1.30,118389'
   sha256 'bc1c6c341fcc04a8e214f9e4ced44058c6239f30ddd0e1a923f04c8d01c92d91'
 
   url "http://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
-  name 'Oracle VirtualBox 5.1'
+  name 'Oracle VirtualBox @ v5.1'
   homepage 'https://www.virtualbox.org/wiki/Download_Old_Builds_5_1'
 
   pkg 'VirtualBox.pkg'


### PR DESCRIPTION
The rational for VirtualBox @ v5.1 is only to be able to install the version that vagrant supports as it's latest official supported version. 

That simplifies some things when working with vagrant and virtualbox. 
I found an older pull request that was basically for the same reason [https://github.com/caskroom/homebrew-versions/pull/2322](1) 

Maybe considering the fact that this version aims to be the latest vagrant supported version, the cask could be named virtualbox-vagrant to indicate that purpose. But that is of course debatable. I'm open for your comments.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
