### PR TITLE
Update visual-studio-code-insiders to 1.23.0,1fdf60b882f0edc6753fc964b253783eb46d56ef

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.23.0,e6b61067f22fd94718f7c427d9caded5514761f4'
-  sha256 'ed3ae9ea46c517088b4b08f96c51aec10ea43af7ea2410c73b02fda7b33e89e7'
+  version '1.23.0,1fdf60b882f0edc6753fc964b253783eb46d56ef'
+  sha256 '41d70436302b5d1082e91aed57b3056d9683d2cc5b4ad88b9351c864aa1a65fb'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: 'a7c7024c29a6631499cb1fab09c6ed9df1e6d001efd1ff8b5f345552c4bed025'
+          checkpoint: 'a7ed5b9cebd8ffa4047cd4154726145bade9a86e011be5ef8897762eb0350db0'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.