### PR TITLE
Update telegram-alpha to 3.8-116848,900

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-116795,898'
-  sha256 '9e0385cf3ab0140a4f52454cfb75ee516e2a39966f42f0871dae8c0fd9958544'
+  version '3.8-116848,900'
+  sha256 'aa2fd80f2aac86cd8ac7cd13310b3a2e814a8a3b60f521f6d24d0159c22a83d7'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '19a8c4a553961cef5df4cd6da104fa4aa5092664afa39c115479a1ab3708a20d'
+          checkpoint: 'e938403d2ee5dd0d2a9869bb6d00efdddee5830e59c26c7d38d58bf5206daa37'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.