### PR TITLE
Update sketch-beta to 49.1,51145

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '49.1,51139'
-  sha256 'c39c7c9a37da216717e43cef801f4a996dbd58169ea419b1af61eba6f400a2c9'
+  version '49.1,51145'
+  sha256 'c6f428ded9927a7bae635b81f1f06d83d0ef03688b597c293b4ebf28012d1d4b'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'bf116f095332b0f6950a8ab60034085a023c0cb379983efee90ae65c380482d2'
+          checkpoint: 'c661f2bcbd1b9589f9aec337598c1fa70ac731c62d81d77283e8165c3c12639f'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.