### PR TITLE
Update microsoft-remote-desktop-beta to 10.1.7.941,170

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,10 +1,10 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.1.6.910,168'
-  sha256 '75cb79233831c5f64168975e5678f81245064b436807faa319e638bf606f659b'
+  version '10.1.7.941,170'
+  sha256 'd8a17120a28832c7b498a68be9401826ab690e14ef2e757b60479fcbab130382'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',
-          checkpoint: 'c433077f7e2a5029ecc4d716f6e6aeb2b7a6f6095a5e5c6808b31930a933949c'
+          checkpoint: 'f06042fb26360276adf51aef6ca3888d80f76b94edf625893c1140db3d05060f'
   name 'Microsoft Remote Desktop Beta'
   homepage 'https://rink.hockeyapp.net/apps/5e0c144289a51fca2d3bfa39ce7f2b06/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.