### PR TITLE
Update telegram-alpha to 3.6-109781,716

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-109739,715'
-  sha256 'd9bb7790624c779a12ce137a5b359b2ee8a50766d8f6095a653d20896e415e7e'
+  version '3.6-109781,716'
+  sha256 '85bbbea8e3f3a04026acadb25fa61644ca62ff02d427162c460a7caa866daeb6'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b9d3c5e4942b7140960a5918ee8f624973bc67d5be36943885d730f110b1c9c5'
+          checkpoint: '6de20b1c4c2ed634eaf5caca1b8e45e9ab20ffdbf20e6d883e644a8cf129604c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.