### PR TITLE
Update slicer-nightly to 4.9.0.27158,798500

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27131,792548'
-  sha256 '018a0dd6ea329698f97588d915f20e0118d859b7ff258ed769d484997f39a4a3'
+  version '4.9.0.27158,798500'
+  sha256 '8fbe70b2e6b308b76df72547124e59cd2cd789200ebcb1a9e0a7e0c007f2f0d9'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.