### PR TITLE
Update sourcetree-beta to 2.7.1b2

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -1,11 +1,11 @@
 cask 'sourcetree-beta' do
-  version '2.7.1b1'
-  sha256 'f2f81748ac3b26a62a873332821d08a79df0a6eae4df3905f122733181357891'
+  version '2.7.1b2'
+  sha256 '9e47203f4c189001767bebb81164aa5a91ea7c9ab516cef7d496c649c22d51f3'
 
   # atlassian.com was verified as official when first introduced to the cask
   url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
   appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastBeta.xml',
-          checkpoint: 'dc6c64e9d5d966445152499b122becd0c70d9bead1369f5e733f2edc0928f887'
+          checkpoint: 'eea664192d72a882674bb8c820fb0af2fd80e2b3c521f7341a442fceb3b79bb4'
   name 'Atlassian SourceTree'
   homepage 'https://www.sourcetreeapp.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.