### PR TITLE
Update telegram-alpha to 3.8.3-122820,998

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-122753,997'
-  sha256 '73a71798cc88f6de3c3b3944c0c8fa47d484fd0de48c3caf8411a9b2c6cd7252'
+  version '3.8.3-122820,998'
+  sha256 'bf446607f824c74b36962885df218ffd54e60aa3c64d96da86814b91352839a5'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'a59fe3ee6254db92d3a2df6e0983e11f1b4fc9040823362a65c44712f22d5f04'
+          checkpoint: '6e3bd9273c5c250307f99622e85f77ae55802ad4cbbe4f93f87ad4a3aea5a01b'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.