### PR TITLE
Update telegram-alpha to 3.6.1-111205,741

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-111175,739'
-  sha256 'f0be5286c6652ba4deaff1142b6b9dc582e328c5ae2e67ece487d6e9dbf1b3bd'
+  version '3.6.1-111205,741'
+  sha256 '1360f4ceb133f495b7a46f5d0dabea94cc60600d0d62a4353b81de65a428d7bc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '3fc8aa803acee309f5ddf95a766f0fde652824398a4cc9e79781ec752882f5da'
+          checkpoint: 'b9c1e679bcb1a82d55d627ce2f70971158325d722779948126b15897d1ffdb6a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.