### PR TITLE
Update julia-nightly to 0.7

### DIFF
--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,16 +1,15 @@
 cask 'julia-nightly' do
-  version '0.7.0-448acca718'
-  sha256 'bf862dbb9bd69058f0bab8f9eb4f283b1ac7b47babdb1992ccfc457451513f28'
+  version '0.7.0-e4b6677561'
+  sha256 '8065e24f0a5292d0a26b9ea4ca50de623960450b69bdc1888b041ae73c8956a2'
 
-  # amazonaws.com/julianightlies was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/julianightlies/bin/osx/x64/#{version.sub(%r{(\d+\.\d+).*}, '\1')}/julia-#{version}-osx.dmg"
+  url 'https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.dmg'
   name 'Julia'
   homepage 'https://julialang.org/'
 
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :mountain_lion'
 
-  app "Julia-#{version.sub(%r{(.+)-(.+)}, '\1-dev-\2')}.app"
-  binary "#{appdir}/Julia-#{version.sub(%r{(.+)-(.+)}, '\1-dev-\2')}.app/Contents/Resources/julia/bin/julia"
+  app "Julia-#{version.sub(%r{(.+)-(.+)}, '\1-DEV-\2')}.app"
+  binary "#{appdir}/Julia-#{version.sub(%r{(.+)-(.+)}, '\1-DEV-\2')}.app/Contents/Resources/julia/bin/julia"
 
   zap trash: '~/.julia'
 end

--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,6 +1,6 @@
 cask 'julia-nightly' do
-  version '0.7.0-e4b6677561'
-  sha256 '8065e24f0a5292d0a26b9ea4ca50de623960450b69bdc1888b041ae73c8956a2'
+  version '0.7'
+  sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.dmg'
   name 'Julia'
@@ -8,8 +8,8 @@ cask 'julia-nightly' do
 
   depends_on macos: '>= :mountain_lion'
 
-  app "Julia-#{version.sub(%r{(.+)-(.+)}, '\1-DEV-\2')}.app"
-  binary "#{appdir}/Julia-#{version.sub(%r{(.+)-(.+)}, '\1-DEV-\2')}.app/Contents/Resources/julia/bin/julia"
+  app "Julia-#{version}.app"
+  binary "#{appdir}/Julia-#{version}.app/Contents/Resources/julia/bin/julia"
 
   zap trash: '~/.julia'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.