### PR TITLE
Update airmail-beta to 3.5.5.482,340

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.480,339'
-  sha256 'fec2e9b2cf064642c2500bed03d2bfbb2942a07b4f56535174a0a033870ccded'
+  version '3.5.5.482,340'
+  sha256 'cb3a4f99991aa9c2ee236a4b1f9fad8292ea2c2bb033c7486eb36fa9862dd21a'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'cef7a6ff98bab93982c26682aa10a7a36afb8d7a703ce5e7bbd754abeb79d266'
+          checkpoint: 'd11a6ee9e777722df3cd5d357be9624fd0fde59b59eaaa73728bc43aaac07479'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.