### PR TITLE
Update torbrowser-alpha to 8.0a2

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,10 +1,10 @@
 cask 'torbrowser-alpha' do
-  version '8.0a1'
-  sha256 '2bdb4ad18a986847c619a3cbb3eabc72cc32aca3329c1813476c78b8b8c3efa0'
+  version '8.0a2'
+  sha256 'd881ae553b9be6bfa55127f705f5a033af5b253f7d58eb0eeb5323e7460af7b0'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: 'f1f3e429dfab01a5e9bc2ca7e4751ad43c9117f85202eef57c15e1364476368a'
+          checkpoint: 'f7937fd99238ad8667e70179f2b2634e5940d5b441edbe7fd1ad5029defb581d'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.