### PR TITLE
Update telegram-alpha to 3.8-117766,916

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117736,915'
-  sha256 '8f164cde5aaa95f364f685b727de81bf69354b8be669d776aba9a2f96f638fd8'
+  version '3.8-117766,916'
+  sha256 '6058fbff21228ebb2eaa99580a0a605a375986f6decf7043f1d78646e4298cc6'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '679ef3bafa379d46fc8b31ecf315d0f55421abf715362ffc03fafb4003c16627'
+          checkpoint: 'f6fe52db085ac0b8d52e8a7c50c917ba8534d8a115a886f7ac6a0ffa9067cec3'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.