### PR TITLE
Update emacs-pretest to 26.1-rc1

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,10 +1,10 @@
 cask 'emacs-pretest' do
-  version '26.0.91-1'
-  sha256 'f6b2c64be15806f153913e2d6f2c6e526c9f596d63438c044bafcf34abba1942'
+  version '26.1-rc1'
+  sha256 '8d921bece3244d911e975d71d7ef1b0f80e18c81f0b500e9c854d03b28ea2267'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: '725a3e42d1670bffc704c577a1f6379518a187ea4bfe760f10925e26d4cf3a0f'
+          checkpoint: '43d1a12e3ae12b9b66a3c5717039e9496ac3cad091077d750ab9237b8e19af9d'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.