### PR TITLE
Update telegram-alpha to 3.8-118627,933

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118601,932'
-  sha256 'b1a83f67b9983ef6893ed7f77c5aaff34245a9364b122e39c232153a77a45196'
+  version '3.8-118627,933'
+  sha256 '8eeee85f7c16eabab1ce745422b656217dfda56f41dd772365516b7d13fd903d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '85b0ba6409138881d9c0d42db17d1b47dae654f26a554598401b3897b59b936d'
+          checkpoint: '8d6f4b86e887547995c328c9c968b3647828e04f5b41a34bfd84ffa48f4ff913'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.