### PR TITLE
Update telegram-alpha to 3.7.4-115179,850

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.3-115010,848'
-  sha256 '172dfb85c02f492002da031a6c994a1016476d457f51265b2711b5aeeb709543'
+  version '3.7.4-115179,850'
+  sha256 '950f2fbc5b1cb686ac92aaff030cf3a89300e5971e07aa62c8739f18fb92543c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f594da9feef9ebc6c8d99a38f651535e590fbf7a2cac91824a35690c4b519c5b'
+          checkpoint: '6aa6d92c486262162da636d838bace4982ef2aa40f276b1a6b668c50e90b4f03'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.