### PR TITLE
Update opera-developer to 51.0.2791.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '51.0.2781.0'
-  sha256 '266bbe9eaf745e508534c7400719f6ecef74aee19ff8947d5713b5c7dfc7e457'
+  version '51.0.2791.0'
+  sha256 'b8015baef981d05abf67d5ed65e06c43d4d05a8f38a8d30a28b609992d0be09a'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.