### PR TITLE
Update dropbox-beta to 41.3.77

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '41.3.76'
-  sha256 '7662fbf387fe5ff47fa327937beb89dabf4624d9fbdf6fc59ab66a462730f75e'
+  version '41.3.77'
+  sha256 '4d68fa68d71f6e7cb157aeb016077c428bb1337aa20b903a8462cae9183e9ce6'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.