### PR TITLE
Update microsoft-remote-desktop-beta to 10.1.3.843,160

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '8.2.41.835,153'
-  sha256 '7ac2dae1af04070dc5ba4ac3e4d92017c9bacb25edc03a340499cd3eb046c3f4'
+  version '10.1.3.843,160'
+  sha256 'f9503d3e05e3d0b2cce29c0f368a0794dd7208e01a4203856c2f5d979718ceb8'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'daca2e9f0992a5e7dbc6d9729da2f4a1006e91ecde26619d88ec35f99be8120a'
+          checkpoint: '1af6733ab27c76ea0c80d4ee72d1959397009e65b368357dd8a334e4ca926f2f'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.