### PR TITLE
Update telegram-alpha to 3.7.1-111903,781

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7-111825,774'
-  sha256 'ae7e34668dc56b6f4665aa47237d0925e4773290ffa6e4576676b7e914749780'
+  version '3.7.1-111903,781'
+  sha256 '9b16a6018887819e9b8fced29a4c54b136eb6b61b58223d29687c74485cab929'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '00227e62a226acc3e664d9109ebd102ae873641163f332baf4c36b02914310ca'
+          checkpoint: '9ccc223641b475edc3b4687d0041bd0a0927df7e8ac3804b99f00942835430cc'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.