### PR TITLE
Update telegram-alpha to 3.7.4-115375,866

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.4-115214,853'
-  sha256 '576334497105f4c46a9ff5742f68285da84f3687856351de4a5f0181e2537b19'
+  version '3.7.4-115375,866'
+  sha256 'd600ad789a384a6d88d6946942000e7d0b637f76fbd2c79a30bd7396f774e305'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '8d5f9e1f07f0de094a4a65d5564386cf01cf2e6dcf5bff297ddb0bd0acf4c8ab'
+          checkpoint: 'a2a3f2ee6d6913e156c8d7a9b48fae26d6effe2d7609aea26890e85f646a50f2'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.