### PR TITLE
Update sketch-beta to 48.2,47327

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48.2,47319'
-  sha256 'b29efdb7aed1a67fb81e0ee7330a9f65827ca8a73f4b640e4b9a01980a8dc535'
+  version '48.2,47327'
+  sha256 'f2d1d61785ad45ca48905d5f5160abdec43c7462f82c1fd44ab3dba5087357f7'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '773ac46069403daf55fe5244f8b94e02efce128d606ec7ff28bd64a150d11119'
+          checkpoint: '20562be4a610e8ee844d1b7d3ff73d0aa9a112d8f9c14b5e85f74e4a7130f192'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.