### PR TITLE
Update telegram-alpha to 3.8-116733,897

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116685,896'
-  sha256 '642e0c718621d83f46d7b5a73b9351311b440b8fa38744ad380df9829699ee3c'
+  version '3.8-116733,897'
+  sha256 '1fdf99003e3363683aa4cd30c5b2a56528f877f87e41d2e9c97c65c35f443a06'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '11d5fff5c5cd76a3d2a838087694a8e24cff88edeee427885cde98b888614c78'
+          checkpoint: 'ec9da4771796bbcd2f7f798adc8d32ceef8e7d763ebdeb703614bcc66711354e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.