### PR TITLE
Update telegram-alpha to 3.8-118562,931

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118440,930'
-  sha256 'e7946d4b3c24d07c157455937806e0fe24ec018384026bfc92f8bba8f292d1ac'
+  version '3.8-118562,931'
+  sha256 '1ae6e743770c9c61f293160af73a23775b4c1591cdecdaa3d61f06b3d784f8bd'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'df72cd39d0edc83d3c0b25f2dbf7e1dc63707d945606f0b04db052e4147e7023'
+          checkpoint: '9d727ab78f2a7629e126e3d7d05c856ad32dfd3fd3d1361f9ca564f8b7d29f06'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.