### PR TITLE
Update telegram-alpha to 3.8-115830,871

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.7.5-115423,868'
-  sha256 'b029c3b4eaa7c0dcdd01d8ffa73af24207533d470eaf4d487f0faf1d79fd62e7'
+  version '3.8-115830,871'
+  sha256 '1c9fac90ae1df687d947bbf07e0b51aecad784e1f4387eaaf5dde4631d61bc8d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '15448409b6a031918aafb28ca0bd49eae7a5da55870fe151456035040a904240'
+          checkpoint: '2d232ad36fdb8464f431f097b3d6c3ec4a044f7108bf9a07826d64a80ef2e666'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.