### PR TITLE
Update telegram-alpha to 3.7.4-115214,853

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.3-115010,848'
-  sha256 '172dfb85c02f492002da031a6c994a1016476d457f51265b2711b5aeeb709543'
+  version '3.7.4-115214,853'
+  sha256 '576334497105f4c46a9ff5742f68285da84f3687856351de4a5f0181e2537b19'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f594da9feef9ebc6c8d99a38f651535e590fbf7a2cac91824a35690c4b519c5b'
+          checkpoint: '8d5f9e1f07f0de094a4a65d5564386cf01cf2e6dcf5bff297ddb0bd0acf4c8ab'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.