### PR TITLE
Rename firefoxnightly to firefox-nightly

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -1,4 +1,4 @@
-cask 'firefoxnightly' do
+cask 'firefox-nightly' do
   version '59.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 

--- a/Casks/firefoxnightly.rb
+++ b/Casks/firefoxnightly.rb
@@ -27,7 +27,7 @@ cask 'firefoxnightly' do
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/channel/desktop/#nightly'
 
-  app 'FirefoxNightly.app'
+  app 'Firefox Nightly.app'
 
   zap trash: [
                '~/Library/Application Support/Firefox',


### PR DESCRIPTION
Looks like the .app in the .dmg was changed from `FirefoxNightly.app` to `Firefox Nightly.app` at some point, breaking this formula.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (not included version as this isn't a version change)

