### PR TITLE
Update palemoon to 27.7.2

### DIFF
--- a/Casks/palemoon.rb
+++ b/Casks/palemoon.rb
@@ -1,6 +1,6 @@
 cask 'palemoon' do
-  version '27.7.0'
-  sha256 'ec7049d57771fde31214ea9e87606184a44993aa3c1a1b912a4e144abcbcfbad'
+  version '27.7.2'
+  sha256 '7af4150b92112ee938cd94dc42e8708b5bf92e1dc85868242761758d9684e762'
 
   url "https://mac.palemoon.org/dist/palemoon-#{version}.mac64.dmg"
   name 'Palemoon'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.