### PR TITLE
Update sublime-text-dev to 3168

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,10 +1,10 @@
 cask 'sublime-text-dev' do
-  version '3166'
-  sha256 'd9cf0b72468d5b81f8963ce5765f366580a454e6729631752ba1ce8f882947a4'
+  version '3168'
+  sha256 'b8d35183e7e9538ce6c106c73401e000f4be0f4098f053282d4ab68903a31f8f'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version}.dmg"
   appcast 'https://www.sublimetext.com/updates/3/dev/appcast_osx.xml',
-          checkpoint: '439593b2e1dc9d0520e9547575339a6ea741acc84e6cb1820ed37bd88a058e7c'
+          checkpoint: 'e1a0276d02a4e8576bbded8368b493c43429bacf57dca2734a864a96b3d454bd'
   name 'Sublime Text'
   homepage 'https://www.sublimetext.com/3dev'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.