### PR TITLE
Update telegram-alpha to 3.8-118079,923

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-117962,920'
-  sha256 '42fbfb59015bc89a99ddac6daba584ddcf0b00cca961000dd6359047dfcb1c81'
+  version '3.8-118079,923'
+  sha256 '4fc503138f6b73290d9cddbd04b793f1465ce65d3872c92cb258987befe2bedc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '60aad91b45c0ade55fab326d75c952456c4f3069bb8ca360e93e276ad5074fec'
+          checkpoint: '55bedc8c210db691a28aa1cb8394ad3b3670303763803311aebb4aec581deb96'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.