### PR TITLE
Add zap stanza to opera-developer 51.0.2809.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -9,4 +9,12 @@ cask 'opera-developer' do
   auto_updates true
 
   app 'Opera Developer.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.operasoftware.OperaDeveloper',
+               '~/Library/Caches/com.operasoftware.OperaDeveloper',
+               '~/Library/Cookies/com.operasoftware.OperaDeveloper.binarycookies',
+               '~/Library/Preferences/com.operasoftware.OperaDeveloper.plist',
+               '~/Library/Saved Application State/com.operasoftware.OperaDeveloper.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
