### PR TITLE
Update telegram-alpha to 3.8-118601,932

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118562,931'
-  sha256 '1ae6e743770c9c61f293160af73a23775b4c1591cdecdaa3d61f06b3d784f8bd'
+  version '3.8-118601,932'
+  sha256 'b1a83f67b9983ef6893ed7f77c5aaff34245a9364b122e39c232153a77a45196'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '9d727ab78f2a7629e126e3d7d05c856ad32dfd3fd3d1361f9ca564f8b7d29f06'
+          checkpoint: '85b0ba6409138881d9c0d42db17d1b47dae654f26a554598401b3897b59b936d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.