### PR TITLE
Update telegram-alpha to 3.8-117849,917

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117766,916'
-  sha256 '6058fbff21228ebb2eaa99580a0a605a375986f6decf7043f1d78646e4298cc6'
+  version '3.8-117849,917'
+  sha256 'e4b7960110f8f6e0abf4ce4b3bad3d15dc7acedf535b065312c4f4591efaec8d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f6fe52db085ac0b8d52e8a7c50c917ba8534d8a115a886f7ac6a0ffa9067cec3'
+          checkpoint: '258e8680ea89d0e6b1ba85f08793d64348439354c6003de9fcd2ff8a62386b44'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.