### PR TITLE
Update microsoft-remote-desktop-beta to 10.1.5.866,167

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.1.4.859,164'
-  sha256 '0539ac7b0bb40601222db62f105f73d2f73ba0bd8c53e5a687525a91b046f13d'
+  version '10.1.5.866,167'
+  sha256 '481d889c56b969a5e9cceddfb5d1da2d597b0c6c600448b64c15835baf46cc29'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'a6bdb455e2edd89d1ae81b9bb3ff86a87957de6a6177fa41128fd7ca7cd7e7dc'
+          checkpoint: '9524958ee4b1722389c066544d0158344a5cc4ebbd3ae6615f0d7f001609ce3d'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.