### PR TITLE
Update telegram-alpha to 3.7.2-113450,830

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113398,826'
-  sha256 '2b1109315c2ecf17f2d242c899060395adc576ef12357590dd3b120d91db55bc'
+  version '3.7.2-113450,830'
+  sha256 '14bd40c9248c1ab17406a29c5f6aa79887f4553aa6d0c6bb7404a8bc254c8b91'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'cd0f85fd9da9c06e9ffcf86c0dc471181654be98499a78b68578307cd057e068'
+          checkpoint: 'f1a2d328aa2ecb142f81dbb18e3d16b27bd85101675e2a246d552f35af8b5a64'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.