### PR TITLE
Update firefox-esr to 52.5.3

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '52.5.2'
+  version '52.5.3'
 
   language 'cs' do
-    sha256 '20424255ecfd9fb38c416b9c2061783b9999150433c4b220a255e156003d2af1'
+    sha256 '0a6dcf858fba89ce777e7285d0908b9af99970b7cfc7d4b1fd8464675cb961ce'
     'cs'
   end
 
   language 'de' do
-    sha256 '84e7e2325f371a9105b4388205482dcdd7fecd78c241301ee4c88a57d59c34a5'
+    sha256 'aa3de146ca3da32347cee09288fe0f357946430967d053b11188231350296429'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'c9ef105c040ce8564b7e7ce3d6d21b978684ae32a5d536c46aa01de49f92a02e'
+    sha256 '75c278339064c5ff884070e61b5c2d5e27b40632bd6ca1ca1e9da04b91959996'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'a3089c7c3bcf3afcff978d68b3a48992c650e4e621f62aef40078b2a33bd13cf'
+    sha256 '4125a0c0eef0de35a6c90db7162ae64235457de9833ddda0e997081ebe40c234'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '049e832cd456d68a40a4a807096a62dbe531fef56e63dc390550b0e3a897a027'
+    sha256 'def84beb287f29aedb24af0cc927c270e9f7c37175ea1beb3ae9f9ae399c07c5'
     'fr'
   end
 
   language 'gl' do
-    sha256 '2943109fdd615f904642ac6c69666d8f10bbfde65ce0a1020646b7ef48a11629'
+    sha256 '7606cac624a649e8b05a0204a3c9817e0725d405326cfb02c9f3f5ae43e13043'
     'gl'
   end
 
   language 'it' do
-    sha256 '398aff3937f1821fee9920e54ffa919fef12bc9518816b331c16c08337f9fa33'
+    sha256 'd64ae29b03193898cd4072c127a42518922ae9e9b349fe6ab54930fd74660a61'
     'it'
   end
 
   language 'ja' do
-    sha256 '9df8af58b52924f757719b6ceee6059c2d97e8b68977133ad4ac4f9824416c30'
+    sha256 '2756d549299cc624b39ea73560ae44a3233881cd795144448be9888bd31c77fd'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'b28d6f30cc450dfbc16308fd494e689eaaee094562e037c6b226ac159216c041'
+    sha256 'fb498b7d0c9c99802b0d3dc25e39f0c4a1dcb3f8db6e1f011dab02e48e81e7d5'
     'nl'
   end
 
   language 'pl' do
-    sha256 '700ea632de03c90c5aaf99a6001b4bc106a115ca1620061befba1daebfc3f28d'
+    sha256 'f4aebbbd1122c7a575a26c814500d279651c5dd046e16da170386a193bdf0e24'
     'pl'
   end
 
   language 'pt' do
-    sha256 '06a77b762dc0b3ff280db3d274112d9e052aad6185236d18b21a6ee6e075af8b'
+    sha256 'ba50c4a6a3b7d47e85a941d8937ed39b4c4c195b75b60868d022075eaed4afb3'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'ce224d65f27c00080e098c838f11af9e6460ee2e26aa195061d555343f87ebce'
+    sha256 'ba7440537cdc6e379cb27ffbbc2a64b2f15035f5aed4525098571848f5e3c06c'
     'ru'
   end
 
   language 'uk' do
-    sha256 'ea4dbabe7f0a1bd0882ea4c57caf5f3113398f01eadbf029b78888d9d4003499'
+    sha256 '12aef695883972e5791913acbffaa5bfb3f65c05a4f21e930ab9f4f378165d82'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '7419cdac8e931bdfa6d5e8defb4233c2b13073799da9f4a4626d0b0bd8e05e3f'
+    sha256 '93563aa858c3504b8d56ac480fa1aaeb3a864e8825f39d6628b6efa68aecdd69'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'd04e503c2c8e65a26aa650494892abdd879ee19443201bcbd3bee41815d07b70'
+    sha256 '5356f9672c2d604cd25f04384bc63465bc535f6676a6797baa43e532bd963a22'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
