### PR TITLE
Update telegram-alpha to 3.7.2-113295,821

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113291,820'
-  sha256 'b8b4a6b9185dd6d48003705c0a273a3e25a1c34274a1923dc42436bb8a0d9da3'
+  version '3.7.2-113295,821'
+  sha256 '42d16f08151ebaeef7fa288013152097a35bdaacd303f625b6895bcfc7dd7dab'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'ac284cb639f3a57c68f35299cd952df4c2155584079848734ab9b2726b2f6bb1'
+          checkpoint: '19b22d8310a80525aa70766d10c3ac904b974584264b38e5867fe449ebaf5b46'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.