### PR TITLE
Update skype-preview to 8.20.76.1

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,6 +1,6 @@
 cask 'skype-preview' do
-  version '8.19.76.3'
-  sha256 'eae42ffff4cad51a266d4cb25ed207a4adad91f959e319a0bc4cc8e07b594682'
+  version '8.20.76.1'
+  sha256 '84eecab93936b3bb628a0f5cc53ad6a1eb5a82e93e7a55167255530b7e109e65'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.