### PR TITLE
Update dropbox-beta to 42.3.112

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '41.3.79'
-  sha256 '85156ab137d2f78830289fb0eeda4c2c1c63f208b1db6433eb85c699a6e1ee5c'
+  version '42.3.112'
+  sha256 '1969613559b3401aaf4e4739c34c6f5ffe5757386bcf284bf80feea1799f84e9'
 
   # clientupdates.dropboxstatic.com was verified as official when first introduced to the cask
   url "https://clientupdates.dropboxstatic.com/client/Dropbox%20#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.