### PR TITLE
Update airmail-beta to 3.5.5.471,331

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.3.470,330'
-  sha256 '8e0a8a04fb847cd776ceea091f4590ae329c0c0f46263bab5e806a4b77a690c9'
+  version '3.5.5.471,331'
+  sha256 '2714ac87ab3a6dcc0257798bfdac6f55dc786a02b5e36216a19122264c325715'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '927870a2955df6be50868b295c756ce4dde3196aeb9ddcfb98f18c41d4429a62'
+          checkpoint: '05378d3243a606190d5a5a55c93bde864f1036a3352122c590093868f006ecf1'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.