### PR TITLE
Update keka-beta to 1.1.0,8

### DIFF
--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -1,11 +1,11 @@
 cask 'keka-beta' do
-  version '1.1.0,7'
-  sha256 'b75ab747b9c686227e77a091f937ff9686b1a9fcbb55663e42af0670dc1dded0'
+  version '1.1.0,8'
+  sha256 'bee697f1fcb7bf9b763c6b6c9db003701bbfab893e61fb694de87d2645c8fe44'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-beta.#{version.after_comma}/Keka-#{version.before_comma}-beta.#{version.after_comma}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '6b03977d3ba196a396941a5a17ad9d907294c9803b9937574ab941eebae4e8ce'
+          checkpoint: 'fc7c71b1bf0be4fdb216d7894bddb366871d92a703235c9ce5643b5e1c901205'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.