### PR TITLE
Update opera-developer to 51.0.2830.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '51.0.2809.0'
-  sha256 '8d44700cfb5b29237b0c0dc18cf0bb23a18593af2cbb7473a182051d927f3a70'
+  version '51.0.2830.0'
+  sha256 '6d7a6cfb8721e1385988e0d606d2a2498d61e1d8bc238091e954cd15e8463edc'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.