### PR TITLE
Update telegram-alpha to 3.6-110130,730

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-110016,727'
-  sha256 '22328c3822e9d5d49c76fd60d9b82a1c5a109b468a42963b260049208e26eb88'
+  version '3.6-110130,730'
+  sha256 '56228586dfe33bb16527f1c6ec72be7a36f34b6ba6aa071acbcdb78de7280cf2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6fc5d9912bc0a92b562c6afaf4c9a85464ee675bd00c2f335f089dfaeea7a2a0'
+          checkpoint: 'da5ecd3c568ba5cfc252c3075a0865b013147ae37786894702021e780db911ad'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.