### PR TITLE
Update telegram-alpha to 3.8.1-121861,983

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-121852,982'
-  sha256 '89318023f89cf0055cf4ad6cbcf58ddedc28a82d41272a71cc152cb17819f075'
+  version '3.8.1-121861,983'
+  sha256 '2ca335d60f548736638a2efb5dcce62b3a2f91067ab7ceca6e0c8aa79b27d6e9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '5f76258b2d916564c35f91619f15c72127cf38dd450934eb7a80143e17d1d30e'
+          checkpoint: 'f508afe34816a01bc22cee7ee355947735f6c061eaacc28bc1af463264760a12'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.