### PR TITLE
Update opera-beta to 51.0.2830.23

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '51.0.2830.16'
-  sha256 '4a12fafa8ee10e5d7d46e34206c7db8734a0eb5bc1474c6378c40127410b7a74'
+  version '51.0.2830.23'
+  sha256 '7c120ad2f47abb030a82aaef59a9384720b0103b78a2f831e3e92ef24a3b38be'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.