### PR TITLE
Update homepage for omnipresence-beta

### DIFF
--- a/Casks/omnipresence-beta.rb
+++ b/Casks/omnipresence-beta.rb
@@ -4,7 +4,7 @@ cask 'omnipresence-beta' do
 
   url "http://omnistaging.omnigroup.com/omnipresence/releases/OmniPresence-#{version}-Test.dmg"
   name 'OmniPresence Beta'
-  homepage 'https://www.omnigroup.com/omnipresence'
+  homepage 'https://omnistaging.omnigroup.com/omnipresence/'
 
   depends_on macos: '>= :yosemite'
 


### PR DESCRIPTION
This is the equivalent for what has been set as the homepage for [`omnifocus-beta`](https:///homebrew-versions/Casks/omnifocus-beta.rb).