### PR TITLE
Update opera-beta to 52.0.2871.27

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '52.0.2871.20'
-  sha256 '0554a63c96207a08a21113a3ad2da988e7f6c29d76f16b3dc7e8b69fb0512cf4'
+  version '52.0.2871.27'
+  sha256 'dbde74e9f40b65a71254c67fc2273af3d37effe1a0f5aa5e701fbda9c5d2b3e8'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.