### PR TITLE
Update rhinoceroswip to 5E397w

### DIFF
--- a/Casks/rhinoceroswip.rb
+++ b/Casks/rhinoceroswip.rb
@@ -1,11 +1,11 @@
 cask 'rhinoceroswip' do
-  version '5E374w'
-  sha256 'd17c1dd9b2ec7941f4567b69b5ee927c5bc2361c18b19ca4acec48572ab87490'
+  version '5E397w'
+  sha256 '783f0af684eff5adbea34afad2eb602a908c7fdbf0e7c2223f74025388cddfaa'
 
   # mcneel.com was verified as official when first introduced to the cask
   url "https://files.mcneel.com/Releases/Rhino/5.0/Mac/RhinoWIP_#{version}.dmg"
   appcast 'https://files.mcneel.com/rhino/5.0/mac/5CwipUpdates.xml',
-          checkpoint: '9adb7ec00ff79f831de8954eb4d0d3c87c69f287ee0cf694754825d60733637a'
+          checkpoint: 'ee6458f135585c7502e88415b506eaa2e91de3fc73fc263cab38eab1d4e7dc97'
   name 'Rhinoceros WIP'
   homepage 'https://www.rhino3d.com/download/rhino-for-mac/5/wip'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.