### PR TITLE
Add Ableton Live Standard v9.7.5

### DIFF
--- a/Casks/ableton-live-standard9.rb
+++ b/Casks/ableton-live-standard9.rb
@@ -1,0 +1,13 @@
+cask 'ableton-live-standard9' do
+  version '9.7.5'
+  sha256 'db7953c5f3fa52c331c7186e97b70d0d22d269a02ed054014025b2ddde72d130'
+
+  url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
+  name 'Ableton Live 9 Standard'
+  homepage 'https://www.ableton.com/en/live/'
+
+  app "Ableton Live #{version.major} Standard.app"
+
+  zap trash: '~/Library/*/*[Aa]bleton*',
+      rmdir: '~/Music/Ableton/Factory Packs'
+end


### PR DESCRIPTION
Legacy install formula for Ableton Live 9 Standard, specifically
version 9.7.5 (latest stable of version 9)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
