### PR TITLE
Update libreoffice-rc to 6.0.3.1

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-rc' do
-  version '6.0.2.1'
-  sha256 '6211d49a962f9573e27b657b51fe9a8105c61e4dd99510c3f23adfcc98f1c9e4'
+  version '6.0.3.1'
+  sha256 'd9420b8d4b6c22755057eb1dabdf5bc549638ebb0c77dc17433524a6d6a2fa98'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: 'e094f1800964c089406542172bd6f36e155b4c0dc216e243246e2aa19dc45755'
+          checkpoint: '853c7148d98793a82c382b055261a55dece73cb32c7392b8c0004ab35fa2204c'
   name 'LibreOffice Release Candidate'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.