### PR TITLE
Update airmail-beta to 3.5.5.477,337

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.475,335'
-  sha256 '4567574f44b8fed50146e050b51ee1df7dd9937ad2e2916aa217dfcdf7d1304a'
+  version '3.5.5.477,337'
+  sha256 '8d52d5b2d2c7ed34f6676292d6efd064332e3687a565d2950327aa82965686f8'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '8d3cd96f4bd0cc8747a9ebe3cfd6c7ff5889dd37b26986d662075dabc8bb28aa'
+          checkpoint: 'e9a367142256bb016a4699b1562d914352ff8adafef241f988d6ad5ec9d54c2a'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.