### PR TITLE
Update vivaldi-snapshot to 1.15.1104.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1099.3'
-  sha256 '790356fcad6bedd36c7448e3b57c6241b5ea541e9039ed8b19fc31a3697e0b79'
+  version '1.15.1104.3'
+  sha256 '45c204a37ee31f57bfba5f6f3dc7054bd4d1c3831d98fc8696d37f2fc6ad4379'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '5e743ed50161def8f93d72b80f2fde84629683b091273fac6c2c22d6fa85f9a7'
+          checkpoint: '0db1cc77ea71c1724254ffa049c33a1660b7990e4ac2c4960895ad585a14d0a2'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.