### PR TITLE
Update mongodb-compass-beta to 1.12.0-beta.1

### DIFF
--- a/Casks/mongodb-compass-beta.rb
+++ b/Casks/mongodb-compass-beta.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-beta' do
-  version '1.9.0-beta.2'
-  sha256 '7d4a213efb4e9b7b29d5f556c09109b2c236d3a82b7394ab209ef6404935c81b'
+  version '1.12.0-beta.1'
+  sha256 '55f757c35fda1f953f360dad003fa266bd3cf9b7fcdd9d734362431b52d068bb'
 
   url "https://downloads.mongodb.com/compass/beta/mongodb-compass-#{version}-darwin-x64.dmg"
   name 'MongoDB Compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.