### PR TITLE
Update hyper-canary to 2.0.0-canary.15

### DIFF
--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,11 +1,11 @@
 cask 'hyper-canary' do
-  version '2.0.0-canary.14'
-  sha256 'be4e48c5323badd401eb488fa1b0c26bff27b8772cc7cf16dab63ebecc7dbd7d'
+  version '2.0.0-canary.15'
+  sha256 'c101a6dca9a6d40fa2ae3dc8932f1860f6ae598f8c7085d1af7512f66b2d9004'
 
   # github.com/zeit/hyper was verified as official when first introduced to the cask
   url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip"
   appcast 'https://github.com/zeit/hyper/releases.atom',
-          checkpoint: 'da84ac2ef441ce57cd10b2cddee1fd3349784ad9bd8ffe68850c01d6c64258a4'
+          checkpoint: '406a182ef84edb8c644658a8dab72e05aa89773a1cc26fb103651b2ceee02d68'
   name 'Hyper'
   homepage 'https://hyper.is/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.