### PR TITLE
Update vivaldi-snapshot to 1.14.1077.37

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.14.1077.25'
-  sha256 'e60727eb9ab5c954d3debc488e77ff5f3ecbee66e48f93f629d754783ee6038e'
+  version '1.14.1077.37'
+  sha256 'f4e38954bf78b94379eb86cde3c592c14a1b90fd1830e51c931baee1ca4a1fea'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'a74ac7a93615a39d80cc6d4e784aad736fa68f70239cf37486368c1041ca9314'
+          checkpoint: '0d04728ee64577cc8bf764fafb027c155e1ff59742c8e53328e1145bbb8042c9'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.