### PR TITLE
Update toggl-dev to 7.4.144

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.142'
-  sha256 '40be81ef8fdffaa68cc73c26145658cf20d5504841c04070c6c9187592bd8a53'
+  version '7.4.144'
+  sha256 '7bac63b5d2ef6e3fc96d3b712995637bc00b0bc2c0bbaaf68906aae6a6b1a999'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'cc98877a2a83b8e4a9a930769483266d5ab55a4a29808cf94158875200aab8ef'
+          checkpoint: '5919eabf10691ffd9f4475694514ba01dbbbf0c2a46d82e90f01c1fc07aa1554'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.