### PR TITLE
Update omegat-dev to 4.1.4

### DIFF
--- a/Casks/omegat-dev.rb
+++ b/Casks/omegat-dev.rb
@@ -1,11 +1,11 @@
 cask 'omegat-dev' do
-  version '4.1.3'
-  sha256 '3f43019780741545ceabbbaa642a2a73e6db5e473364e264089cf2f84fc902cb'
+  version '4.1.4'
+  sha256 'cff08c41cc6f9c8eac76e3bf4756d76feade57dbd0ddadcc55f1cab1d5446039'
 
   # downloads.sourceforge.net/omegat was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Signed.zip"
   appcast 'https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest',
-          checkpoint: 'f83e1c66a06d0b3f98ee8af9ae8be163d47eb0f914987ba4bf6b344d4dd7787b'
+          checkpoint: '74928e8884a81e73988f43f6ac2cf03cff869563cba0cb0015b40d184f8433eb'
   name 'OmegaT Development'
   homepage 'https://omegat.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.