### PR TITLE
Update telegram-alpha to 3.8-116795,898

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116733,897'
-  sha256 '1fdf99003e3363683aa4cd30c5b2a56528f877f87e41d2e9c97c65c35f443a06'
+  version '3.8-116795,898'
+  sha256 '9e0385cf3ab0140a4f52454cfb75ee516e2a39966f42f0871dae8c0fd9958544'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'ec9da4771796bbcd2f7f798adc8d32ceef8e7d763ebdeb703614bcc66711354e'
+          checkpoint: '19a8c4a553961cef5df4cd6da104fa4aa5092664afa39c115479a1ab3708a20d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.