### PR TITLE
Update microsoft-remote-desktop-beta to 8.2.41.835,153

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.40.834,152'
-  sha256 '3e7f3882f28a0cb28176b057554c940be9935d01214c776ee23da01b94423777'
+  version '8.2.41.835,153'
+  sha256 '7ac2dae1af04070dc5ba4ac3e4d92017c9bacb25edc03a340499cd3eb046c3f4'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '983b31eb2de63a13d2d42422f6617fbbf8476242bcb630cd16971823dc6c3193'
+          checkpoint: 'daca2e9f0992a5e7dbc6d9729da2f4a1006e91ecde26619d88ec35f99be8120a'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.