### PR TITLE
Update telegram-alpha to 3.8-117508,911

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117477,910'
-  sha256 '10923301cadff1e4be62b8556b2546409d0e40e2aa123a8be67b2b7d0a236c63'
+  version '3.8-117508,911'
+  sha256 'b73191569e9f61b32ac67854741c986ab19bd002e0dd8b880cd9201cb161761f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '085df82a34e2f88b29169b0296b098dac0281a1b4d32eef547c8a54fbd1c8285'
+          checkpoint: '6e1fe69a2ea9786fd465da6ef9cfaaa19a97d82a035bd07b9a7fc03cf4c0b0ca'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.