### PR TITLE
Update rstudio-preview to 1.1.442

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.1.430'
-  sha256 '67d5cdb6c960f9322979d2219d48267be29b1c99a78714c1228fb4e904a7ed23'
+  version '1.1.442'
+  sha256 '1a1064c860d4172b1dd51f8f798bcbb0c5d41ce56fb63a65ccecced513205957'
 
   # amazonaws.com/rstudio-dailybuilds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-dailybuilds/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.