### PR TITLE
Update omnifocus-beta to 2.x-r306258

### DIFF
--- a/Casks/omnifocus-beta.rb
+++ b/Casks/omnifocus-beta.rb
@@ -1,10 +1,12 @@
 cask 'omnifocus-beta' do
-  version '2.x-r303501'
-  sha256 '2c15ac0c7ddf6d4e8ef7cb70fceb6a13556e67b45f5a4a586a9b1ae3aa53660f'
+  version '2.x-r306258'
+  sha256 'b2214831838c9e48d0adcc6ce53d5802f3413ab83c8362ed990e6fce03e08480'
 
   url "https://omnistaging.omnigroup.com/omnifocus/releases/OmniFocus-#{version}-Test.dmg"
   name 'OmniFocus'
   homepage 'https://omnistaging.omnigroup.com/omnifocus/'
+
+  depends_on macos: '>= :sierra'
 
   app 'OmniFocus.app'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.