### PR TITLE
Update telegram-alpha to 3.8-118767,938

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118742,937'
-  sha256 '0b3de3dc5bc946c8430554f4ae8277d6db69a63ed23af1cdc329cc18d64ac22b'
+  version '3.8-118767,938'
+  sha256 '0c5dc07c2e7019b451ddc1cafb6e2979219740254f76a8ea0b5da0538a9c4b66'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bc233df86d36baecd86cf92c9720a6145db967a7f0b166b7f1d19154c3f53c96'
+          checkpoint: 'c784d0fa55e1452931fca9e66124bf0ef29aa9e29d7fc74aff8889bbbd7122b1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.