### PR TITLE
Update telegram-alpha to 3.8-116685,896

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116648,895'
-  sha256 'c15dce97fc750d8ebef7151c0b3e88edf71edc55a5535d6017e19f48a600cf7a'
+  version '3.8-116685,896'
+  sha256 '642e0c718621d83f46d7b5a73b9351311b440b8fa38744ad380df9829699ee3c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'cb520f620b70647e0bac9d4cb6f14119b353608a545a11554c24eb46088852b6'
+          checkpoint: '11d5fff5c5cd76a3d2a838087694a8e24cff88edeee427885cde98b888614c78'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.