### PR TITLE
Add ableton-live-lite v9.7.5 (latest is 10.x)

### DIFF
--- a/Casks/ableton-live-lite9.rb
+++ b/Casks/ableton-live-lite9.rb
@@ -1,0 +1,10 @@
+cask 'ableton-live-lite9' do
+  version '9.7.5'
+  sha256 'c91876c86e06717c86b4e1df7168c9916c789a7e0eb2ea2d43fec3abe892c183'
+
+  url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
+  name 'Ableton Live Lite'
+  homepage 'https://www.ableton.com/en/products/live-lite/'
+
+  app "Ableton Live #{version.major} Lite.app"
+end


### PR DESCRIPTION
* Include the latest minor version of legacy versions of commercial and freemium software.

9.x licenses don't fit for 10.x, and I have 9.x license, as others do, I bet

Migrated from https://github.com/caskroom/homebrew-cask/blob/a3efac733c26d96fdddb03e3359c9cd8d33fe065/Casks/ableton-live-lite.rb

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
