### PR TITLE
Update telegram-alpha to 3.7.1-111953,785

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.1-111903,781'
-  sha256 '9b16a6018887819e9b8fced29a4c54b136eb6b61b58223d29687c74485cab929'
+  version '3.7.1-111953,785'
+  sha256 'ffbb53a03fdaadae1f792359b09e4f213577866bd5e9e3a8b24a366fc1c39212'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '9ccc223641b475edc3b4687d0041bd0a0927df7e8ac3804b99f00942835430cc'
+          checkpoint: '8b9d332cdb0154f72fd984613dc5e3de744b9cede5d83a6e79633d162198049f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.