### PR TITLE
Update telegram-alpha to 3.7.4-115149,849

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.3-115010,848'
-  sha256 '172dfb85c02f492002da031a6c994a1016476d457f51265b2711b5aeeb709543'
+  version '3.7.4-115149,849'
+  sha256 'd09505b35d7c8d43c788ccd1447b363f96a0de4f326457fb4a32fce51af1c360'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f594da9feef9ebc6c8d99a38f651535e590fbf7a2cac91824a35690c4b519c5b'
+          checkpoint: '6c8138dc3aa7748c06fa240b0d86de82f3b60d8b0992cc53bd7d6e35ee543a66'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.