### PR TITLE
Update telegram-alpha to 3.8.1-121979,984

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.1-121861,983'
-  sha256 '2ca335d60f548736638a2efb5dcce62b3a2f91067ab7ceca6e0c8aa79b27d6e9'
+  version '3.8.1-121979,984'
+  sha256 '831d42ba772b542a97fe331c36ff653d648729bfd3948e628bc29049b2168246'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'f508afe34816a01bc22cee7ee355947735f6c061eaacc28bc1af463264760a12'
+          checkpoint: '545ea1106cef9c81ee67754175b74f5277c55a53e0524445f613b21f3bf6ca1a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.