### PR TITLE
Update telegram-alpha to 3.8.1-119118,961

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8-118999,958'
-  sha256 '9b964c35d3a703ecbc6a54020c1208297868c968e545aa84682f75ca5ab5edfe'
+  version '3.8.1-119118,961'
+  sha256 'a22c11a026d9f0dc9188e7417aebdc5b9f1024483696df962008f2fc4bc1e8e8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'ee37c17c8bb5077fab47fd7c429fab195c55e8979217b2616219942d05082183'
+          checkpoint: '6dde055e9369209445579061f26925a8d2875ac0f95bea4c058ca57185af0451'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.