### PR TITLE
Update toggl-dev to 7.4.124

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.123'
-  sha256 'db10b8e16c4d24337d3a6dd59b8b9be48dc32de1dc232ec7d08aba1182a68122'
+  version '7.4.124'
+  sha256 '2066f173a2e5899c39447a3c79ad4790021a162a58a76c30ea3db0ae03519bb5'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '2f80345ffeefd8a915f9d6b1a783e55f750673d6afb02f7d374965e67371f08a'
+          checkpoint: '4145d3abde3b84d5a5eb6367418d02ad6993bf94cc876bacd3408c252f9e0d83'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.