### PR TITLE
Update jabref-beta to 4.2

### DIFF
--- a/Casks/jabref-beta.rb
+++ b/Casks/jabref-beta.rb
@@ -1,11 +1,11 @@
 cask 'jabref-beta' do
-  version '4.1'
-  sha256 'f22108d6bda73978a51ca5759dd2a46619678427f3d9154e55f935004fa93751'
+  version '4.2'
+  sha256 '2f00ff13cca7e4d780cc365426b06a01384268394d2d2fa476655968acf55eba'
 
   # github.com/JabRef/jabref was verified as official when first introduced to the cask
   url "https://github.com/JabRef/jabref/releases/download/v#{version}/JabRef_macos_#{version.dots_to_underscores}.dmg"
   appcast 'https://github.com/JabRef/jabref/releases.atom',
-          checkpoint: '90eba3d359c9692fd843f940d17b9796dde4ab327b65651e865515eb0697081a'
+          checkpoint: 'e03551ded048dcdbfd73ae376dfcfd9b9bfade9fc0e21b47f8d41ed0f633bc68'
   name 'JabRef Beta'
   homepage 'https://www.jabref.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.