### PR TITLE
Update dropbox-beta to 46.3.59

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '45.3.90'
-  sha256 'a2d078ecd4bff3fe72e527d6ced59b92f22ca6eac100b288221df947bc04cdc4'
+  version '46.3.59'
+  sha256 '77054f6e9ebafc6f0cf67441630acb724c459778fd682d9ecb486a74eec4e997'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.