### PR TITLE
Update telegram-alpha to 3.8.3-123683,1007

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123666,1006'
-  sha256 'afa82f49b7aa7302fbea93f73e56d44ec837a38d1841ee9e95c1fa6d1c4b024b'
+  version '3.8.3-123683,1007'
+  sha256 'e38bfda18b599a77ff1cc3a27ab14dd41eb3e13efff6b8c86ec5aa42a74211a9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6d77525dfac3237217592cccfe809b46428d8f4f7c012b649d2cba4bbcd48b50'
+          checkpoint: 'a9738f54d809a51932508a11961d2c674efa82c9d6144eb0f667e4acbad25160'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.