### PR TITLE
Update airmail-beta to 3.5.5.483,341

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.482,340'
-  sha256 'cb3a4f99991aa9c2ee236a4b1f9fad8292ea2c2bb033c7486eb36fa9862dd21a'
+  version '3.5.5.483,341'
+  sha256 '91d8d2499a1bc0235ec99ec0774a483afba2f00d1d4626d84b90ccc4b87a872c'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: 'd11a6ee9e777722df3cd5d357be9624fd0fde59b59eaaa73728bc43aaac07479'
+          checkpoint: '3dd4483bd944d6e8c73276281a73de0a80e7c8a44d79e8c331334c71a4906043'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.