### PR TITLE
Update telegram-alpha to 3.6-109891,722

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-109820,720'
-  sha256 'e92b06db7b168e2e97dd36982b5eedd4ced278a8f468373fe2afdd8d7ad57a0e'
+  version '3.6-109891,722'
+  sha256 '8f118b47e8305e111a582b13102254d09509083c93910982bddad8584eb86451'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1f044b51331f1757a98a5555c13ea2a33cee6472399bd211e7fc0c8bf9477922'
+          checkpoint: '55a33eb817191fcaa618b3020ea060fbea920fdd01ca987d055395736464883c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.