### PR TITLE
Update vivaldi-snapshot to 1.15.1137.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1132.3'
-  sha256 'a9ce30e54b64ff06304549b2d6be5e66bf7e50daff1b5711119b79ff5a62a108'
+  version '1.15.1137.3'
+  sha256 'cff0a6330608e9c4be0128d9a5d14a7529d7b5e4d4bdbc24ef167e6cab97a1b1'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c3516910360693e6f0bbae990093497fab2bcf6ef317164e4997a6765bc96431'
+          checkpoint: '98d2efd3543b4c77be41969536454609a6bcca9f37840c7f4ea5fbcea832395b'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.