### PR TITLE
Update telegram-alpha to 3.8.1-119481,966

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-119441,965'
-  sha256 '0468543ab67ffe2fb50eef97fa43dbff2215c6b52ec4a9ecfa204bcc988df301'
+  version '3.8.1-119481,966'
+  sha256 'd76f69406ff07a50770f89893f5f62028b242480bb2023591be3274cd2d596f4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '59a648f86089b937975953d8f000cbeeb33e323a2d6084f1052d2f8126c48e73'
+          checkpoint: '32272cba7b4b0554dc5ba2d53d498a6f770986e48a23e9a37c9e616208281d0e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.