### PR TITLE
Update airmail-beta to 3.5.5.484,342

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.483,341'
-  sha256 '91d8d2499a1bc0235ec99ec0774a483afba2f00d1d4626d84b90ccc4b87a872c'
+  version '3.5.5.484,342'
+  sha256 'e39c5aaa9d9728892c810a2b69fc63fd8230b8a5a696b46c00942f28de41287e'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '3dd4483bd944d6e8c73276281a73de0a80e7c8a44d79e8c331334c71a4906043'
+          checkpoint: 'a738e5891ac43dc8c48e804447405f2d02be092121c479d41a2120561642560f'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.