### PR TITLE
Update telegram-alpha to 3.8.3-123506,1003

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123448,1001'
-  sha256 '4580384a68108c791415bd872734378754ee652f79bdf4a42bb0d8546bace248'
+  version '3.8.3-123506,1003'
+  sha256 '334da05e13fa4fa357ded9c6c33a7b2b0b633c93326c2d22218468a75801fb98'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '87624c6b74b15f4d7ea7a35a78dfcda834d028885549856dc99bce57db357213'
+          checkpoint: '05589cd15b5deecbe6656bc8f1b84d1757bc92ae687c089ebc9ab13a226028de'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.