### PR TITLE
Update atom-beta to 1.26.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.26.0-beta1'
-  sha256 'ee6c4bd3d2b90a54d58a2e8d0c44a0c18267837e091fb4065f6e5d392a0bbc60'
+  version '1.26.0-beta2'
+  sha256 '92088ce053f7a409bb50a10efd6f45d7687c90c23a8afa4259c734a18a185dd1'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '17e5f1df6b4a224aa8920d6da5dde8d6a6f69398143449f65f3baf84e7badd02'
+          checkpoint: '9d05a616347daf2b4a58bb516e07ea528ebdb8cf7975127b0bdaf306513ece71'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.