### PR TITLE
Update telegram-alpha to 3.8.3-122643,990

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-122604,989'
-  sha256 '06a36f69cd262fa9fbfee8488427d4d8bfaf5da5a949a253cbb9e92a60f37c34'
+  version '3.8.3-122643,990'
+  sha256 'd7c3cda8712e36d81bc18e9ec907416cb3f81f3ac1bc3edb1b0cf27663aefe13'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b617126ff0678a9880fd49c5078e1fcd592d6cd11e6c932875124c549f7e8bc2'
+          checkpoint: 'd80f2e278ca49b67f8bbb025d41ba572552cf0858bb2fe2dfd68d904e98860f8'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.