### PR TITLE
Update visual-studio-code-insiders to 1.24.0,987c3dccf45ef0447b7b4c52c81794fab2b6dad5

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.24.0,8a07c8d935998d1b1153dde0c5b337189d35cea0'
-  sha256 '0b4a1fe8cd450228780dbced9216169432416b39faf20ad5b2de1981214a7bd9'
+  version '1.24.0,987c3dccf45ef0447b7b4c52c81794fab2b6dad5'
+  sha256 '46544787e5ba649f8fc01d0f8c9ac96ca79b11cda854bbdcba445995cc7a787b'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: '22144962eba4376379711a038c731bd7fdbf50b4a3fc7055b4580628fff70ca3'
+          checkpoint: '41b5bea737980d2fe98a069e856a6ec867f09911660ee2eec7e9d6364c84639d'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.