### PR TITLE
Update telegram-alpha to 3.8-117541,913

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117508,911'
-  sha256 'b73191569e9f61b32ac67854741c986ab19bd002e0dd8b880cd9201cb161761f'
+  version '3.8-117541,913'
+  sha256 '7ce65fbda311411b9e490217ef30765016e19b3fd872795d6191953dfece7339'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6e1fe69a2ea9786fd465da6ef9cfaaa19a97d82a035bd07b9a7fc03cf4c0b0ca'
+          checkpoint: '548a20373a65718fe9efbd91ebdcc3fbd8015953f09047a90acf61b9b5ed9875'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.