### PR TITLE
Update exoduseden to 1.46.0

### DIFF
--- a/Casks/exoduseden.rb
+++ b/Casks/exoduseden.rb
@@ -1,6 +1,6 @@
 cask 'exoduseden' do
-  version '1.45.0'
-  sha256 'a37b7d9ef29cae21dfbe2530bb1603d970e26fd0cf6b9dc384852049e2ecb5bb'
+  version '1.46.0'
+  sha256 '78b2b62e39dd13c033ecf26bf49c992666fede685e4aef0f3a6f819f2b162222'
 
   # exodusbin.azureedge.net/releases was verified as official when first introduced to the cask
   url "https://exodusbin.azureedge.net/releases/exodus-eden-macos-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.