### PR TITLE
Update telegram-alpha to 3.8.3-124486,1014

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.3-124457,1013'
-  sha256 '0c81c2fcbdffff0597b7c58dd0e80c3370686c7b2f7cba26f99fd2e90c6a2854'
+  version '3.8.3-124486,1014'
+  sha256 '781454d843a3896e937fd3701c6444766f934f61352c8bbae7da11e13f092074'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '87d7bdeb7f3a24454ba9b442f486bac90d56fd5d9faf5e6015c03a5ee49fac8d'
+          checkpoint: '335f3162ef464a3ea524e5e077aa3aa08cf313d6a993f51611d7d93e36a79669'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.