### PR TITLE
Update telegram-alpha to 3.8.3-123666,1006

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123617,1005'
-  sha256 '7111217a0ac558a48c59bd6229e1c93271dde87106ba962140300fe569f9db4e'
+  version '3.8.3-123666,1006'
+  sha256 'afa82f49b7aa7302fbea93f73e56d44ec837a38d1841ee9e95c1fa6d1c4b024b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'bbf9ec629745793d5baed6a6dc26bdd6e6079e331688fd573172a40a25424840'
+          checkpoint: '6d77525dfac3237217592cccfe809b46428d8f4f7c012b649d2cba4bbcd48b50'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.