### PR TITLE
Update toggl-dev to 7.4.139

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.137'
-  sha256 '8d09be909d328d9b4d122ce35619aa12cef4ebdc9c6d523ba4be0d22e0c4c7e1'
+  version '7.4.139'
+  sha256 '0eb9fec43fa4343de06c7cb6c57a7c9e3d29a75cbd010227db600d6c39231f71'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'fb37d58dd1a0559518cec1708daeb32611d33afe9f0740e80ac286052af0514b'
+          checkpoint: 'aacbc94e945695f693fcd7ee1bdf1d3878e74c22b4e8205f906d91dd80a6173b'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.