### PR TITLE
Update insync-beta to 1.4.5.37069

### DIFF
--- a/Casks/insync-beta.rb
+++ b/Casks/insync-beta.rb
@@ -1,6 +1,6 @@
 cask 'insync-beta' do
-  version '1.4.1.37037'
-  sha256 '0fca8d6b3240406608141e480f4238d41f6ddab75cbf8d53e1591d128068052f'
+  version '1.4.5.37069'
+  sha256 '3d0f63d709b65ff44fc32aae34a2456809ac2e53ed9f4e1effbe35ab5b5dce5f'
 
   # d2t3ff60b2tol4.cloudfront.net/builds was verified as official when first introduced to the cask
   url "https://d2t3ff60b2tol4.cloudfront.net/builds/Insync-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.