### PR TITLE
Update airmail-beta to 3.5.5.475,335

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.473,333'
-  sha256 '184014dda4c58e78deb2f00941639125fb4b2d738d4b2827fd77b90a1aa7b9ff'
+  version '3.5.5.475,335'
+  sha256 '4567574f44b8fed50146e050b51ee1df7dd9937ad2e2916aa217dfcdf7d1304a'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '2994501505a820be5337f90a98f40534aad7951ca43d13568a6ce4d50317f746'
+          checkpoint: '8d3cd96f4bd0cc8747a9ebe3cfd6c7ff5889dd37b26986d662075dabc8bb28aa'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.