### PR TITLE
Update telegram-alpha to 3.8.3-122579,988

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-122520,987'
-  sha256 '8cbd42da752b74be33f456182a6afbfac1e77e549c0b15a59bc97934f925eee9'
+  version '3.8.3-122579,988'
+  sha256 'edb1b189d201692ea5de902fff4cecba1c0388a636297ddf7db7547935802be0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '92d890b709a836171bea5b5657ff7691f434cb415bd70b87a73f35e94d514817'
+          checkpoint: 'a24f307132afda33b696b319c6bc4db68d8657529999edb43ef41c58521dd4ae'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.