### PR TITLE
Update tower-beta to 3.0.0-145,145-6d4676e6

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '3.0.0-143,143-a6ed580c'
-  sha256 '7809e9b30415a8f4e94bffed17fa48f72abc309da5f85dd8a2d357ab76c3f5bd'
+  version '3.0.0-145,145-6d4676e6'
+  sha256 '790e0ad7a07da0b9fbaaad5cca29172b34dc383b2b318f73c4deb3f6511dec30'
 
   # amazonaws.com/apps/tower3-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma}/Tower-#{version.before_comma}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/beta",
-          checkpoint: '41a2b1c60214e0d350c92fb051ffeccf17ba2ba0de1411dd5a4e7f5fab2c12d4'
+          checkpoint: '4a3b122bc27ac500f81e0772d7ffdfadbd56906ac5e56f1a2f275b95fb0e82b4'
   name 'Tower'
   homepage 'https://www.git-tower.com/public-beta-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.