### PR TITLE
Update telegram-alpha to 3.8-117979,921

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117945,919'
-  sha256 '33084e21345f46125f8bcc6cdaf3da843d17b1fc4ce8865107d8ecc053faf2a9'
+  version '3.8-117979,921'
+  sha256 '209401ba40507eac5a838e470930c77bdae907bc5350f486bd06f8ae0956e62f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '15171e7bc11c098e73b01f378f6518d45c3abfa0f261a8e6eab61c1c2f29eb2b'
+          checkpoint: 'a74291169a899ab6ed1f77d943891c6639877b02df637fdbd671835af62b6318'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.