### PR TITLE
Update toggl-dev to 7.4.137

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.135'
-  sha256 '11914f931e2c2f1c910481a665a8b00c84f8413c3a8d719e3ebce38f5d27f29a'
+  version '7.4.137'
+  sha256 '8d09be909d328d9b4d122ce35619aa12cef4ebdc9c6d523ba4be0d22e0c4c7e1'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '39fb054ea16045dc04f772d7a3d554ff4709c9c37c14cc6d6fb70ff60aa7a5d6'
+          checkpoint: 'fb37d58dd1a0559518cec1708daeb32611d33afe9f0740e80ac286052af0514b'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.