### PR TITLE
Update iterm2-beta to 3.1.6beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.6beta2'
-  sha256 '308913aa20c96e9cc04fd40ba18889a0c485d7b254dfc081d67c6dbf2bbbb328'
+  version '3.1.6beta3'
+  sha256 '92f84974eff399079d1116af20488a45222f0555fbd8e10433215056ed91f42f'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '7d0995667320d6deba73d81017fa3f59c47f6592031c198e3999cc50c0863d1c'
+          checkpoint: 'f25f7e2ff4c763b365c1ea36ce435a96a8e1882876d002586394cad4e1e37352'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.