### PR TITLE
Update keka-beta to 1.1.0,1

### DIFF
--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -1,11 +1,11 @@
 cask 'keka-beta' do
-  version '1.1.0,10'
-  sha256 '9ad00c76b14f25f55edbed785c0b214f0d3591cd24ae9ba198a28bb5bb0ec38a'
+  version '1.1.0,1'
+  sha256 '02c835e6e1906a4bdce35d8a473f04c26ebf0537d87a3244135aaaa9dccae75d'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
-  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-beta.#{version.after_comma}/Keka-#{version.before_comma}-beta.#{version.after_comma}.dmg"
+  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-rc.#{version.after_comma}/Keka-#{version.before_comma}-rc.#{version.after_comma}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom',
-          checkpoint: 'f063b1c39c0f5fe0dc7b0b667d398495cc4d6ffd790b689827370c6269125a11'
+          checkpoint: 'd878e18a600e07e63ffa6a232b2ce6f6f1deb30960816229b29fbfa5f74926f2'
   name 'Keka'
   homepage 'http://www.kekaosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.