### PR TITLE
Update telegram-alpha to 3.8-118839,943

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118820,941'
-  sha256 '0dff28c56525f4df3287182ace3ca0c8b7a69b801a200b7a7c88aaf1d8bcaa06'
+  version '3.8-118839,943'
+  sha256 '9b0a7b67017d7f4db11f379c0946772108f6ce29f7faab2fe5839cc2abddd8e8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'fc34afd58e69c9038afc2732792effb068c72624658ab5ed28bced0d6c03a436'
+          checkpoint: '9f1d09562f6a429c9e8ef5bad03340a8b84b63564cf514d2648d65a935d9e679'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.