### PR TITLE
Update torbrowser-alpha to 8.0a7

### DIFF
--- a/Casks/torbrowser-alpha.rb
+++ b/Casks/torbrowser-alpha.rb
@@ -1,10 +1,10 @@
 cask 'torbrowser-alpha' do
-  version '8.0a6'
-  sha256 '559d74313f1ebde7e40674880ebb16e82569038056d2fb10b7474d8c6a102241'
+  version '8.0a7'
+  sha256 '78a2c2be21286a8ea4e7dd38fd5ad1eac566c6da6d188a907af6993eee2b19c2'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/',
-          checkpoint: '4900a07154a64caf87850497b7cf8561a584f8c66066a8bfb2201bfb1a3a4c35'
+          checkpoint: '821b5e99ab6c6d95bc1a226bcb63fe153787ff864c19f6b8a807259f5a5941c4'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
   gpg "#{url}.asc", key_id: 'ef6e286dda85ea2a4ba7de684e2c6e8793298290'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.