### PR TITLE
Update vivaldi-snapshot to 1.15.1147.29

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.15.1147.23'
-  sha256 '39bcbe25d65c02f010b63be8ca040718af6302f613a2ceed49325014185adab8'
+  version '1.15.1147.29'
+  sha256 '0e08afb170c71c11df3912583d7d1bfbc9aab83f88a0f8d362f3794016936d32'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: 'f8950e57aa72a1062600703a823abfa85495af920e0837c830a7a324d983cfb1'
+          checkpoint: '51d86a98a147acdee0b77bbd2666a618a1d0c4fda012d8987812b45b355df00d'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.