### PR TITLE
Update telegram-alpha to 3.8.3-124408,1012

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-124395,1011'
-  sha256 'ccb72b9c34d7fe3d0a20f322eb658725316fc8f2cd1e7b012b0c76308f951bb2'
+  version '3.8.3-124408,1012'
+  sha256 '41eaa1f8b39743ccbded3af534df2d9b95eea68ca296e82082c4b93b5918f1a3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '7ab7ceed95b281ef4139fb8d45ddbe687bf0f7860771432e1d3241e9de85c5d1'
+          checkpoint: '9169c1a7e95f97b830a87193d9cff408f73037627602b8923ea0a15a2ad7767f'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.