### PR TITLE
Update telegram-alpha to 3.7-111696,762

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.6.1-111635,757'
-  sha256 '9ca567b9cb7e398cfa92d0388bf993024da955e89d548b029545a1ba481dfd29'
+  version '3.7-111696,762'
+  sha256 '800cc91d9b7fd4fb24c9a925ee6b47bf0d9dc29b74d7ed6869dfbda269fea4b5'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '81dc9e24abcb08d9a336edbf5665929fe52256f9dbc3002de02a2b2811715ac8'
+          checkpoint: '0c7faefe0e0483670c070e0760eeda4efe4810f59a0716b8daf8071f095bc2e9'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.