### PR TITLE
Update dropbox-beta to 50.3.66

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '50.3.65'
-  sha256 'c8321b74f62595a8c8cdfad26f2ae46ed0afa8a6fafe7cfdf28e37e550a75708'
+  version '50.3.66'
+  sha256 '49ed93312ef7e4a779499df5620da658527033400dcc6c294a02d09490038bcd'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.