### PR TITLE
Update slicer-nightly to 4.9.0.26842,760102

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.26813,735359'
-  sha256 '28ac978548dd6819eb6c84a5c712018d38bcdc17f9bae907d29256e4299f0b7b'
+  version '4.9.0.26842,760102'
+  sha256 'f8c6e8184fc1e5b7434bd22491fc175e140ea99fda39880738951764f2737a5d'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.