### PR TITLE
Update istat-menus5 to 5.32

### DIFF
--- a/Casks/istat-menus5.rb
+++ b/Casks/istat-menus5.rb
@@ -2,8 +2,7 @@ cask 'istat-menus5' do
   version '5.32'
   sha256 'bfb1cd95d119c4248190dc6093147a2b08a04b27b9e57e90638d720f7b2f24c7'
 
-  # amazonaws.com/bjango was verified as official when first introduced to the cask
-  url "https://s3.amazonaws.com/bjango/files/istatmenus#{version.major}/istatmenus#{version}.zip"
+  url "https://files.bjango.com/istatmenus#{version.major}/istatmenus#{version}.zip"
   name 'iStats Menus'
   homepage 'https://bjango.com/mac/istatmenus/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.