### PR TITLE
Update boxcryptor-beta to 2.3.201.730

### DIFF
--- a/Casks/boxcryptor-beta.rb
+++ b/Casks/boxcryptor-beta.rb
@@ -1,8 +1,8 @@
 cask 'boxcryptor-beta' do
-  version :latest
-  sha256 :no_check
+  version '2.3.201.730'
+  sha256 '0caf99cbe2b8b64d4d78501a664e91ae27757bc094f185f62dec2d6b120139a9'
 
-  url 'https://www.boxcryptor.com/l/download-macosx-beta'
+  url "https://downloads.boxcryptor.com/Boxcryptor_v#{version}_Installer.dmg"
   name 'Boxcryptor'
   homepage 'https://www.boxcryptor.com/en/'
 

--- a/Casks/boxcryptor-beta.rb
+++ b/Casks/boxcryptor-beta.rb
@@ -6,7 +6,7 @@ cask 'boxcryptor-beta' do
   name 'Boxcryptor'
   homepage 'https://www.boxcryptor.com/en/'
 
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :yosemite'
 
   app 'Boxcryptor.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.