### PR TITLE
Update telegram-alpha to 3.8-118820,941

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118814,940'
-  sha256 'a44f69570baceb54286fa0443130b4e430abe8a4715626e88a5772ef7bb5784a'
+  version '3.8-118820,941'
+  sha256 '0dff28c56525f4df3287182ace3ca0c8b7a69b801a200b7a7c88aaf1d8bcaa06'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '28a771394afeb58647c5ccddea101c0603ac67f3944b68a97be3b9a9bc1118ab'
+          checkpoint: 'fc34afd58e69c9038afc2732792effb068c72624658ab5ed28bced0d6c03a436'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.