### PR TITLE
Update vivaldi-snapshot to 1.15.1147.19

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1146.5'
-  sha256 'ce0173a9dfddf1a96f5516bc660261b617290b1efe35a322b200488951e93bd7'
+  version '1.15.1147.19'
+  sha256 '4e30a20125b8675e1f47b366ae73fd8508da4e2bda7ec48be7713d26c73456b1'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '5a53aa5906f393abf4d5d482714f2fa8b30e7132d76910609d3e5faa2246bd07'
+          checkpoint: 'c00b2e3b1a7d022690e52fc0ba55650f52f303681a1f135544cf3b7d9fc4e1ab'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.