### PR TITLE
Update electron-beta to 2.0.0-beta.2

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '2.0.0-beta.1'
-  sha256 '47a2fbc513aaca863b6dcadbe27cad642cd2611ffaac1795687564c92f989fa6'
+  version '2.0.0-beta.2'
+  sha256 '66a44fa36dc9e5c0245d57cff27c9778c8c48f90af9b46c886551ba7decfe118'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: 'd5dc63ab8e0f31f0f538f07aec28c70fa78673b7b0a840c7739c70ad189504a9'
+          checkpoint: '407d4c29612dfe0f7196a6288063689cbb09cd763255001aff23c2203d078a59'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.