### PR TITLE
Update discord-canary to 0.0.185

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -1,10 +1,10 @@
 cask 'discord-canary' do
-  version '0.0.181'
-  sha256 '5e32dd3bcf79d0b74f3d27ad30a941329767c0a6eeb9518b8c855e26dde61d05'
+  version '0.0.185'
+  sha256 'ac2c49cd8e5d069c8a8b32b27b67b5d204d3909093613c3206c8027fedf7c394'
 
   url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg"
   appcast 'https://discordapp.com/api/canary/updates?platform=osx',
-          checkpoint: '7075b599a2707a55a4601a83879752639d25c01a69fb96c2cae5aa54e5649243'
+          checkpoint: '29bbbf008a4fc177a2ae295e6f65f494bac46beb702eeece4938f287fca1c7f5'
   name 'Discord Canary'
   homepage 'https://discordapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.