### PR TITLE
Update rhinoceroswip to 5E326w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E292w'
-  sha256 'e78bc7249a0384767c53d90c03f606161bc077e2832508dd7303987fc2aadf02'
+  version '5E326w'
+  sha256 '7b0ca852eb5a9b1ba07deb60254faffea8058af7ad3c04bcc442d3450eebc301'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '7115f6ed6773a66a0f922ba8ee396cb1da5e5fcf76531c6062800c27ee6ca2d7'
+          checkpoint: '3c7f584b50495d0ebb27074738ad0ed55e030a2d4282abc54233e8871bd86661'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.