### PR TITLE
Update keka-beta to 1.1.0,9

### DIFF
--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -1,11 +1,11 @@
 cask 'keka-beta' do
-  version '1.1.0,8'
-  sha256 'bee697f1fcb7bf9b763c6b6c9db003701bbfab893e61fb694de87d2645c8fe44'
+  version '1.1.0,9'
+  sha256 '5b2eb698ff2395c765fb92f3fc158e9c0222e0b454749ae24c1cb508c59e54e2'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-beta.#{version.after_comma}/Keka-#{version.before_comma}-beta.#{version.after_comma}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: 'fc7c71b1bf0be4fdb216d7894bddb366871d92a703235c9ce5643b5e1c901205'
+          checkpoint: '38d9902876e25fdf81ff368eb5f9bcdb4dbe2004ed7cd9eaecc73a07d12d4dc2'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.