### PR TITLE
Update prince-latest to 20171026

### DIFF
--- a/Casks/prince-latest.rb
+++ b/Casks/prince-latest.rb
@@ -1,10 +1,10 @@
 cask 'prince-latest' do
-  version '20170907'
-  sha256 '3c882cbbcdd646e27263105fce8079391d703c8243ad640b4b2db3364dadce5f'
+  version '20171026'
+  sha256 '8c0467f1565aa3062c40acfb41ea682b1be064eb9122d0387ba89f5d32891963'
 
   url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
   appcast 'https://www.princexml.com/latest/',
-          checkpoint: '53edcc6bb96a56e42143629a6cc380229ef1f27ed372e550f012e3f71a10f548'
+          checkpoint: 'babd91d1315897fafd95b2713636a1e93e732ee7196cc83123d89c4855f7cba8'
   name 'Prince'
   homepage 'https://www.princexml.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.