### PR TITLE
Update safari-technology-preview to 50

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '49'
+  version '50'
 
   if MacOS.version == :sierra
-    sha256 '3b3e42412a3ba6328586b66600c05c7079f970206d0282cf903c1df7415deecd'
-    url 'https://secure-appldnld.apple.com/STP/091-68519-2018-02-7-670EB77C-DB92-11E7-A17C-A4421C5E62D6/SafariTechnologyPreview.dmg'
+    sha256 '26531536867de15e86605eae5561378a578c7844a6f417a01a0a5e23788b7668'
+    url 'https://secure-appldnld.apple.com/STP/091-68522-20180220-16E14EBA-15EB-11E8-9B12-3B4DC5C276A0/SafariTechnologyPreview.dmg'
   else
-    sha256 '3dd26a10a8b1101449acb1376aafe93a8bc95d53794fcd4d6ea7a54ee44b15c9'
-    url 'https://secure-appldnld.apple.com/STP/091-68516-2018-02-7-670EB77C-DB91-11E7-A17C-A4421C5E62D6/SafariTechnologyPreview.dmg'
+    sha256 '30b8777d1eda4fec8ecd7927d29e8f3daf277c437e9e85a82cf939955faaed49'
+    url 'https://secure-appldnld.apple.com/STP/091-68523-20180220-16E16C74-15EB-11E8-A84A-3A4DC5C276A0/SafariTechnologyPreview.dmg'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.