### PR TITLE
Update skype-preview to 8.13.76.6

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,6 +1,6 @@
 cask 'skype-preview' do
-  version '8.12.76.7'
-  sha256 '038b1162d970d96d0403894c0a1a24f8258abcdbd12cb5a192f1ea68416f17fe'
+  version '8.13.76.6'
+  sha256 '01d1cad257549459a49f52d0223d92278d6232286ccce3c69ee64f7c707fe728'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.