### PR TITLE
Update telegram-alpha to 3.8-118877,948

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118874,946'
-  sha256 '1254e56403da90ae79358af18512dcc949c52c9dd228b192c80c85f2125526f5'
+  version '3.8-118877,948'
+  sha256 'c7b301d9c0800a54e5bd56cec9700ee9ce2575c338c1bd64c28c7ee6ff0728d2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '27b7cb1561c7175929edabd0fb86f6230a645d2c7a58a8325f75862e86ca3c21'
+          checkpoint: '8247abfdfddc00c910e13f580a39d50bfa47859f63eeffda053701adde7f80b0'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.