### PR TITLE
Update telegram-alpha to 3.8-113491,832

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113450,830'
-  sha256 '14bd40c9248c1ab17406a29c5f6aa79887f4553aa6d0c6bb7404a8bc254c8b91'
+  version '3.8-113491,832'
+  sha256 'b2024bd0d51196decb91e9c7bb4ef60411c1e9974b6f354ac81f1d0c50d3a634'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f1a2d328aa2ecb142f81dbb18e3d16b27bd85101675e2a246d552f35af8b5a64'
+          checkpoint: '385137ae67e7ff4ef0270a995a0556c42f37ae8cd4ce8a425b6c1380bf8bbc9b'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.