### PR TITLE
Update slicer-nightly to 4.9.0.27090,784836

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27085,783959'
-  sha256 '7ff66ee208de5b4883e77924e4f7a095376b455093b9ac06221b2c7dd764e0d0'
+  version '4.9.0.27090,784836'
+  sha256 'a8aa051cffceaea069308420fc91e2f57f670ad58ed9335b73bb829c90d1b30c'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.