### PR TITLE
Update vivaldi-snapshot to 1.14.1064.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1047.3'
-  sha256 '558c9e3c3f2639a9dbdb49b19fed4bcd4b6f95772848505dc568f3451b24660a'
+  version '1.14.1064.3'
+  sha256 '9f87d8985142f368722344f87befc1993b97a30ddc33e35304953af432e14d5f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '482ef48777f4dd331edbe4a3ab9a885e828c13d4c373ab03da553d3cda90e1ba'
+          checkpoint: 'cd99afaedda493ad199c4c1c319073c0fc44a06d69dfa35408315dca77ea390b'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.