### PR TITLE
Update telegram-alpha to 3.6-109739,715

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-109697,713'
-  sha256 'bac646aaa40a2470a7f6cb64a46078f1e5c0c212a4996917988fac496b21b5b9'
+  version '3.6-109739,715'
+  sha256 'd9bb7790624c779a12ce137a5b359b2ee8a50766d8f6095a653d20896e415e7e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '209b08145f572a1c45f6777687dcd627d98728d1f0d8be9b3427146896563544'
+          checkpoint: 'b9d3c5e4942b7140960a5918ee8f624973bc67d5be36943885d730f110b1c9c5'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.