### PR TITLE
Update electron-beta to 2.0.0-beta.1

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '1.8.2-beta.4'
-  sha256 'cb554483b0435678c207129c37fdd52890751c7d2cd92ddecdf1d6d582100f71'
+  version '2.0.0-beta.1'
+  sha256 '47a2fbc513aaca863b6dcadbe27cad642cd2611ffaac1795687564c92f989fa6'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '1663d8c295eff9997dd88d7e2eba80580fd47a0b5e054a97d58ae5d789ed9f29'
+          checkpoint: 'd5dc63ab8e0f31f0f538f07aec28c70fa78673b7b0a840c7739c70ad189504a9'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.