### PR TITLE
Update libreoffice-dev to 6.0.0.0.beta1

### DIFF
--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-dev' do
-  version '5.4.3.2'
-  sha256 '3d4ac4bce9b711e5aa74ee119085125537656dc64cdf9f67a958563c274e6e49'
+  version '6.0.0.0.beta1'
+  sha256 'd835e369e30a89da59a0931f793e836462bf1b6f308f1ade094d5d328d96f73b'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
-  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOfficeDev_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'f47b16fab2f982d47a7796e68de3bf79e841cfbcc2f5d4f65ffab3d25b467771'
+          checkpoint: '7810d3e3bb4c834024d33ee8edbce5c869f5205d16a91faa8efb05958f52faf6'
   name 'LibreOffice Development Version'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'

--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -10,23 +10,19 @@ cask 'libreoffice-dev' do
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  conflicts_with cask: [
-                         'libreoffice',
-                         'libreoffice-still',
-                       ]
   depends_on macos: '>= :mountain_lion'
 
-  app 'LibreOffice.app'
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/regmerge"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/regview"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/senddoc"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/ui-previewer"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/uno"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/unoinfo"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/unopkg"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
-  binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
+  app 'LibreOfficeDev.app'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/gengal"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regmerge"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regview"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/senddoc"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/ui-previewer"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uno"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unoinfo"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unopkg"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uri-encode"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/xpdfimport"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/soffice.wrapper.sh"
   binary shimscript, target: 'soffice'
@@ -34,7 +30,7 @@ cask 'libreoffice-dev' do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      '#{appdir}/LibreOffice.app/Contents/MacOS/soffice' "$@"
+      '#{appdir}/LibreOfficeDev.app/Contents/MacOS/soffice' "$@"
     EOS
   end
 

--- a/Casks/libreoffice-dev.rb
+++ b/Casks/libreoffice-dev.rb
@@ -10,6 +10,10 @@ cask 'libreoffice-dev' do
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
+  conflicts_with cask: [
+                         'libreoffice',
+                         'libreoffice-still',
+                       ]
   depends_on macos: '>= :mountain_lion'
 
   app 'LibreOfficeDev.app'

--- a/Casks/libreofficedev.rb
+++ b/Casks/libreofficedev.rb
@@ -1,4 +1,4 @@
-cask 'libreoffice-dev' do
+cask 'libreofficedev' do
   version '6.0.0.0.beta1'
   sha256 'd835e369e30a89da59a0931f793e836462bf1b6f308f1ade094d5d328d96f73b'
 
@@ -10,26 +10,22 @@ cask 'libreoffice-dev' do
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  conflicts_with cask: [
-                         'libreoffice',
-                         'libreoffice-still',
-                       ]
   depends_on macos: '>= :mountain_lion'
 
   app 'LibreOfficeDev.app'
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/gengal"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regmerge"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regview"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/senddoc"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/ui-previewer"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uno"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unoinfo"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unopkg"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uri-encode"
-  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/xpdfimport"
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/gengal", target: 'gengal-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regmerge", target: 'regmerge-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/regview", target: 'regview-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/senddoc", target: 'senddoc-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/ui-previewer", target: 'ui-previewer-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uno", target: 'uno-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unoinfo", target: 'unoinfo-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/unopkg", target: 'unopkg-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/uri-encode", target: 'uri-encode-dev'
+  binary "#{appdir}/LibreOfficeDev.app/Contents/MacOS/xpdfimport", target: 'xpdfimport-dev'
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/soffice.wrapper.sh"
-  binary shimscript, target: 'soffice'
+  binary shimscript, target: 'soffice-dev'
 
   preflight do
     IO.write shimscript, <<~EOS


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.