### PR TITLE
Update electron-beta to 2.0.0-beta.8

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,11 +1,11 @@
 cask 'electron-beta' do
-  version '2.0.0-beta.7'
-  sha256 'b7f65888bb49e0517d1156b22f2970e197373ef3bdb5b76451f59e18f2a00235'
+  version '2.0.0-beta.8'
+  sha256 '5d40f579031b44db95b6d65478b6f783c0fe1d3838146d4a4a507a62a5d80930'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"
   appcast 'https://github.com/electron/electron/releases.atom',
-          checkpoint: '6cc639e1a6f1cb410ca2297671064bcf4bc12292b2bbf6c2018846dc80201af7'
+          checkpoint: 'f5f01556e1c19fd748eef7851fc7fe2a427b93ef0f91dbabc332345f03d12102'
   name 'Electron'
   homepage 'https://electron.atom.io/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.