### PR TITLE
Update vivaldi-snapshot to 1.15.1130.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1125.3'
-  sha256 '5bcdf4ddfe5892edff4c947d15e9aa6c492c8718eb77188704558d98eaf5a73f'
+  version '1.15.1130.3'
+  sha256 '9379634ba84d1780bc60d2dd2273da02f0989ad1192334cd878310b4f13a9be2'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '928cff7de80e5d32c2ea954288ebcc0adc592dc5e5aab048e15f33a394d00a84'
+          checkpoint: '8d97776bd25cd60909572010d921e858011bdeb73f0895af256eac24b463e11e'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.