### PR TITLE
Update soulseek-rc to 2017-11-21

### DIFF
--- a/Casks/soulseek-rc.rb
+++ b/Casks/soulseek-rc.rb
@@ -1,9 +1,9 @@
 cask 'soulseek-rc' do
-  version '2017-7-29'
-  sha256 '2ccc407192e91a3a15ab60214e1799145434d666251e801b540701c406825758'
+  version '2017-11-21'
+  sha256 'ec9889bed69107fe56fd78745a668ef574bdd7d29ddd370464136109cbc4f11f'
 
-  # dl.dropboxusercontent.com/s/jx7790ztbn147ko was verified as official when first introduced to the cask
-  url "https://dl.dropboxusercontent.com/s/jx7790ztbn147ko/SoulseekQt-#{version}.dmg"
+  # dl.dropboxusercontent.com/s/ruvio22uu1onddi was verified as official when first introduced to the cask
+  url "https://dl.dropboxusercontent.com/s/ruvio22uu1onddi/SoulseekQt-#{version}.dmg"
   name 'Soulseek'
   homepage 'https://www.slsknet.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

See: http://www.slsknet.org/news/node/3653