### PR TITLE
Update vivaldi-snapshot to 1.15.1147.21

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1147.19'
-  sha256 '4e30a20125b8675e1f47b366ae73fd8508da4e2bda7ec48be7713d26c73456b1'
+  version '1.15.1147.21'
+  sha256 '72f0c8ed617191ce82af2f98134ef8b932decdf5ec9be139dc00fbfc74edf113'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'c00b2e3b1a7d022690e52fc0ba55650f52f303681a1f135544cf3b7d9fc4e1ab'
+          checkpoint: '93c17850855d06215c068825407385d8131de867168d516e28e2ff8b7cfb1747'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.