### PR TITLE
Update vivaldi-snapshot to 1.14.1077.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1072.3'
-  sha256 '345849e24bd6cd14d67f02f243b2eda50e69477f0df0d6d4a6028da64ef52f39'
+  version '1.14.1077.3'
+  sha256 '08f61ac07478917bc64ab3cd98ad7920d451ad5d7a241a913704b99e586173ac'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '50be3002ffd6487f1b547d7ec659f5cfb15866101029bd7c677a97fdbe9b6f53'
+          checkpoint: '73290226316713b2ce519f89dda1039e97c7c89d759aa581c9b6ac5506ae2f67'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.