### PR TITLE
Update rstudio-preview to 1.1.446

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.1.444'
-  sha256 '37b1181da721f34bb3a8fdec66cd94b42592dca5ca4eb7d90ece971e1e2b2382'
+  version '1.1.446'
+  sha256 '44cb54fda79ad3ee78b0aa290ef64464bc2d5daaf5fca777fe4a9df1d4ecc4f7'
 
   # amazonaws.com/rstudio-dailybuilds was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-dailybuilds/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.