### PR TITLE
libreofficedev.rb: remove auto:update true

### DIFF
--- a/Casks/libreofficedev.rb
+++ b/Casks/libreofficedev.rb
@@ -10,7 +10,6 @@ cask 'libreofficedev' do
   homepage 'https://www.libreoffice.org/download/pre-releases/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'
 
-  auto_updates true
   depends_on macos: '>= :mavericks'
 
   app 'LibreOfficeDev.app'


### PR DESCRIPTION
LibreOffice does not have an auto-updater. It checks for updates, but only provides a link, or lets the user choose to auto-download the dmg to a predefined path.

The installation has to be done by the user.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
