### PR TITLE
Update thunderbird-daily to 61.0a1

### DIFF
--- a/Casks/thunderbird-daily.rb
+++ b/Casks/thunderbird-daily.rb
@@ -1,5 +1,5 @@
 cask 'thunderbird-daily' do
-  version '59.0b2'
+  version '61.0a1'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central/thunderbird-#{version}.en-US.mac.dmg"

--- a/Casks/thunderbird-daily.rb
+++ b/Casks/thunderbird-daily.rb
@@ -1,5 +1,5 @@
 cask 'thunderbird-daily' do
-  version '59.0a1'
+  version '59.0b2'
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central/thunderbird-#{version}.en-US.mac.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.