### PR TITLE
Update telegram-alpha to 3.8-118440,930

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118397,928'
-  sha256 'd6d59c29cfd2ed16b836ca1d73215c223c26091b6601621031e9c8a8088113a6'
+  version '3.8-118440,930'
+  sha256 'e7946d4b3c24d07c157455937806e0fe24ec018384026bfc92f8bba8f292d1ac'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f6a0da5e7c3c8979dbebfe2b6ef66b081356ac88f6023de50c598be2fd19b572'
+          checkpoint: 'df72cd39d0edc83d3c0b25f2dbf7e1dc63707d945606f0b04db052e4147e7023'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.