### PR TITLE
Update airmail-beta to 3.5.3.468,328

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.466,327'
-  sha256 '505a62741fcea94c13564b048aff69fbafd5aaf55ae914224aa1225441525915'
+  version '3.5.3.468,328'
+  sha256 'e581d0aa68d33f4a68383e23b99473d400f68f49f31524b81204b948d1eb00fa'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'eeed7ba011d5b2ef862265275b684b24171668ddd51b0da63d6ea6568960159f'
+          checkpoint: '44a9b64537b4b3c7f6969f949e5c74672dd95cc6861ccb1fe490e848c2e8a389'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.