### PR TITLE
Update telegram-alpha to 3.8-118397,928

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118357,927'
-  sha256 'cf2206a46af3d321abcf70dc4ef1e2cc7a6f857581d0b2f7326b51c6209b0c9e'
+  version '3.8-118397,928'
+  sha256 'd6d59c29cfd2ed16b836ca1d73215c223c26091b6601621031e9c8a8088113a6'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '680a6ad833ab5c9691fb436101a709f8884c15ceee90aa90c54f1b3dfbeb53ae'
+          checkpoint: 'f6a0da5e7c3c8979dbebfe2b6ef66b081356ac88f6023de50c598be2fd19b572'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.