### PR TITLE
Update omegat-dev to 4.1.3

### DIFF
--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,15 +1,15 @@
 cask 'omegat-dev' do
-  version '4.1.2,02'
-  sha256 '8a3574d97de621da21b99749a8af67edee0ac414ecec357d7098f93423fd1238'
+  version '4.1.3'
+  sha256 '3f43019780741545ceabbbaa642a2a73e6db5e473364e264089cf2f84fc902cb'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version.before_comma}%20update%2#{version.after_comma}/OmegaT_#{version.gsub(',', '_')}_Beta_Mac_Signed.zip"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
-          checkpoint: '4128fd774ac85dcb6ed7d433f72a0b6b2b1db9f8ba9198bb56630a562ffde0ce'
+          checkpoint: 'f83e1c66a06d0b3f98ee8af9ae8be163d47eb0f914987ba4bf6b344d4dd7787b'
   name 'OmegaT Development'
   homepage 'https://omegat.org/'
 
-  app "OmegaT_#{version.gsub(',', '_')}_Beta_Mac_Signed/OmegaT.app"
+  app "OmegaT_#{version}_Beta_Mac_Signed/OmegaT.app"
 
   caveats do
     depends_on_java('8+')


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.