### PR TITLE
Update telegram-alpha to 3.7.1-113053,800

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.1-113008,796'
-  sha256 '2f7a55963f77fb01c7bb37b88d886224b034157a0d1bf65ba8d8801ffe39e36f'
+  version '3.7.1-113053,800'
+  sha256 'a19901af5fe8e9a68bbc9bd74a8e3e918e42cada0c8506766502ba918743996c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '80dff52c1846baab7a67b7aa21f5718ec81682519a0a5bd9c7781089a9affde4'
+          checkpoint: 'a8013809a1928f31b7d29b63d1e10dcedfae72b9562f9d8823eb1ec189dd2ec2'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.