### PR TITLE
Update telegram-alpha to 3.7.3-113631,833

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.2-113450,830'
-  sha256 '14bd40c9248c1ab17406a29c5f6aa79887f4553aa6d0c6bb7404a8bc254c8b91'
+  version '3.7.3-113631,833'
+  sha256 'ee406f09e5bd1eb070523a9ca7884670ae346302cbca67ec98da2f6f8a5e9e4b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f1a2d328aa2ecb142f81dbb18e3d16b27bd85101675e2a246d552f35af8b5a64'
+          checkpoint: 'a0f2b5bd7bda055e1f5f71d3c10169f7a2c2a13a075e286aa871f7a439d30380'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.