### PR TITLE
Update sketch-beta to 50,54800

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '50,54675'
-  sha256 '1cb1683dfd5711a518fe713fc4f277c944a7fe494a968c48420e1a8b7f60c48b'
+  version '50,54800'
+  sha256 '3bbd3f418d0ec4887eb5f61665a2c077015eb2374d4371a4b95704eb133b1381'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'a713ec9278648b4baa18a13bbcd3c9a8c634cb1f6521954692cd08f0b98a7343'
+          checkpoint: '566f23f81c26e7431eb71134b5daaa68b39d3d29471c18b196f6df4707b0b83c'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.