### PR TITLE
Update telegram-alpha to 3.8-117850,918

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117849,917'
-  sha256 'e4b7960110f8f6e0abf4ce4b3bad3d15dc7acedf535b065312c4f4591efaec8d'
+  version '3.8-117850,918'
+  sha256 '957b989a52c1868840dcd1c2f0fb072ef2171f03271089c9b3f77a1aec3b9b35'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '258e8680ea89d0e6b1ba85f08793d64348439354c6003de9fcd2ff8a62386b44'
+          checkpoint: '73b868c189f2dfe0f5fd8c0df9ff1b2dfb8e2496da852a1be4bc53f0b75beac2'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.