### PR TITLE
Update sketch-beta to 48,47232

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48,47228'
-  sha256 '43a5bf9b34908440d3030cdfad118169dd65746674f9f630f17f05c293c25f6e'
+  version '48,47232'
+  sha256 '6fcadd63d5308d82813913834247e7acad3efd1becb329bf38ea952838352866'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '8149c2739ce4eb23bfdccfcc7483bd6a5d740651402a7b90eef339cd07c6f823'
+          checkpoint: 'f68ab84737e7b428844b977615b68c8410e607a917e394a40be329456db6c203'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.