### PR TITLE
Update kap-beta to 2.1.0-beta.1

### DIFF
--- a/Casks/kap-beta.rb
+++ b/Casks/kap-beta.rb
@@ -1,11 +1,11 @@
 cask 'kap-beta' do
-  version '2.0.0-beta.6'
-  sha256 '30ce520293c7c256a4a1c9e1a2e7571bba4e80891ef202f815e2f8ff0976e634'
+  version '2.1.0-beta.1'
+  sha256 '7169233e52cdf60daeeaaa34e79d74b17fa7c932ade2993bfb4c4ebc9826f8b7'
 
   # github.com/wulkano/kap was verified as official when first introduced to the cask
   url "https://github.com/wulkano/kap/releases/download/v#{version}/kap-beta-#{version}.dmg"
   appcast 'https://github.com/wulkano/kap/releases.atom',
-          checkpoint: 'de20087c95aa10dc858c9dfe525571a1e8937665bfc5d2bfdae97bd0a1b6526f'
+          checkpoint: 'ac78e1e690955628389f1369323974385dd87eed1baa1940af61f7c175e4ab1b'
   name 'Kap Beta'
   homepage 'https://getkap.co/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.