### PR TITLE
Update vivaldi-snapshot to 1.14.1042.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1038.3'
-  sha256 '3de501c7b247cfcb57141b1d898899ac67911f488fd5115bcab3a76639540c50'
+  version '1.14.1042.3'
+  sha256 '77afa3c48f723dcd2a3dd0b2ec7d7d85cc703633705de93fb7e85c20f470999e'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'be522f282f3e4e1b4e87d89f3afacbee738783911a3d040b7ba98a2f1c0aa030'
+          checkpoint: '7301d645b61305bff40fb2e7f776e7da749124117654f9e7840722310b5a6775'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.