### PR TITLE
Update toggl-beta to 7.4.140

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggl-beta' do
-  version '7.4.129'
-  sha256 '1eb1f0dc3baed9e293040f9e77946c055376339802f967beb1266f8e8bfe22c2'
+  version '7.4.140'
+  sha256 '7ba2c6b6fb6f604b7c06b62629ffc668d5ea6bf5d44754649bca5758dfd80bda'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: '3966ec4cc86a430fec8d9bcce3bbf3890b20ec90db238151062793e56b8d4457'
+          checkpoint: 'aab463b7ad37f33c3b633088aeb72ed35b6ca5b1e6726112b69ac5b46dddc5a5'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.