### PR TITLE
Update torbrowser-alpha to 8.0a5

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,10 +1,10 @@
 cask 'torbrowser-alpha' do
-  version '8.0a4'
-  sha256 '7d629b22fa0b8c2ee66b23e8a2f6a8ce07a86975e9f0529730237c241f467b0a'
+  version '8.0a5'
+  sha256 '853bd9c9e8ba1d785bf2904ebd2681253c47413efb317bd7c4094f20d7c270c0'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '872b43f4be239c9e06844efca17ed0d5af86e5a5acfc5f22f851a22374284d1e'
+          checkpoint: '2b3dca7ace4c81a050aad6999e6da75436df18d4b3354d63d7b934d7622f6758'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.