### PR TITLE
Update opera-beta to 50.0.2762.42

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '50.0.2762.35'
-  sha256 '48f9af87b855068ad261fc4ffba272f28049268247e7b11d121bb93ad197ada6'
+  version '50.0.2762.42'
+  sha256 '0ae6866beb0047a2aebd22df7d2638f2d95ad8c08227879905d0e96e1add2235'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.