### PR TITLE
Update libreoffice-rc to 6.0.4.1

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-rc' do
-  version '6.0.3.2'
-  sha256 'acb71b1d1b8c8857a0150d5cf9db06515abe82458fd4684be3b88d98d722fd98'
+  version '6.0.4.1'
+  sha256 '93cbc30356f4c82f063f96661683f7617a4f1c75a8eef64f18ba14c4da0dc869'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/testing/',
-          checkpoint: '3332e95a1e3a6373c1e19e46f9f877a044ca52756058c9e5523ae96e5ebadb69'
+          checkpoint: 'c93385a18726b8dee6f0fffbfbb9aa67a0c9f08576bdf854f9332fff07052660'
   name 'LibreOffice Release Candidate'
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'

--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -4,7 +4,7 @@ cask 'torbrowser-alpha' do
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '2b3dca7ace4c81a050aad6999e6da75436df18d4b3354d63d7b934d7622f6758'
+          checkpoint: '4900a07154a64caf87850497b7cf8561a584f8c66066a8bfb2201bfb1a3a4c35'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.