### PR TITLE
Update telegram-alpha to 3.8-116444,892

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116129,891'
-  sha256 '6e2bec72a777fef489a61984f3e1e7f278267b417027fd262fcb9ccc0c4d8010'
+  version '3.8-116444,892'
+  sha256 'e81348544af824f6dc37862df0ced582364847c84864d162d5ebd02078e5fff9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '910a72b9c385655642bb40bb69631bf4008085efcf353afb5d629c8555cb4071'
+          checkpoint: '0592bc8467a4210e17fc4c006b92364ea3e24c0b7f9c506cd571da3a69010c56'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.