### PR TITLE
Update toggl-dev to 7.4.120

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.118'
-  sha256 '4e7a4d15e20579279e803091610e95cfcf6388f91ef59801f80f09fb7ac2bbf8'
+  version '7.4.120'
+  sha256 'c4b04e94172ba96231aadb796f232543f8c669c9f7e63269bccc4365659b5b11'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '41503327ef3b7fb4c0fa9f92dac5c61f5b3a31a9b949438ca408e3c787c1c615'
+          checkpoint: 'a463e6382bd18de52a9610a3d7d01f067dfd04d9f7ed7dafef1173f2982e19dc'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.