### PR TITLE
Update telegram-alpha to 3.8-118866,945

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118839,943'
-  sha256 '9b0a7b67017d7f4db11f379c0946772108f6ce29f7faab2fe5839cc2abddd8e8'
+  version '3.8-118866,945'
+  sha256 'd83d3d30a95b4bdee965e4d7561df50a87efdb8ab1ea7dbbd2536d52d1db5edd'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '9f1d09562f6a429c9e8ef5bad03340a8b84b63564cf514d2648d65a935d9e679'
+          checkpoint: '55bf5676ae96a47191cb9a9581173be9b71a2af38d228e2a2e3dd9b02b2148ee'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.