### PR TITLE
Update telegram-alpha to 3.8-118814,940

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118780,939'
-  sha256 '197d2ea367620b9ce59faebd24da804a57e3638c1b2f7a78e864b2b4806a8405'
+  version '3.8-118814,940'
+  sha256 'a44f69570baceb54286fa0443130b4e430abe8a4715626e88a5772ef7bb5784a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bdbf6e5a8502f271354637c5c19f171121fe33d1a16917b79a8985f38e8d9708'
+          checkpoint: '28a771394afeb58647c5ccddea101c0603ac67f3944b68a97be3b9a9bc1118ab'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.