### PR TITLE
Update telegram-alpha to 3.6.1-111316,750

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-111234,743'
-  sha256 '256fe0b1f63fa6fe1d9db161689d2bec265892b5277c61f8a55112e3d13f0c28'
+  version '3.6.1-111316,750'
+  sha256 'bde83062d31f946935859a76d1ca79ed0a528af6e8f9ffeeb4e5ef5f65ef486f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'e7482d04c16829b4a45e21e1a47f690891ba42a6616c6b0f8abb76309d745d49'
+          checkpoint: '5c22953c95460892d2e53f6f31134c99a12a3e09fec8d48d93d5bf8fff233844'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.