### PR TITLE
Update telegram-alpha to 3.8-118737,936

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118640,934'
-  sha256 '21f236dc1f3541fd88f778d019e4954f28440e5c9b1a95126b8295f848a99370'
+  version '3.8-118737,936'
+  sha256 'aadf519a8fc9edda9babce328cb14c34cb7d047e22af219b7985133c2297cfae'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a191a38900c228ae72dfe290637b451f76f7c344fb713bfc82f854f2463d0ab9'
+          checkpoint: '95beb267f04bbe5c967fa2dc17d609cc238e0efee43fad6c2f37072556ff695b'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.