### PR TITLE
Update telegram-alpha to 3.7.2-113328,823

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113300,822'
-  sha256 '3196eab73ce4df3762e6104a83c04a2c944cbff8d4a1c154aef2136652e3d30c'
+  version '3.7.2-113328,823'
+  sha256 '59945b158e1836b19b7c20d0f87b5c2307f7f9a0678db0c8e336488959378fc9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '0711608bf620f4e25266c1174929dc7802eba05bc88dc926507ca5465f9320aa'
+          checkpoint: 'a699bd3679d041b2344203c675ee22c21ef8a99b3be0f693ff097117c65a2fcd'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.