### PR TITLE
Update telegram-alpha to 3.7.2-113398,826

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113328,823'
-  sha256 '59945b158e1836b19b7c20d0f87b5c2307f7f9a0678db0c8e336488959378fc9'
+  version '3.7.2-113398,826'
+  sha256 '2b1109315c2ecf17f2d242c899060395adc576ef12357590dd3b120d91db55bc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a699bd3679d041b2344203c675ee22c21ef8a99b3be0f693ff097117c65a2fcd'
+          checkpoint: 'cd0f85fd9da9c06e9ffcf86c0dc471181654be98499a78b68578307cd057e068'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.