### PR TITLE
Update 1password-beta to 6.8.6.BETA-2

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,10 +1,10 @@
 cask '1password-beta' do
-  version '6.8.5.BETA-2'
-  sha256 '403fce6ef8c18bfe8a8e086a50ac83ae4e28f01409da2c7c4197a33e94b7204a'
+  version '6.8.6.BETA-2'
+  sha256 '78029997588bb77fd0d996d769537667015eb2c60124b8082c4e5f82039dc213'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: '4ca0ce7d107be3c5229cb6be0860c7bdc230543490433e59a2a828bd65bab13b'
+          checkpoint: '26a4889324377f936adb47939e48b91752a57420bd474ad6d6524f26eda932cf'
   name '1Password'
   homepage 'https://agilebits.com/downloads'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.