### PR TITLE
Update telegram-alpha to 3.6.1-111054,735

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-110227,732'
-  sha256 'b7349e1a9eca2214b71e1773861c3ebf6972333ebeebe620df2ab651c9670133'
+  version '3.6.1-111054,735'
+  sha256 'da28b6a7090d52292fd6525d7a637ec6640175e7242cf4d33018584505d616f7'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1c749bf8d4a0a3fe880071546d4d10f578bb3455cac503016bec266274e2e7cc'
+          checkpoint: 'aaaba86ecccb0a994b6985b3aa4cce7c1a455d21e3dcb33ddae91b6be8ec3fa5'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.