### PR TITLE
Update telegram-alpha to 3.8-116597,893

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116444,892'
-  sha256 'e81348544af824f6dc37862df0ced582364847c84864d162d5ebd02078e5fff9'
+  version '3.8-116597,893'
+  sha256 '962b06d3b48c3dddfa6137c07088bc353baa5f1f05a613f450a2f8621c1bfead'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '0592bc8467a4210e17fc4c006b92364ea3e24c0b7f9c506cd571da3a69010c56'
+          checkpoint: 'e16ef8bc18c9688a45d4d5ee93ae7d47c0349f6f96c0a8173183650da1e9c460'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.