### PR TITLE
Update telegram-alpha to 3.8-118201,925

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118095,924'
-  sha256 'b51e45e8047a5f7795cd8d2ed89813c0b4ca17aec4df96f4ede0438058be6561'
+  version '3.8-118201,925'
+  sha256 '6b5673baa3ca871c2e94e0477737c55fb839b4032d83799ef8b24a777a0ab1ce'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '91053f4e3855981b7301b7ed30da4595249d447b751405ed2af819d48a9755cd'
+          checkpoint: '75a66a8d7cda5af0f40c8b9a655ab8215b4342bba37fdb8efef85d4ddc0861ce'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.