### PR TITLE
Update emacs-pretest to 26.0.91

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,10 +1,10 @@
 cask 'emacs-pretest' do
-  version '26.0.90'
-  sha256 '85ed39cda9795ca1951b0ecae40d5c965a1f0b13e1cc4691ba5ccb1145ac178f'
+  version '26.0.91'
+  sha256 'b43575f0db141e358a4c916891c6dc50e1693daa54b2d23d86efb7d048dbef2a'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: '855d4c518cad52c8b643fb9c39ebcacfd2fcf63b8fd3183cc6a0eb2690440375'
+          checkpoint: '047327f6099140650abdbfc636d48500c3cd13281947b363f4c8da4f1fe42893'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.