### PR TITLE
Update toggl-dev to 7.4.122

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.120'
-  sha256 'c4b04e94172ba96231aadb796f232543f8c669c9f7e63269bccc4365659b5b11'
+  version '7.4.122'
+  sha256 'f22d8cc92b0e5546e0b2bd47ee00fb6f92469553b7155e05db91336da7e56987'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'a463e6382bd18de52a9610a3d7d01f067dfd04d9f7ed7dafef1173f2982e19dc'
+          checkpoint: '48aedca1b7a7b28aa56681c2ccb343af38829debb0408dcd44538b443a794b01'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.