### PR TITLE
Update atom-beta to 1.27.0-beta0

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,11 +1,11 @@
 cask 'atom-beta' do
-  version '1.26.0-beta2'
-  sha256 '92088ce053f7a409bb50a10efd6f45d7687c90c23a8afa4259c734a18a185dd1'
+  version '1.27.0-beta0'
+  sha256 '2fb36e933c03bd80f2a2bce0ff0294552b20647a0799760bd246956b1d4c1f75'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"
   appcast 'https://github.com/atom/atom/releases.atom',
-          checkpoint: '9d05a616347daf2b4a58bb516e07ea528ebdb8cf7975127b0bdaf306513ece71'
+          checkpoint: 'dd7b20578ba5e92dd8b8bb53294793ae9d3405dff2489f4fecd158e9b330a2ec'
   name 'Github Atom Beta'
   homepage 'https://atom.io/beta'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.