### PR TITLE
Update sketch-beta to 48.2,47319

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48,47232'
-  sha256 '6fcadd63d5308d82813913834247e7acad3efd1becb329bf38ea952838352866'
+  version '48.2,47319'
+  sha256 'b29efdb7aed1a67fb81e0ee7330a9f65827ca8a73f4b640e4b9a01980a8dc535'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'f68ab84737e7b428844b977615b68c8410e607a917e394a40be329456db6c203'
+          checkpoint: '773ac46069403daf55fe5244f8b94e02efce128d606ec7ff28bd64a150d11119'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.