### PR TITLE
Update vivaldi-snapshot to 1.15.1125.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1111.3'
-  sha256 '1d9697ac6321fac39383cad5c3d5ab1e52cb13eb69cdb31a7c129833c0401649'
+  version '1.15.1125.3'
+  sha256 '5bcdf4ddfe5892edff4c947d15e9aa6c492c8718eb77188704558d98eaf5a73f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c3f04830fad8ff5d0168aa69bfd8ea5c2a74291e7958066040d1212ed5af716f'
+          checkpoint: '928cff7de80e5d32c2ea954288ebcc0adc592dc5e5aab048e15f33a394d00a84'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.