### PR TITLE
Update telegram-alpha to 3.8.1-119436,962

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,5 +1,5 @@
 cask 'telegram-alpha' do
-  version '3.8-119436,962'
+  version '3.8.1-119436,962'
   sha256 '9a12ca74b199ed7f7db75445556ff2edb1f602891ea1c060f7659aa7153126f1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-119118,961'
-  sha256 'a22c11a026d9f0dc9188e7417aebdc5b9f1024483696df962008f2fc4bc1e8e8'
+  version '3.8-119436,962'
+  sha256 '9a12ca74b199ed7f7db75445556ff2edb1f602891ea1c060f7659aa7153126f1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6dde055e9369209445579061f26925a8d2875ac0f95bea4c058ca57185af0451'
+          checkpoint: 'e74f977a05cfb05646dcf323089f7beb7fe2e90aafd58ee8a4da7a07bce24b26'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.