### PR TITLE
Update opera-developer to 52.0.2845.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '52.0.2838.0'
-  sha256 '1fe19bb18c8e7c728204b8efa2f4bbf763605bd99e4052448881f650dbd94c25'
+  version '52.0.2845.0'
+  sha256 'a210c4dc56960d52b74dbc7496a8c89d336ee22b8c62c8706dcef22cc59e25d2'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.