### PR TITLE
Update telegram-alpha to 3.8.3-124395,1011

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-123922,1010'
-  sha256 '8bccad40f3c9dc04a90b708ebdad5b77e39d1d58a7d1ab19b6692921a3ea9e79'
+  version '3.8.3-124395,1011'
+  sha256 'ccb72b9c34d7fe3d0a20f322eb658725316fc8f2cd1e7b012b0c76308f951bb2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c9942a795a974c48ae2007c7eeb82101c95b51a244f9fad9c5f05bbb4156dca4'
+          checkpoint: '7ab7ceed95b281ef4139fb8d45ddbe687bf0f7860771432e1d3241e9de85c5d1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.