### PR TITLE
Update 1password-beta to 7.0.BETA-4

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -2,6 +2,7 @@ cask '1password-beta' do
   version '7.0.BETA-3'
   sha256 '1116d6b18cdf18fa532bdc5463e5a2767252ecb47a6015f407a2de9675180c3b'
 
+  # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
           checkpoint: '51b05534eaace042bdb613f473450b6cf951156667f2ee5b0d3b8f419e35ec93'

--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,19 +1,17 @@
 cask '1password-beta' do
   version '7.0.BETA-3'
-  sha256 'e8a15236fe58aca9ee49ef212cf043d3cbd02423e39c5448ced3f32cb260bc83'
+  sha256 '1116d6b18cdf18fa532bdc5463e5a2767252ecb47a6015f407a2de9675180c3b'
 
   # 1password.com was verified as official when first introduced to the cask
-  url "https://c.1password.com/dist/1P/mac7/1Password-#{version}.pkg"
-  appcast 'https://app-updates.agilebits.com/download/OPM7',
-          checkpoint: '6b2c01a30d89571fba0ed4da630b0650f182a642d44c8097d90298caf2a705d1'
+  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
+          checkpoint: '51b05534eaace042bdb613f473450b6cf951156667f2ee5b0d3b8f419e35ec93'
   name '1Password'
-  homepage 'https://1password.com/downloads/'
+  homepage 'https://1password.com/'
 
   auto_updates true
 
-  pkg "1Password-#{version}.pkg"
-
-  uninstall pkgutil: 'com.agilebits.pkg.onepassword7'
+  app "1Password #{version.major}.app"
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',

--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,16 +1,19 @@
 cask '1password-beta' do
-  version '6.8.7.BETA-2'
-  sha256 '100806f4243a55868f5eafce1ec79a9708bcb187183affb0b7a060e8fbe27851'
+  version '7.0.BETA-3'
+  sha256 'e8a15236fe58aca9ee49ef212cf043d3cbd02423e39c5448ced3f32cb260bc83'
 
-  url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
-  appcast 'https://app-updates.agilebits.com/product_history/OPM4',
-          checkpoint: 'f7e758cf0ceb8ca3cad760946a16dad6f5da6959c9d384b3ec7a5937ab4b4db9'
+  # 1password.com was verified as official when first introduced to the cask
+  url "https://c.1password.com/dist/1P/mac7/1Password-#{version}.pkg"
+  appcast 'https://app-updates.agilebits.com/download/OPM7',
+          checkpoint: '6b2c01a30d89571fba0ed4da630b0650f182a642d44c8097d90298caf2a705d1'
   name '1Password'
-  homepage 'https://agilebits.com/downloads'
+  homepage 'https://1password.com/downloads/'
 
   auto_updates true
 
-  app "1Password #{version.major}.app"
+  pkg "1Password-#{version}.pkg"
+
+  uninstall pkgutil: 'com.agilebits.pkg.onepassword7'
 
   zap trash: [
                '~/Library/Application Scripts/2BUA8C4S2C.com.agilebits.onepassword-osx-helper',

--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -2,7 +2,6 @@ cask '1password-beta' do
   version '7.0.BETA-3'
   sha256 '1116d6b18cdf18fa532bdc5463e5a2767252ecb47a6015f407a2de9675180c3b'
 
-  # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
           checkpoint: '51b05534eaace042bdb613f473450b6cf951156667f2ee5b0d3b8f419e35ec93'

--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,11 +1,11 @@
 cask '1password-beta' do
-  version '7.0.BETA-3'
-  sha256 '1116d6b18cdf18fa532bdc5463e5a2767252ecb47a6015f407a2de9675180c3b'
+  version '7.0.BETA-4'
+  sha256 '7dc3c4e6945c334ba3efc5d5b8fe7413ea6474fd2fa05617ecc5462fa2bc60bf'
 
   # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
-          checkpoint: '51b05534eaace042bdb613f473450b6cf951156667f2ee5b0d3b8f419e35ec93'
+          checkpoint: 'a17dd1e624c82653f775ca7870f8ba244e8e4077282156457646d1cbbab95bc1'
   name '1Password'
   homepage 'https://1password.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download 1password-beta` is error-free.
- [x] `brew cask style --fix 1password-beta` reports no offenses.
- [x] The commit message includes the cask’s name and version.