### PR TITLE
Update torbrowser-alpha to 8.0a3

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,10 +1,10 @@
 cask 'torbrowser-alpha' do
-  version '8.0a2'
-  sha256 'd881ae553b9be6bfa55127f705f5a033af5b253f7d58eb0eeb5323e7460af7b0'
+  version '8.0a3'
+  sha256 'c20655c293035591c398b92c12b7e443b74a918e01a85dabb7ad454dd9ad8ee5'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: 'f7937fd99238ad8667e70179f2b2634e5940d5b441edbe7fd1ad5029defb581d'
+          checkpoint: 'a9b3569ba19d354f07ba787c5957ef7f8b6c06e65cc9ce91aa5bfc41f47f38ee'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.