### PR TITLE
Update toggl-dev to 7.4.118

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.113'
-  sha256 'd5f1a69b14e9d80ef94186961aa8ff3830b0e93f3691ec3cdaae0228e7418ab0'
+  version '7.4.118'
+  sha256 '4e7a4d15e20579279e803091610e95cfcf6388f91ef59801f80f09fb7ac2bbf8'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '405fef1455a664a389ebf3861d25a490c0a71d092a27ee643c4726dbcedb0898'
+          checkpoint: '41503327ef3b7fb4c0fa9f92dac5c61f5b3a31a9b949438ca408e3c787c1c615'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.