### PR TITLE
Update vivaldi-snapshot to 1.14.1038.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1036.3'
-  sha256 '373406481dc27835f26b8e6fe38a1f1baccb4ca63dec208277bd6d7bdb2a3489'
+  version '1.14.1038.3'
+  sha256 '3de501c7b247cfcb57141b1d898899ac67911f488fd5115bcab3a76639540c50'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '3520d5b599966b0cc5127659c52a43a3a507f9ccafbb5a380fe553d5319f109f'
+          checkpoint: 'be522f282f3e4e1b4e87d89f3afacbee738783911a3d040b7ba98a2f1c0aa030'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.