### PR TITLE
Update toggl-dev to 7.4.127

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.124'
-  sha256 '2066f173a2e5899c39447a3c79ad4790021a162a58a76c30ea3db0ae03519bb5'
+  version '7.4.127'
+  sha256 '525844e56035038274033e57c4e3f245a508cf833fd329e857b1a2221d859b97'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '4145d3abde3b84d5a5eb6367418d02ad6993bf94cc876bacd3408c252f9e0d83'
+          checkpoint: '7a55c7d00cb8a46b0760311ce8d516a1f025bdab266680cbf082315c2b3ef82b'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.