### PR TITLE
Update safari-technology-preview: auto_updates true

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -12,8 +12,8 @@ cask 'safari-technology-preview' do
   name 'Safari Technology Preview'
   homepage 'https://developer.apple.com/safari/download/'
 
-  depends_on macos: '>= :sierra'
   auto_updates true
+  depends_on macos: '>= :sierra'
 
   pkg 'Safari Technology Preview.pkg'
 

--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -13,6 +13,7 @@ cask 'safari-technology-preview' do
   homepage 'https://developer.apple.com/safari/download/'
 
   depends_on macos: '>= :sierra'
+  auto_updates true
 
   pkg 'Safari Technology Preview.pkg'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Safari Technology Preview is automatically updated in the Mac App Store.
