### PR TITLE
Update toggl-beta to 7.4.111

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggl-beta' do
-  version '7.4.91'
-  sha256 'db15819a99fc8df8eeb797ec3d2f0ef424a69d90a1a088cc62314858e03edb28'
+  version '7.4.111'
+  sha256 'd40f458b784bf9ab625135f93287c3c9e8095d275e63fb9adc3c52deb30a9e34'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: 'e8c237f002835fd7d03a39f0d84052d24d3b5186238385e5b6d38d20638b2adc'
+          checkpoint: '49d04d5cd8de4a761c6c5ecbfead65c67b687c91782e822a84bae6d22c8f207a'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.