### PR TITLE
Update torbrowser-alpha to 8.0a6

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -4,7 +4,7 @@ cask 'torbrowser-alpha' do
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '2b3dca7ace4c81a050aad6999e6da75436df18d4b3354d63d7b934d7622f6758'
+          checkpoint: '4900a07154a64caf87850497b7cf8561a584f8c66066a8bfb2201bfb1a3a4c35'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'

--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'torbrowser-alpha' do
-  version '8.0a5'
-  sha256 '853bd9c9e8ba1d785bf2904ebd2681253c47413efb317bd7c4094f20d7c270c0'
+  version '8.0a6'
+  sha256 '559d74313f1ebde7e40674880ebb16e82569038056d2fb10b7474d8c6a102241'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.