### PR TITLE
Update toggl-beta to 7.4.129

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggl-beta' do
-  version '7.4.122'
-  sha256 'f22d8cc92b0e5546e0b2bd47ee00fb6f92469553b7155e05db91336da7e56987'
+  version '7.4.129'
+  sha256 '1eb1f0dc3baed9e293040f9e77946c055376339802f967beb1266f8e8bfe22c2'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: 'bcba302dde3b18f09de12b829c801637bbe3764662f3879a41649bd2c5e24aad'
+          checkpoint: '3966ec4cc86a430fec8d9bcce3bbf3890b20ec90db238151062793e56b8d4457'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.