### PR TITLE
Add java10 1.10.0_1-b10 (new cask)

### DIFF
--- a/Casks/java10.rb
+++ b/Casks/java10.rb
@@ -1,0 +1,97 @@
+cask 'java10' do
+  version '10.0.1,10:fb4372174a714e6b8c52526dc134031e'
+  sha256 'cf3d33be870788eed5bb5eeef8f52aa9d7601955c8742efbec0cf9fbd6245ceb'
+
+  url "http://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}+#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}_osx-x64_bin.dmg",
+      cookies: {
+                 'oraclelicense' => 'accept-securebackup-cookie',
+               }
+  name 'Java Standard Edition Development Kit'
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk#{version.major}-downloads-4416644.html"
+
+  # auto_updates true: JDK does not auto-update
+  depends_on macos: '>= :yosemite'
+
+  pkg "JDK #{version.before_comma}.pkg"
+
+  postflight do
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string WebStart', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string Applets', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/MacOS", '/Library/Java/MacOS'],
+                   sudo: true
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   sudo: true
+  end
+
+  uninstall pkgutil:   [
+                         "com.oracle.jdk-#{version.before_comma}",
+                         'com.oracle.jre',
+                       ],
+            launchctl: [
+                         'com.oracle.java.Helper-Tool',
+                         'com.oracle.java.Java-Updater',
+                       ],
+            quit:      [
+                         'com.oracle.java.Java-Updater',
+                         'net.java.openjdk.cmd', # Java Control Panel
+                       ],
+            delete:    [
+                         '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin',
+                         "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
+                         '/Library/PreferencePanes/JavaControlPanel.prefPane',
+                         '/Library/Java/Home',
+                         '/Library/Java/MacOS',
+                       ]
+
+  zap trash: [
+               '/Library/Application Support/Oracle/Java',
+               '/Library/Preferences/com.oracle.java.Deployment.plist',
+               '/Library/Preferences/com.oracle.java.Helper-Tool.plist',
+               '~/Library/Application Support/Java/',
+               '~/Library/Application Support/Oracle/Java',
+               '~/Library/Caches/com.oracle.java.Java-Updater',
+               '~/Library/Caches/Oracle.MacJREInstaller',
+               '~/Library/Caches/net.java.openjdk.cmd',
+               '~/Library/Preferences/com.oracle.java.Java-Updater.plist',
+               '~/Library/Preferences/com.oracle.java.JavaAppletPlugin.plist',
+               '~/Library/Preferences/com.oracle.javadeployment.plist',
+             ],
+      rmdir: [
+               '/Library/Application Support/Oracle/',
+               "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk",
+               '~/Library/Application Support/Oracle/',
+             ]
+
+  caveats <<~EOS
+    This Cask makes minor modifications to the JRE to prevent issues with
+    packaged applications, as discussed here:
+
+      https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
+
+    If your Java application still asks for JRE installation, you might need
+    to reboot or logout/login.
+
+    Installing this Cask means you have AGREED to the Oracle Binary Code
+    License Agreement for Java SE at
+
+      https://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
+end


### PR DESCRIPTION
💁 These changes add a Cask for Java 10

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
