### PR TITLE
Update visual-studio-code-insiders to 1.20.0,f9115349ef09cfef2bed669680d10ac58b490dce

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.20.0,08ec16001adaab8a86183431f6aec09209caa4ab'
-  sha256 '6ae796e2a9934419b5d068af23cd884807a9b670a71a5879dbfef5db5e8bcb33'
+  version '1.20.0,f9115349ef09cfef2bed669680d10ac58b490dce'
+  sha256 '20679d167e268d5de708d99143fa0737f0894b0c715f02d34c3e406302e9c5ce'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: '0c1a2d39700bd1b8da5d1735ff6af2f82e2378555745ae3d87dbffffaa025c68'
+          checkpoint: 'e6300f20911f0000638ec5fe629d5fec6fa8671295d52fbdebe286711f24b585'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.