### PR TITLE
Update opera-beta to 51.0.2830.8

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '51.0.2830.2'
-  sha256 '1c5cc3bbc8a756a6e47897c8bdbfb7fc8913c9e750bd2333f1c1cfae23348e5d'
+  version '51.0.2830.8'
+  sha256 '4dc28428af4466d7429e1ffa601f00df89baf89a4bb1775220597cb4a5578cf7'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.