### PR TITLE
Update telegram-alpha to 3.7.3-114841,843

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.3-114819,840'
-  sha256 '3fc6189d13c4b4eeacbd8faeb4730e8cbec418452af07c508f9920e72b64e2bb'
+  version '3.7.3-114841,843'
+  sha256 'd22a694c97d22f4cbad82ca729425b22176fdea60a02f9855368c2b306c65eb4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '8fd8347acf999bf3a0d9cdf31a87d415df8b1ca851f2beaa62f119c973d02476'
+          checkpoint: '66050b96c32700597c1bc28f3e38b06a68cbf69f5c26bfed577a88542dea2976'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.