### PR TITLE
Update whatpulse-beta to 2.7.2b1

### DIFF
--- a/Casks/whatpulse-beta.rb
+++ b/Casks/whatpulse-beta.rb
@@ -2,7 +2,7 @@ cask 'whatpulse-beta' do
   version '2.7.2b1'
   sha256 '54dc8c55cdca3d2f19bcd7ea788ac6aa2c57f6c7629e82de32ee93cc6211e0ad'
 
-  url "http://static.whatpulse.org/files/beta/whatpulse-mac-#{version}.dmg"
+  url "https://static.whatpulse.org/files/beta/whatpulse-mac-#{version}.dmg"
   name 'WhatPulse'
   homepage 'https://whatpulse.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.