### PR TITLE
Update telegram-alpha to 3.6-109798,717

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-109781,716'
-  sha256 '85bbbea8e3f3a04026acadb25fa61644ca62ff02d427162c460a7caa866daeb6'
+  version '3.6-109798,717'
+  sha256 'b40bea1e761782342d35633ba31234f5858ea755434cac0e652192e161261f3c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6de20b1c4c2ed634eaf5caca1b8e45e9ab20ffdbf20e6d883e644a8cf129604c'
+          checkpoint: '8cd2764c5e0a88168f3b40fb74861045f7650d9ecb438c5b1fec05dbb88f5a59'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.