### PR TITLE
Update telegram-alpha to 3.8-116129,891

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-115962,885'
-  sha256 '5617b3c7cf9372be8b2f18610ef2f578d5937392e3e79aad44c821bd918e310a'
+  version '3.8-116129,891'
+  sha256 '6e2bec72a777fef489a61984f3e1e7f278267b417027fd262fcb9ccc0c4d8010'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '4370c86409a1b286bba602ebe9841a9f152bbf322bbd3c6db87576a983f4f7aa'
+          checkpoint: '910a72b9c385655642bb40bb69631bf4008085efcf353afb5d629c8555cb4071'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.