### PR TITLE
Update slicer-nightly to 4.9.0.27169,802024

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27158,798500'
-  sha256 '8fbe70b2e6b308b76df72547124e59cd2cd789200ebcb1a9e0a7e0c007f2f0d9'
+  version '4.9.0.27169,802024'
+  sha256 '89bdc3cdebf7b1822764494f77cff7b8e14038faf8edd2ab0ac6f6ebb78a7649'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.