### PR TITLE
Update telegram-alpha to 3.6.1-111635,757

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-111566,754'
-  sha256 '54e7a0567a4491c83a21067115993930c7392784b8a8edcd50319415fc5f3cbf'
+  version '3.6.1-111635,757'
+  sha256 '9ca567b9cb7e398cfa92d0388bf993024da955e89d548b029545a1ba481dfd29'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a0033778bdd7df18ef43cc6838a6e78172df12ccafcc248a2249c0ddc82d77cb'
+          checkpoint: '81dc9e24abcb08d9a336edbf5665929fe52256f9dbc3002de02a2b2811715ac8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.