### PR TITLE
Update safari-technology-preview to 53

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '52'
+  version '53'
 
   if MacOS.version == :sierra
-    sha256 'e35a9488d9b8df605fcc59e73982b36c33cf8c87761741db7d7ecbbcfb175e92'
-    url 'https://secure-appldnld.apple.com/STP/091-75180-20180321-568313D8-1D74-11E8-A64C-0BF6EA84401E/SafariTechnologyPreview.dmg'
+    sha256 '138a23187f3b32c0185dc94c908a8439ea6bb426e666046ec81bc21066e26504'
+    url 'https://secure-appldnld.apple.com/STP/091-77046-20180404-01B460F0-827F-4BBF-8F35-E0876FDB41D2/SafariTechnologyPreview.dmg'
   else
-    sha256 '2b6faaacbc1867ae3c0650edfec36138ae2a9913b80ae93c2c19a894a2fb623b'
-    url 'https://secure-appldnld.apple.com/STP/091-75179-20180321-568313D8-1D74-11E8-A64C-0BF6EA84401E/SafariTechnologyPreview.dmg'
+    sha256 'b6e511790e9f072e78d60c3bf7f0ddc20dfa5ad7c0597d003d36fa14df0222ae'
+    url 'https://secure-appldnld.apple.com/STP/091-77044-20180404-FB4FBD2C-0D13-4FC3-A340-ED73FB81CC73/SafariTechnologyPreview.dmg'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.