### PR TITLE
Update keka-beta to 1.1.0,10

### DIFF
--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -1,11 +1,11 @@
 cask 'keka-beta' do
-  version '1.1.0,9'
-  sha256 '5b2eb698ff2395c765fb92f3fc158e9c0222e0b454749ae24c1cb508c59e54e2'
+  version '1.1.0,10'
+  sha256 '9ad00c76b14f25f55edbed785c0b214f0d3591cd24ae9ba198a28bb5bb0ec38a'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-beta.#{version.after_comma}/Keka-#{version.before_comma}-beta.#{version.after_comma}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: '38d9902876e25fdf81ff368eb5f9bcdb4dbe2004ed7cd9eaecc73a07d12d4dc2'
+          checkpoint: 'f063b1c39c0f5fe0dc7b0b667d398495cc4d6ffd790b689827370c6269125a11'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.