### PR TITLE
Update telegram-alpha to 3.7-111819,773

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7-111814,771'
-  sha256 'b445d42aa1d3248034ca9e0937884049136cc46a5a236ef635400a104aa61d2a'
+  version '3.7-111819,773'
+  sha256 'f256fad12fcd970b081ebe3885de3b82e32f424271deac4a04b6372242fcd6dc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'aa25b888d1e25438672ef95b29e42f34678c9d3a5d1e2deeac03f386ce72de75'
+          checkpoint: 'e194f50dbaa8435758fb61b73105c26e7e300789a640203941a7e7aee45b4c0c'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.