### PR TITLE
Update chirp-daily to 20180104

### DIFF
--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -1,6 +1,6 @@
 cask 'chirp-daily' do
-  version '20171229'
-  sha256 'bf0b9c81f934706982913f774b2d00a76a436338717ed140d4de63de5efa21ce'
+  version '20180104'
+  sha256 '83b735b04b646b286bb053277d3b8385307f265aec9a682a2525fce1768cdcb6'
 
   url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-#{version}.app.zip"
   name 'CHIRP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.