### PR TITLE
Update telegram-alpha to 3.8.4-124556,1016

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-124537,1015'
-  sha256 '84c38b6029f06a95a14eea57b7bcd5684fa8600eec2b946f961ac8aa639dd261'
+  version '3.8.4-124556,1016'
+  sha256 '8f6105733d90be178ef7bac5d7692cd201388df7b8e3f02d5227f687ec1478e1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1dbe3718f67dc25721a40ebf9d778a27402ea1120124d187c4e7529077d05afc'
+          checkpoint: '169fa2a7de85dce05d695fabd2a3a871ce7bf14545f4b96b95bfca15087bc38d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.