### PR TITLE
Update telegram-alpha to 3.7.1-112307,795

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.1-112000,791'
-  sha256 'a724617884add64b4a45d622775a98770ec955ddd927c5a5f5a6b06e0d1cd959'
+  version '3.7.1-112307,795'
+  sha256 '8358df2ca0148cfe00535766fa43724d07e9dce1c808664e19ee7d064af8b984'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a0c2d91730b622ad6968783ea9f04da05f7a7e83ffd45193971dafd1a5cf13a2'
+          checkpoint: '6296b27ff813dceef9d4277edfaa8a53476b4e33689760e78d7c642e98466b18'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.