### PR TITLE
Update vivaldi-snapshot to 1.15.1147.23

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1147.21'
-  sha256 '72f0c8ed617191ce82af2f98134ef8b932decdf5ec9be139dc00fbfc74edf113'
+  version '1.15.1147.23'
+  sha256 '39bcbe25d65c02f010b63be8ca040718af6302f613a2ceed49325014185adab8'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '93c17850855d06215c068825407385d8131de867168d516e28e2ff8b7cfb1747'
+          checkpoint: 'f8950e57aa72a1062600703a823abfa85495af920e0837c830a7a324d983cfb1'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.