### PR TITLE
Update sublime-text-dev to 3166

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3165'
-  sha256 'b720e2277040cb68608a1e8ba8d8963ebafbacefc3332f789fc2fdaaf0f5ec40'
+  version '3166'
+  sha256 'd9cf0b72468d5b81f8963ce5765f366580a454e6729631752ba1ce8f882947a4'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: 'd28b277bd8fa1cb4860724f82d12b64248d4c3a42a073124decd8aa71222ba8f'
+          checkpoint: '439593b2e1dc9d0520e9547575339a6ea741acc84e6cb1820ed37bd88a058e7c'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.