### PR TITLE
Update sketch-beta to 48,47228

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48,47218'
-  sha256 'ed10efb1aa724805e12aebb828d5672dc6cf8c7202cf1c1f5ca1428e042f582a'
+  version '48,47228'
+  sha256 '43a5bf9b34908440d3030cdfad118169dd65746674f9f630f17f05c293c25f6e'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'b51cb114ee03c572efe2e41337a696306fb0c28264ea09b0bcdd9088c1356669'
+          checkpoint: '8149c2739ce4eb23bfdccfcc7483bd6a5d740651402a7b90eef339cd07c6f823'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.