### PR TITLE
Update telegram-alpha to 3.6.1-110227,732

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6-110155,731'
-  sha256 '147eea4513ac57abefd0f8c04e4b406d78c09d800a3e224cdebf951fdfd92a9e'
+  version '3.6.1-110227,732'
+  sha256 'b7349e1a9eca2214b71e1773861c3ebf6972333ebeebe620df2ab651c9670133'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bcedd6e780e6289e7607e80320fabe643eb6390059dca6d8b63b1d309034e6fe'
+          checkpoint: '1c749bf8d4a0a3fe880071546d4d10f578bb3455cac503016bec266274e2e7cc'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.