### PR TITLE
Update vivaldi-snapshot to 1.15.1146.5

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1137.3'
-  sha256 'cff0a6330608e9c4be0128d9a5d14a7529d7b5e4d4bdbc24ef167e6cab97a1b1'
+  version '1.15.1146.5'
+  sha256 'ce0173a9dfddf1a96f5516bc660261b617290b1efe35a322b200488951e93bd7'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '98d2efd3543b4c77be41969536454609a6bcca9f37840c7f4ea5fbcea832395b'
+          checkpoint: '5a53aa5906f393abf4d5d482714f2fa8b30e7132d76910609d3e5faa2246bd07'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.