### PR TITLE
Update firefox-esr to 52.7.3

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '52.7.2'
+  version '52.7.3'
 
   language 'cs' do
-    sha256 '465dd32952dffc8499136929b9b04a43fb5be8f53c3dfede7383a266575f5011'
+    sha256 '54f47bedecdad19d2ab24cb4ffb61b113cecbb500e3f32dc2d2e835cb0a5cf17'
     'cs'
   end
 
   language 'de' do
-    sha256 '4b8e1ead4a6cb521bfbf4373bc3b371cdbffad4afce698ed42a860eb7c95091f'
+    sha256 '108f39b664d65b4db7d606d973f2cba9a38154eb366fa21a7582bb6f757892a7'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'e8d59785a880d066feb803b640f96c6637b0c4c3e3cc72fb5102870a88288dac'
+    sha256 'b2a0587e6348b594b320eca4799fe98ed9897f743901be1a4191e148bd4a44ac'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '699b85133f7995044ec94cef591c57424300142aaccddd9a3da17206ad820028'
+    sha256 '2073a57394c34223157a015aa6de8235b710d6661b6b22f8aa309053aea1b642'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'f309ca2c4ca4c66dc54db0703dbcc26305f3719e2d4a0c8a15df6228f1ed3664'
+    sha256 'c0c94162212dc1f68ac662108c76505c4914b5a10991c77fa0045bf170aa800f'
     'fr'
   end
 
   language 'gl' do
-    sha256 'bd490b7b2a3a8f0947dd5b0fbb3e1f7f190f8d3e403327c31987b0b3d0e3257f'
+    sha256 '8e6f9f8f9903e5fa04e1ccaae81f65c3d6c13b84483241311f56175c241935b8'
     'gl'
   end
 
   language 'it' do
-    sha256 'a5f266bf6455a77ef96137b31ef38af5594e06bac25e43220d01b94741a70b73'
+    sha256 'f0e0e0ea0bd13350601fe385823e7ebd89668a5f0416c815ce870e749a9c9422'
     'it'
   end
 
   language 'ja' do
-    sha256 '0cbafec163e6ebf61835d0b823acaface640326c357da8b6787488e972e27e8c'
+    sha256 'd17833d39802c9b088d66ec3150519e7a80defbeb32ab30f4950f4bc3c227273'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'd8385cf79e2ddfe725ee425fc8700f1beefc9042b91d66fbfc2b107ac5efe162'
+    sha256 '06a79db6d1b3cdc6972f1fdc1b1ccdf8d02a2ab3f19449a201578a8252ce3278'
     'nl'
   end
 
   language 'pl' do
-    sha256 'f86337cf72c0fdd8ad3ba3c9c0218010350624e03874a0c69508c846d8b2267b'
+    sha256 'e312d6d9bcaed3d4529873141cf441509fdfc9bee93467a215603e84e863d747'
     'pl'
   end
 
   language 'pt' do
-    sha256 '98414a2f194768a663faa2b7e5896390b33bb7931da135dfb32d1e965f36dd5c'
+    sha256 '7316b27f20988a76e97e608e6f6a5153d31e7fef27040a7abd37160ee5d5f964'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '08ce666647157c988afcac1e9508e402c125c79708e7560250432ac492057985'
+    sha256 '630c23d11c9d593ee71609ec982eedecd8cec5ed544d5d53fd7305a307544990'
     'ru'
   end
 
   language 'uk' do
-    sha256 'b2c8908f097ee7a8ae9e86e1d29a9e136bb24ced414fc48bcacdf713bb7aab8e'
+    sha256 '8fc59275b5d98ec1a5a4c8aa690a4d23bfa0fce31dd92fb0ebfae690d8a6480c'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '49c5e1d5637a6ba1b7b2745307f225a78dc15e4f4fb0a4c6188875e5e01fe461'
+    sha256 '579b094895dd1f67f8a920e5473fe4e0ab6288e6979268e978e026452341c3f8'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '83bd1e7e9c5bfc0f8d5ed76de7ff4fb38c4d87c8f024b78c4aef89f1a4bffe12'
+    sha256 '3328e18babfec873636d395b21a2e2ef1b827bdf76f778f5b97554e672373549'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
