### PR TITLE
Update earlybird to 58.0b3

### DIFF
--- a/Casks/earlybird.rb
+++ b/Casks/earlybird.rb
@@ -1,11 +1,14 @@
 cask 'earlybird' do
-  version '57.0a1'
+  version '58.0b3'
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central/thunderbird-#{version}.en-US.mac.dmg"
+  # download-installer.cdn.mozilla.net/pub/thunderbird/releases was verified as official when first introduced to the cask
+  url "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/#{version}/mac/en-US/Thunderbird%20#{version}.dmg"
   name 'Earlybird'
   name 'Thunderbird Nightly'
   homepage 'https://www.mozilla.org/en-US/thunderbird/channel/'
+
+  depends_on macos: '>= :mavericks'
 
   app 'Earlybird.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.