### PR TITLE
Update jabref-beta to 4.1

### DIFF
--- a/Casks/jabref-beta.rb
+++ b/Casks/jabref-beta.rb
@@ -1,11 +1,11 @@
 cask 'jabref-beta' do
-  version '4.0-beta3'
-  sha256 '9c95ddb95164073a4e66a52c69fd0994bb99b390285160f204d6799ed1d431a5'
+  version '4.1'
+  sha256 'f22108d6bda73978a51ca5759dd2a46619678427f3d9154e55f935004fa93751'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: 'f69c0b2f44afba77f0e6202faa841622e16b229aa3a8492013ffc67d6c916f37'
+          checkpoint: '90eba3d359c9692fd843f940d17b9796dde4ab327b65651e865515eb0697081a'
   name 'JabRef Beta'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.