### PR TITLE
Add Cask for ctop 0.7

### DIFF
--- a/Casks/ctop.rb
+++ b/Casks/ctop.rb
@@ -1,0 +1,10 @@
+cask 'ctop' do
+  version '0.7'
+  sha256 '2106270f60b7b4774eef4eee05a84a5e3a733077730788840f74d323934c8d0e'
+
+  url 'https://github.com/bcicen/ctop/releases/download/v0.7/ctop-0.7-darwin-amd64'
+  name 'ctop'
+  homepage 'https://ctop.sh/'
+
+  binary 'ctop-0.7-darwin-amd64', target: 'ctop'
+end


### PR DESCRIPTION
https://ctop.sh/

I've been using my own tap, but the owner of the project also thinks it's interesting to have it here on the official repos.
https://github.com/bcicen/ctop/pull/118

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
