### PR TITLE
Update torbrowser-alpha to 7.5a10

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,10 +1,10 @@
 cask 'torbrowser-alpha' do
-  version '7.5a9'
-  sha256 '6d96ee0821b6c721d8c2df5a9d61d18860441cce97c9a9322c054390bb25e835'
+  version '7.5a10'
+  sha256 'c63c840bf85a3410ec8e3c72c8a2a45ac07532ac881959615a1a50a41373f545'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '7d4e69c1937b00fc4299a790ec355dbf93f1718ed63f96fd057bc41fab9ececd'
+          checkpoint: '69bf5867088ea2bcf90d328d252ee0bc9d5a74e2bdb956b2a8be9c830fb36c14'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.