### PR TITLE
Update telegram-alpha to 3.8-117477,910

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117344,908'
-  sha256 '126051a48e7d5e087271d9df4db23c88b319364bad19dc1b6879edd31f6da840'
+  version '3.8-117477,910'
+  sha256 '10923301cadff1e4be62b8556b2546409d0e40e2aa123a8be67b2b7d0a236c63'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c94d63c21938b6c0064a9b71864943d68214c4a02bcd6a541a90820b8e1add8b'
+          checkpoint: '085df82a34e2f88b29169b0296b098dac0281a1b4d32eef547c8a54fbd1c8285'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.