### PR TITLE
Update firefox-nightly to 60.0a1

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -1,5 +1,5 @@
 cask 'firefox-nightly' do
-  version '59.0a1'
+  version '60.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 
   language 'cs' do


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.