### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.40.834,152

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.39.831,151'
-  sha256 'dcb194c6fa3a5228d18884788863fc54e0a1a8ac662bf83cce839a6ed5317dcf'
+  version '8.2.40.834,152'
+  sha256 '3e7f3882f28a0cb28176b057554c940be9935d01214c776ee23da01b94423777'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '05d927b09c1939c3231fa89ea49cf65df6b73c2f748027a63f9263c4debba013'
+          checkpoint: '983b31eb2de63a13d2d42422f6617fbbf8476242bcb630cd16971823dc6c3193'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.