### PR TITLE
Update slicer-nightly to 4.9.0.27125,789225

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27112,787717'
-  sha256 'cf178f774c2ceaa5f1607fd2e62e15b029f4e71fba01f2ba6d769adbca5d44c3'
+  version '4.9.0.27125,789225'
+  sha256 '31b398f9e6d80659e060e2c8004effe5e1d98df5b563c0cf74a53aa9618835fc'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.