### PR TITLE
Update telegram-alpha to 3.7.3-114982,847

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.3-114841,843'
-  sha256 'd22a694c97d22f4cbad82ca729425b22176fdea60a02f9855368c2b306c65eb4'
+  version '3.7.3-114982,847'
+  sha256 '3b0398e884ac83cf7615f87384f90e451ff9bf657433ad6d1c02bbc88e1a9912'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '66050b96c32700597c1bc28f3e38b06a68cbf69f5c26bfed577a88542dea2976'
+          checkpoint: 'f7abb07f5b5fcebcf5c60f5504ef7c96cf3bd3a05f108043741fc0f4b7fcf6d7'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.