### PR TITLE
Update vivaldi-snapshot to 1.15.1111.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1104.3'
-  sha256 '45c204a37ee31f57bfba5f6f3dc7054bd4d1c3831d98fc8696d37f2fc6ad4379'
+  version '1.15.1111.3'
+  sha256 '1d9697ac6321fac39383cad5c3d5ab1e52cb13eb69cdb31a7c129833c0401649'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '0db1cc77ea71c1724254ffa049c33a1660b7990e4ac2c4960895ad585a14d0a2'
+          checkpoint: 'c3f04830fad8ff5d0168aa69bfd8ea5c2a74291e7958066040d1212ed5af716f'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.