### PR TITLE
Update telegram-alpha to 3.8.3-123520,1004

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123506,1003'
-  sha256 '334da05e13fa4fa357ded9c6c33a7b2b0b633c93326c2d22218468a75801fb98'
+  version '3.8.3-123520,1004'
+  sha256 'cddf94f5227fd294b42f27be27271b49ed11e53871f5d6bef00891896c9aec3a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '05589cd15b5deecbe6656bc8f1b84d1757bc92ae687c089ebc9ab13a226028de'
+          checkpoint: 'cc94cde1f91901a5e3c99b0ed8b7f7958c259482f62b655a050f01227898c59e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.