### PR TITLE
Update vivaldi-snapshot to 1.14.1072.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1064.3'
-  sha256 '9f87d8985142f368722344f87befc1993b97a30ddc33e35304953af432e14d5f'
+  version '1.14.1072.3'
+  sha256 '345849e24bd6cd14d67f02f243b2eda50e69477f0df0d6d4a6028da64ef52f39'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'cd99afaedda493ad199c4c1c319073c0fc44a06d69dfa35408315dca77ea390b'
+          checkpoint: '50be3002ffd6487f1b547d7ec659f5cfb15866101029bd7c677a97fdbe9b6f53'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.