### PR TITLE
Update vivaldi-snapshot to 1.14.1047.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1042.3'
-  sha256 '77afa3c48f723dcd2a3dd0b2ec7d7d85cc703633705de93fb7e85c20f470999e'
+  version '1.14.1047.3'
+  sha256 '558c9e3c3f2639a9dbdb49b19fed4bcd4b6f95772848505dc568f3451b24660a'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '7301d645b61305bff40fb2e7f776e7da749124117654f9e7840722310b5a6775'
+          checkpoint: '482ef48777f4dd331edbe4a3ab9a885e828c13d4c373ab03da553d3cda90e1ba'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.