### PR TITLE
Update firefox-esr to 52.7.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '52.6.0'
+  version '52.7.0'
 
   language 'cs' do
-    sha256 '9bbc9d0f50945d5a96916d88bf75dc7718c51fce69de177f019ad67556087d26'
+    sha256 '4e78cdf384264709260f133277f1b7ee9fe5e6726f200ef3080dc60f15bcb892'
     'cs'
   end
 
   language 'de' do
-    sha256 'ebee9cf8217b8467b305adb690f070499ae8e1812c707a6994aca7942fc067b5'
+    sha256 'e7f9d168f48048505e8317111302cfa1b85c3c52b35a056b43cc801346d86394'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'bfc45aa3eaeef6e85da34264138980f29fa61434605af0c379bceb9f1f3a3dfe'
+    sha256 '009fa007f4a502b3117a69cb431996f665cac4ca8abf7d0b5e6e60bbe8c7939b'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '9967fe4f93c4896a33fad2fb0f7ccac6f96a56d65d8c03e31d9528f6be3c7495'
+    sha256 '6cf7cbc0fe212f76a4eb2106d7c5a13cc661e0a689470f9b5f4f0ba43332989c'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '2a075e50a2a0e0a197d6c8c983753554b5cc8721a6b3fc8d6ab529e05628885d'
+    sha256 '3af49d3bb8065d928e08629f12dbc91760287d4436af385287eb613c1dcc37fb'
     'fr'
   end
 
   language 'gl' do
-    sha256 '5af11694890d5b5796d6ad48944c5a9a277cca670065ba68a2f5defda0a8822d'
+    sha256 'b353f8edd7c6f1d439971b4f6525a81239e5fb15a7c5f6d96c6f5a5088d1e75c'
     'gl'
   end
 
   language 'it' do
-    sha256 'b3c0fbdce0c2926535e1757123199f747de2daf1accb2ef135288c7cf47f55e1'
+    sha256 '60119a067bfdd8a2adcd2b597e230b25fa63335384b5a6166c49758f796cf223'
     'it'
   end
 
   language 'ja' do
-    sha256 '6eaad2ef55a9c6fbc119641dc5f229e1c8c78701725d06355ac939e9e2c01f2d'
+    sha256 '5f0dfabd41cf7797269285840b69da633d0530cddbc7a9db72d4deaaf0082809'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '366348ab95f860612958f39e70e663082a640b3b00f068c285343b600ee263f6'
+    sha256 'a42cf6964e2e7a34ba262b6ee99844897bcd4691d2836b62b9991937807f9e5d'
     'nl'
   end
 
   language 'pl' do
-    sha256 '9fe537fb82b369798845234bb6a8ee0de6a075eddbf7235ac3dfea9450c07101'
+    sha256 'b236676b897ee4f6a5dc7a318ae3384eaafaef60cbc4869537b5d1ad13c80d23'
     'pl'
   end
 
   language 'pt' do
-    sha256 '918e405fada078c691398898513fa9f8408e750ce7b1a75012ef0e91c54396b8'
+    sha256 '7d7825d596cc1f64a40383a7bdbd0a651b6dc029269cc2c7f6484c669001cb14'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'ff754c11bab9d1b9e55a836ae1ef5e9d7a319c56156c1c2d4a4526da5094b08f'
+    sha256 '49412f6e33c0ed998455c04cf7bf4da74855cdda1792fca8b67211aa13ca06cb'
     'ru'
   end
 
   language 'uk' do
-    sha256 '0097714f1886fbcba919bffc508be00990b7df3c135751f2a038d493bbdb8361'
+    sha256 'c9adfa519fbe91738d7d937c90d3908a097fce35ae448d53a3c40d3b0128c595'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'e3be57ad458d227755667c5186960aa70b22acd9f4c6d89d2f1d0371ea8425fa'
+    sha256 '2cf5298288f37058333745f2ef3bc29f4e91d7e46efff4f86d3e657cbcdafe8f'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'b921a98b3cdc3cf0f09667a9bb90da3ea909a678e87b0f0adaaf9d031cb83b03'
+    sha256 'd43f032da0f4408c5af79148689984244e2dcbb4f16ac532414b25dff273209e'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
