### PR TITLE
Update telegram-alpha to 3.7-111814,771

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7-111811,770'
-  sha256 '022abcadd2133f13426d4f5437f906e29d0ef3c216ef2dce4de14ab5f93d7735'
+  version '3.7-111814,771'
+  sha256 'b445d42aa1d3248034ca9e0937884049136cc46a5a236ef635400a104aa61d2a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '4fef76081815104e05e570fa4cd909f90d173f246734a025ba9b03ec1e141532'
+          checkpoint: 'aa25b888d1e25438672ef95b29e42f34678c9d3a5d1e2deeac03f386ce72de75'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.