### PR TITLE
Update microsoft-remote-desktop-beta to 10.1.4.850,163

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.1.3.843,160'
-  sha256 'f9503d3e05e3d0b2cce29c0f368a0794dd7208e01a4203856c2f5d979718ceb8'
+  version '10.1.4.850,163'
+  sha256 'f1f55998ebfa73f49787fdfcbdb098a9a7239dafafff37bfc48f203abee87fd2'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: '1af6733ab27c76ea0c80d4ee72d1959397009e65b368357dd8a334e4ca926f2f'
+          checkpoint: '1e18257d9dbd3b425f020b027b24c587f9c35b6cd26c096f62054f8dc339bc4c'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.