### PR TITLE
Update telegram-alpha to 3.7.1-113204,805

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.1-113053,800'
-  sha256 'a19901af5fe8e9a68bbc9bd74a8e3e918e42cada0c8506766502ba918743996c'
+  version '3.7.1-113204,805'
+  sha256 'af5c162b17fb10b10fa772ea4478ab5b11dd01f0d9d5669846d87d9c1700a701'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a8013809a1928f31b7d29b63d1e10dcedfae72b9562f9d8823eb1ec189dd2ec2'
+          checkpoint: 'de3431c873a5e44b0c54d7db33ee396f01dbd6da40bdee52df0a450398be62c3'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.