### PR TITLE
Update slicer-nightly to 4.9.0.27036,781530

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.26962,777766'
-  sha256 'bc11c8ab77d152180d4d2b0ecd015d2a3360373f9374c10b77905e7be6317567'
+  version '4.9.0.27036,781530'
+  sha256 'b30028c1f89698157a3aa7d43aa2754d0a0d26f3fb4eefafab0b784a65338710'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.