### PR TITLE
Update airmail-beta to 3.5.3.466,327

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.465,326'
-  sha256 'fa2028a0233dbef36b5451ce6da659423879b7e21470b2eae6740fe6aaf83f98'
+  version '3.5.3.466,327'
+  sha256 '505a62741fcea94c13564b048aff69fbafd5aaf55ae914224aa1225441525915'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '3b1c74ec26c305b1e231d97d4d1aa2a70f07c50670ccc7b70284e6e2b7124e5a'
+          checkpoint: 'eeed7ba011d5b2ef862265275b684b24171668ddd51b0da63d6ea6568960159f'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.