### PR TITLE
Update telegram-alpha to 3.8.1-119441,965

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-119436,962'
-  sha256 '9a12ca74b199ed7f7db75445556ff2edb1f602891ea1c060f7659aa7153126f1'
+  version '3.8.1-119441,965'
+  sha256 '0468543ab67ffe2fb50eef97fa43dbff2215c6b52ec4a9ecfa204bcc988df301'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'e74f977a05cfb05646dcf323089f7beb7fe2e90aafd58ee8a4da7a07bce24b26'
+          checkpoint: '59a648f86089b937975953d8f000cbeeb33e323a2d6084f1052d2f8126c48e73'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.