### PR TITLE
Update telegram-alpha to 3.8.4-124659,1019

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-124556,1016'
-  sha256 '8f6105733d90be178ef7bac5d7692cd201388df7b8e3f02d5227f687ec1478e1'
+  version '3.8.4-124659,1019'
+  sha256 '21d45a22b836bb6c7fa8eaa7fa80a1d66fd4d19538e900392a53e18edaacc4c8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '169fa2a7de85dce05d695fabd2a3a871ce7bf14545f4b96b95bfca15087bc38d'
+          checkpoint: '8109830d3e8cf8243e4c7610a4284a098961241aea81c659c59e5204d71cc750'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.