### PR TITLE
Update slicer-nightly to 4.9.0.27085,783959

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27083,783379'
-  sha256 '21eaee7263adcd0a2d8c3bfbe9f58aca30419e531d36fda1416bba7e9662204b'
+  version '4.9.0.27085,783959'
+  sha256 '7ff66ee208de5b4883e77924e4f7a095376b455093b9ac06221b2c7dd764e0d0'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.