### PR TITLE
Update rhinoceroswip to 5E366w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E334w'
-  sha256 '68efabba924ec8d49557c5ab05ed5a84b330ead3762fab741d7d2a790e0dfdea'
+  version '5E366w'
+  sha256 '38647b7dfac3baf192c64551d0ec1c9d6f8d4fad2bab51bc6de49730be59bc8c'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '992c219c5c41b09ee2c427f23df958e85ce8f2ebd58e155370d73543db246b46'
+          checkpoint: '1d630ee23aae454e4ef7a5826bf72111a426b0e85eed46bf7a3d2ea823a0eefe'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.