### PR TITLE
Update toggl-dev to 7.4.135

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.130'
-  sha256 '8d75f2d18a4819749ef1c15b37006e83c826701df7559551be16b7c21d70d0db'
+  version '7.4.135'
+  sha256 '11914f931e2c2f1c910481a665a8b00c84f8413c3a8d719e3ebce38f5d27f29a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '2e0ce2e53e0cfe155e8cc67dc0d77d259aeb038afc4b34ff88f1ede3eb8b9c05'
+          checkpoint: '39fb054ea16045dc04f772d7a3d554ff4709c9c37c14cc6d6fb70ff60aa7a5d6'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.