### PR TITLE
Update telegram-alpha to 3.8.1-121837,981

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-119667,968'
-  sha256 'a57f440752f3a6e4c8034645201ff326c5203ea32e83ee93a6671d0bbfc0b433'
+  version '3.8.1-121837,981'
+  sha256 'fea2c62485b732bb07697295b3a0d452ab17c92ad8263a3a1bb6075be7bb6184'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '9f742592534574685ebabf8a4c14dee1bba385f16f734653a7717b9e0d943128'
+          checkpoint: '5f76258b2d916564c35f91619f15c72127cf38dd450934eb7a80143e17d1d30e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.