### PR TITLE
Update telegram-alpha to 3.6-109947,724

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-109911,723'
-  sha256 '13006c16a95b08e0690e871a0bb083fd90ef3a51629fc98e88bd38e960613ecf'
+  version '3.6-109947,724'
+  sha256 'f3f28a33d4b32b7034c68f5d491991841098b5aa00742573b7848c6b8e17d068'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '077f286237547522557cd94e6d66d3ceb5699b6d0eefae7a9917b641f0f5b07e'
+          checkpoint: '5d207be108ee86442863b1958bd94f680f63faab5b8728043b0e3c86a3a8d8f6'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.