### PR TITLE
Update vivaldi-snapshot to 1.15.1099.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1090.3'
-  sha256 '9e4c66a61da12d850d785f6e7c07fe2dd52d005c7fff219f57ff08e8d86b5f06'
+  version '1.15.1099.3'
+  sha256 '790356fcad6bedd36c7448e3b57c6241b5ea541e9039ed8b19fc31a3697e0b79'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'a79e655079a18df612220284cc3aec92522211e9fc811bdac4477b116806e65a'
+          checkpoint: '5e743ed50161def8f93d72b80f2fde84629683b091273fac6c2c22d6fa85f9a7'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.