### PR TITLE
Update kap-beta to 2.0.0-beta.6

### DIFF
--- a/Casks/kap-beta.rb
+++ b/Casks/kap-beta.rb
@@ -1,11 +1,11 @@
 cask 'kap-beta' do
-  version '2.0.0-beta.5'
-  sha256 '046e4b0a863ad4a8d941f085b72a67060c6bbcfc46cefef34e6253e85ed74232'
+  version '2.0.0-beta.6'
+  sha256 '30ce520293c7c256a4a1c9e1a2e7571bba4e80891ef202f815e2f8ff0976e634'
 
   # github.com/wulkano/kap was verified as official when first introduced to the cask
   url "https://github.com/wulkano/kap/releases/download/v#{version}/kap-beta-#{version}.dmg"
   appcast 'https://github.com/wulkano/kap/releases.atom',
-          checkpoint: '8522eff5137c8a60569737e790072d0db8acf886778f57836cc5e1a96dcb0735'
+          checkpoint: 'de20087c95aa10dc858c9dfe525571a1e8937665bfc5d2bfdae97bd0a1b6526f'
   name 'Kap Beta'
   homepage 'https://getkap.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.