### PR TITLE
Update telegram-alpha to 3.8-118999,958

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118991,957'
-  sha256 '1a0b6e733e859992abd8ea3f6e408969382e7e7fdc7ef008cdacf282d842a833'
+  version '3.8-118999,958'
+  sha256 '9b964c35d3a703ecbc6a54020c1208297868c968e545aa84682f75ca5ab5edfe'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c15e9da1c31a8d0174ca7c6a41b69c4e1037d4263ab23670774ec09a94f9cf38'
+          checkpoint: 'ee37c17c8bb5077fab47fd7c429fab195c55e8979217b2616219942d05082183'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.