### PR TITLE
Update sketch-beta to 50,54971

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '50,54935'
-  sha256 'b5da38074396dbbba7cb158a39d861e733dcfd73b6dcecfe154f8f9c03e84376'
+  version '50,54971'
+  sha256 '7f9d6965d15971ac9f32a1dd3a437504628695e71e443c4bc9867787b5b59bc8'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'd06fcde251129e3e00e654c14cb027e6a0fdca65110d4a4b6a68e9fc748dfd59'
+          checkpoint: '2b95b6231312774e72a9653eeb256ad4c4bd41df88730150b608e9d5defea305'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.