### PR TITLE
Update visual-studio-code-insiders to 1.19.0,dc84f454ea245a1131e28557de1204b8cd1cc320

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.19.0,3c470706ded48fc75c05f86bc4f9c7b0f4d6c708'
-  sha256 '5653495dc05b29d614ff9664e0dc4d6c1817a7df4f81a87ca15cf6500d9b6392'
+  version '1.19.0,dc84f454ea245a1131e28557de1204b8cd1cc320'
+  sha256 '1e5013404b6646adb6f57d253e6f4808603bc88d9b0e1845cc970901be1d5b7e'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: 'c1c068f4f0f6618d411f80bbde53991c09490ce9a707b7d7c72a79246ad47ab4'
+          checkpoint: 'e11329b74062e050664c6868346548ef7f6fef42b69543451ea8a25a02e84621'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'
@@ -14,7 +14,7 @@ cask 'visual-studio-code-insiders' do
   depends_on macos: '>= :mavericks'
 
   app 'Visual Studio Code - Insiders.app'
-  binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code"
+  binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code", target: 'code-insiders'
 
   zap trash: [
                '~/Library/Application Support/Code - Insiders',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Add binary `target: code-insiders` to match the app and allow parallel installs.

![insiders](https://user-images.githubusercontent.com/26216252/33419790-cbd72abc-d5f7-11e7-9353-3d4629a30f54.png)
