### PR TITLE
Update telegram-alpha to 3.8-118357,927

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118201,925'
-  sha256 '6b5673baa3ca871c2e94e0477737c55fb839b4032d83799ef8b24a777a0ab1ce'
+  version '3.8-118357,927'
+  sha256 'cf2206a46af3d321abcf70dc4ef1e2cc7a6f857581d0b2f7326b51c6209b0c9e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '75a66a8d7cda5af0f40c8b9a655ab8215b4342bba37fdb8efef85d4ddc0861ce'
+          checkpoint: '680a6ad833ab5c9691fb436101a709f8884c15ceee90aa90c54f1b3dfbeb53ae'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.