### PR TITLE
update lilypond-dev to 2.19.81-1

### DIFF
--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -1,9 +1,8 @@
 cask 'lilypond-dev' do
-  version '2.19.80-1'
-  sha256 'c73e4f9856b94a3ea760634ec3829f87495d4c392af95889a584987fe6260a38'
+  version '2.19.81-1'
+  sha256 'eeaadb688710fddd6f40389127b9cfaacf9dcbf6205cc763e5a615956e9159be'
 
-  # linuxaudio.org/lilypond was verified as official when first introduced to the cask
-  url "https://download.linuxaudio.org/lilypond/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
+  url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   name 'LilyPond'
   homepage 'http://lilypond.org/'
 


### PR DESCRIPTION
It also fixes a broken download link after a server change.

according to Karl High (developer mailing list) :

> Changes to servers have things disturbed just now, I understand.

download.linuxaudio.org doesn't host the binaries at the moment.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
