### PR TITLE
Update vivaldi-snapshot to 1.14.1036.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1030.3'
-  sha256 'bbb22c6b6a6e60c2ca7293af90b532477a1ff312253feb6492ab4953a3394d91'
+  version '1.14.1036.3'
+  sha256 '373406481dc27835f26b8e6fe38a1f1baccb4ca63dec208277bd6d7bdb2a3489'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '47a07513d9c81fa9257821633cac9a05a24e7bf5e39834e4a97f42f728333ec2'
+          checkpoint: '3520d5b599966b0cc5127659c52a43a3a507f9ccafbb5a380fe553d5319f109f'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.