### PR TITLE
Update telegram-alpha to 3.8.1-119667,968

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-119481,966'
-  sha256 'd76f69406ff07a50770f89893f5f62028b242480bb2023591be3274cd2d596f4'
+  version '3.8.1-119667,968'
+  sha256 'a57f440752f3a6e4c8034645201ff326c5203ea32e83ee93a6671d0bbfc0b433'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '32272cba7b4b0554dc5ba2d53d498a6f770986e48a23e9a37c9e616208281d0e'
+          checkpoint: '9f742592534574685ebabf8a4c14dee1bba385f16f734653a7717b9e0d943128'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.