### PR TITLE
Update transmit4 to 4.4.13

### DIFF
--- a/Casks/transmit4.rb
+++ b/Casks/transmit4.rb
@@ -3,8 +3,8 @@ cask 'transmit4' do
   sha256 '0d7095351378aa3c581de064f99fedecbfac683377048a4c0457976f5ce79f3b'
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
-  appcast "https://library.panic.com/releasenotes/transmit#{version.major}",
-          checkpoint: '87bb78821ca9d971cbcbdcdc70e69b9210fedbdea676f3b6c70855c593754101'
+  appcast "https://library.panic.com/releasenotes/transmit#{version.major}/",
+          checkpoint: '7df7a4642492b6512de70db5ec9f7acd72707e4a098e9db00ed4f604fb8b90df'
   name 'Transmit'
   homepage 'https://panic.com/transmit/'
 
@@ -14,4 +14,8 @@ cask 'transmit4' do
                '~/Library/Preferences/com.panic.Transmit.plist',
                '~/Library/Application Support/Transmit',
              ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.