### PR TITLE
Update libreofficedev zap stanza

### DIFF
--- a/Casks/libreofficedev.rb
+++ b/Casks/libreofficedev.rb
@@ -35,7 +35,7 @@ cask 'libreofficedev' do
   end
 
   zap trash: [
-               '~/Library/Application Support/LibreOffice',
+               '~/Library/Application Support/LibreOfficeDev',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl*',
                '~/Library/Preferences/org.libreoffice.script.plist',
                '~/Library/Saved Application State/org.libreoffice.script.savedState',


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

This is the only change required in the `zap` stanza for the new `dev` version.