### PR TITLE
Update wine-devel to 3.2

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,10 +1,10 @@
 cask 'wine-devel' do
-  version '3.1'
-  sha256 '7256078fd7038ab1aa242b34a7621a86b8d2201c7dd6b1a1899c3cb65f080aeb'
+  version '3.2'
+  sha256 '8ae6a59b9477f93e6e2eeb23b8a17d5e1ea6ee9210ac31930be594f7b359663b'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html',
-          checkpoint: '17b0c429114cfbc45ed511ee975bf76a595bd00a0d05f2e1cbb6240a5c59fcfc'
+          checkpoint: '549252455e03a1b5e159c67a2133a57823fec1201bbb88bf8b2b70bf9b486095'
   name 'WineHQ-devel'
   homepage 'https://wiki.winehq.org/MacOS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.