### PR TITLE
Update telegram-alpha to 3.8.3-123922,1010

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123921,1009'
-  sha256 '085b183989d5f4db8df8458575a8086a3facbe8579094b723feda0255f10a220'
+  version '3.8.3-123922,1010'
+  sha256 '8bccad40f3c9dc04a90b708ebdad5b77e39d1d58a7d1ab19b6692921a3ea9e79'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7dacfa58741c6639bdba6a55eaff37c36e6511e47a0bbab7328fc6f0f54175a6'
+          checkpoint: 'c9942a795a974c48ae2007c7eeb82101c95b51a244f9fad9c5f05bbb4156dca4'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.