### PR TITLE
Update charles-beta to 4.2.6b2

### DIFF
--- a/Casks/charles-beta.rb
+++ b/Casks/charles-beta.rb
@@ -1,6 +1,6 @@
 cask 'charles-beta' do
-  version '4.3b2'
-  sha256 '76d37b0785f2ddb420f610726c22ab13f2467d3dc86b3605c6712dfa4c44977a'
+  version '4.2.6b2'
+  sha256 '23951227fddd09f4663e45fa1e81205f332ec541049bcbb531119906dd8f257c'
 
   url "https://www.charlesproxy.com/assets/release/#{version.gsub(%r{b\d$}, '')}/charles-proxy-#{version}.dmg"
   name 'Charles'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.