### PR TITLE
Update telegram-alpha to 3.6.1-111566,754

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-111463,751'
-  sha256 'b41a6576f16acb842772fb71768a7ef2a4895fb59e3918bb8c263c02f91a6145'
+  version '3.6.1-111566,754'
+  sha256 '54e7a0567a4491c83a21067115993930c7392784b8a8edcd50319415fc5f3cbf'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'fc3454ae4f6fccbd626348c0177c257de3e4e89bf556d3a8875e3784523ca6d7'
+          checkpoint: 'a0033778bdd7df18ef43cc6838a6e78172df12ccafcc248a2249c0ddc82d77cb'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.