### PR TITLE
Update sketch-beta to 49.1,51139

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '48.2,47327'
-  sha256 'f2d1d61785ad45ca48905d5f5160abdec43c7462f82c1fd44ab3dba5087357f7'
+  version '49.1,51139'
+  sha256 'c39c7c9a37da216717e43cef801f4a996dbd58169ea419b1af61eba6f400a2c9'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: '20562be4a610e8ee844d1b7d3ff73d0aa9a112d8f9c14b5e85f74e4a7130f192'
+          checkpoint: 'bf116f095332b0f6950a8ab60034085a023c0cb379983efee90ae65c380482d2'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.