### PR TITLE
Update opera-developer to 53.0.2885.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '53.0.2880.0'
-  sha256 '9c1f9fa5a866da9fc5086c53825f8e68428bd79515a837776308d4917875afc8'
+  version '53.0.2885.0'
+  sha256 'f2edc94cd1e59102151f8e29036d705266e4d1597b5d1f029357d080a73abbd8'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.