### PR TITLE
Update telegram-alpha to 3.8-118941,955

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118914,951'
-  sha256 '1e44bdbef4586c126c5d760770d94fa4b0ae995db854adca8fde3c541ef7e6cb'
+  version '3.8-118941,955'
+  sha256 '722811fe4f7ddb00e7c3c699bd4c61c9d1f8828e7c6a2c82d4b45da3433663a2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '61daab43eb16b222a1393965f5081427d1857280cd56bec5a3261f7a09b048ae'
+          checkpoint: '8fde6a6839d0be60cb9adede209e5667ce4601a097918beb9a1e34d27be40850'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.