### PR TITLE
Update 1password-beta to 7.0.BETA-9

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,11 +1,11 @@
 cask '1password-beta' do
-  version '7.0.BETA-8'
-  sha256 'b57cf3c88c1333ec636fce8f06a8a3f30886ba6c85aeaa9b5d1af81c12d68ffe'
+  version '7.0.BETA-9'
+  sha256 'd7c95b4a0c24a7495c2a1ce14cc839d764ae857ebc241ba209348e48e70cd40b'
 
   # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}",
-          checkpoint: '82e5478f1071d23e786eac60c3e3225df2480b82aaa40227d7f0f30ee0482628'
+          checkpoint: '55f67d0e7601c1cc2a9f2131862fee473affea8830363efd8c3ba30537a8624d'
   name '1Password'
   homepage 'https://1password.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.