### PR TITLE
Update toggl-dev to 7.4.123

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.122'
-  sha256 'f22d8cc92b0e5546e0b2bd47ee00fb6f92469553b7155e05db91336da7e56987'
+  version '7.4.123'
+  sha256 'db10b8e16c4d24337d3a6dd59b8b9be48dc32de1dc232ec7d08aba1182a68122'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '48aedca1b7a7b28aa56681c2ccb343af38829debb0408dcd44538b443a794b01'
+          checkpoint: '2f80345ffeefd8a915f9d6b1a783e55f750673d6afb02f7d374965e67371f08a'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.