### PR TITLE
Update opera-beta to 53.0.2907.31

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '53.0.2907.7'
-  sha256 'fd2bee0b62f9efe678d9eefbdbb7702f2398a39f4a3e70b36fb7feb92704ce42'
+  version '53.0.2907.31'
+  sha256 'd2a4e9bb4b02258f3cb28e257ae81a01ace83abe8867cb86aa357baa469dac07'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.