### PR TITLE
Update hyper-canary to 2.0.0-canary.8

### DIFF
--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,11 +1,11 @@
 cask 'hyper-canary' do
-  version '2.1.1'
-  sha256 '5672e408cfe07008ac4eb1c01b86251837b9b743434a14b29ef372a4ef9f6148'
+  version '2.0.0-canary.8'
+  sha256 '1dddb18db9af04350b8c520610ca16b9527e783b8746088d2a9f6da62574aa7e'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: '5c7198ff0aee36409854b085f9cdbf451f8b8e7e55d23a0bcdaf046b23fec074'
+          checkpoint: '2ff6fa3fa92f451c706094cb81bc842646fb1b4e8fd9559a19028b199712739e'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

This PR is not downgrading from the previous **Hyper Canary** cask version (`2.1.1`) but updates it to its latest released version.

This is due to the fact that the versioning format for Hyper's canary releases has been changed from the simple `major.minor.patch` SemVer style to a longer format with `major.minor.patch` appending an additional versioning label.