### PR TITLE
Update vivaldi-snapshot to 1.14.1077.25

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1077.3'
-  sha256 '08f61ac07478917bc64ab3cd98ad7920d451ad5d7a241a913704b99e586173ac'
+  version '1.14.1077.25'
+  sha256 'e60727eb9ab5c954d3debc488e77ff5f3ecbee66e48f93f629d754783ee6038e'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '73290226316713b2ce519f89dda1039e97c7c89d759aa581c9b6ac5506ae2f67'
+          checkpoint: 'a74ac7a93615a39d80cc6d4e784aad736fa68f70239cf37486368c1041ca9314'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.