### PR TITLE
Update toggl-dev to 7.4.130

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.129'
-  sha256 '1eb1f0dc3baed9e293040f9e77946c055376339802f967beb1266f8e8bfe22c2'
+  version '7.4.130'
+  sha256 '8d75f2d18a4819749ef1c15b37006e83c826701df7559551be16b7c21d70d0db'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'cb9d1adb1e94ec516d3b4aba3e26c52ba530ac62f1c5204bf6db6c0941b73f11'
+          checkpoint: '2e0ce2e53e0cfe155e8cc67dc0d77d259aeb038afc4b34ff88f1ede3eb8b9c05'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.