### PR TITLE
Update telegram-alpha to 3.8-118095,924

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118079,923'
-  sha256 '4fc503138f6b73290d9cddbd04b793f1465ce65d3872c92cb258987befe2bedc'
+  version '3.8-118095,924'
+  sha256 'b51e45e8047a5f7795cd8d2ed89813c0b4ca17aec4df96f4ede0438058be6561'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '55bedc8c210db691a28aa1cb8394ad3b3670303763803311aebb4aec581deb96'
+          checkpoint: '91053f4e3855981b7301b7ed30da4595249d447b751405ed2af819d48a9755cd'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.