### PR TITLE
Update visual-studio-code-insiders to 1.22.0,762a3f68106d03a6d033dfd7a28ae8dee5977842

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.21.0,91120eb786357aa1e16217ad6a67cf0740f26e8e'
-  sha256 '413582f26f6d3983425c84bc3ae22c263aa6a27550643bcb17b26faffefe83c7'
+  version '1.22.0,762a3f68106d03a6d033dfd7a28ae8dee5977842'
+  sha256 'd88fbddef71864faee28685ac3ff991b3c10e03dd62b66d7771b5b19f47318fe'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: 'e811acbfa53d0686c935fddc532201270a063d2959b8e06e571803bca0a982fd'
+          checkpoint: '3b92c233344291f6095238fc54b6082977c94712284eb7831b8229b1627c8e18'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.