### PR TITLE
Beta updates

### DIFF
--- a/Casks/forklift-beta.rb
+++ b/Casks/forklift-beta.rb
@@ -1,6 +1,6 @@
 cask 'forklift-beta' do
-  version '3.2b'
-  sha256 'd20cec56d0ead4d542e83ffa7f6e98e13f663c17e68f00b9b5284eb8d40eba88'
+  version '3.2.1'
+  sha256 '0f2d38480f23c70f7e0972b6e4f5d0d94284b07a9426ff0cb70e9cbe25e6510e'
 
   url "https://download.binarynights.com/ForkLift#{version}.zip"
   name 'ForkLift'

--- a/Casks/insync-beta.rb
+++ b/Casks/insync-beta.rb
@@ -1,6 +1,6 @@
 cask 'insync-beta' do
-  version '1.4.1.37037'
-  sha256 '0fca8d6b3240406608141e480f4238d41f6ddab75cbf8d53e1591d128068052f'
+  version '1.4.5.37069'
+  sha256 '3d0f63d709b65ff44fc32aae34a2456809ac2e53ed9f4e1effbe35ab5b5dce5f'
 
   # d2t3ff60b2tol4.cloudfront.net/builds was verified as official when first introduced to the cask
   url "https://d2t3ff60b2tol4.cloudfront.net/builds/Insync-#{version}.dmg"

--- a/Casks/jabref-beta.rb
+++ b/Casks/jabref-beta.rb
@@ -1,11 +1,11 @@
 cask 'jabref-beta' do
-  version '4.0-beta3'
-  sha256 '9c95ddb95164073a4e66a52c69fd0994bb99b390285160f204d6799ed1d431a5'
+  version '4.1'
+  sha256 'f22108d6bda73978a51ca5759dd2a46619678427f3d9154e55f935004fa93751'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: 'f69c0b2f44afba77f0e6202faa841622e16b229aa3a8492013ffc67d6c916f37'
+          checkpoint: '90eba3d359c9692fd843f940d17b9796dde4ab327b65651e865515eb0697081a'
   name 'JabRef Beta'
   homepage 'https://www.jabref.org/'
 

--- a/Casks/openbazaar-beta.rb
+++ b/Casks/openbazaar-beta.rb
@@ -1,11 +1,11 @@
 cask 'openbazaar-beta' do
-  version '2.1.1-rc4'
-  sha256 '9a0a2a657f842114b86b31edcbe1fb540ee237622cf4c683318b4e0296149ab0'
+  version '2.1.1'
+  sha256 'f9c036ee04caf8ff61b19fb53da4dc1065fac2582a50b6c485737aa836886e84'
 
   # github.com/OpenBazaar/openbazaar-desktop was verified as official when first introduced to the cask
   url "https://github.com/OpenBazaar/openbazaar-desktop/releases/download/v#{version}/OpenBazaar#{version.major}-#{version.major_minor_patch}.dmg"
   appcast 'https://github.com/OpenBazaar/openbazaar-desktop/releases.atom',
-          checkpoint: '17e788609b7086dd6752916a5ed6a555c9274027adf20c531942cf1d5a6206c7'
+          checkpoint: '52021919914e4f964154a1a948cc1dff3afd32885deb120a78922c012a637384'
   name 'OpenBazaar Beta'
   homepage 'https://www.openbazaar.org/'
 

--- a/Casks/whatpulse-beta.rb
+++ b/Casks/whatpulse-beta.rb
@@ -1,6 +1,6 @@
 cask 'whatpulse-beta' do
-  version '2.7.2b1'
-  sha256 '54dc8c55cdca3d2f19bcd7ea788ac6aa2c57f6c7629e82de32ee93cc6211e0ad'
+  version '2.8.2b3'
+  sha256 'f9873e56bc6cb4becaaaf209da803b98423384869f372b62104b0e16bcecd8ea'
 
   url "https://static.whatpulse.org/files/beta/whatpulse-mac-#{version}.dmg"
   name 'WhatPulse'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
---
This is a collection of updates to beta packages. Most are just matching the stable branches.  
Exceptions are:
* Insync Beta is related to caskroom/homebrew-cask#45769
* WhatPulse is updated to the latest beta based on [its official Twitter status](https://twitter.com/whatpulse/status/951945844248457217).