### PR TITLE
Update telegram-alpha to 3.8.3-122709,993

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-122643,990'
-  sha256 'd7c3cda8712e36d81bc18e9ec907416cb3f81f3ac1bc3edb1b0cf27663aefe13'
+  version '3.8.3-122709,993'
+  sha256 '8ab7d1221d46831c70fbf6afe9e915db59e6768f65298379395e8e70eb1a403e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'd80f2e278ca49b67f8bbb025d41ba572552cf0858bb2fe2dfd68d904e98860f8'
+          checkpoint: '0af2b775bf19bc218cff2ef649b75b2381b37ea38f9fc23f309a8cdd7640ffea'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.