### PR TITLE
Update wine-staging to 3.8

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,11 +1,11 @@
 cask 'wine-staging' do
-  version '3.7'
-  sha256 'c50474f5bd76749c2382e59b0e24a3e4b9936e546048a3ca69d732a92cea013d'
+  version '3.8'
+  sha256 'de01e5758a561dea9b2b9c84f9a69aa1fd9ce2f277a792925f5cc21c589f8ffe'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html',
-          checkpoint: '0cbf008dcc329fc2e2c1d3bf928e5cd745c74a5cdc6ebeebb8613cc2237550eb'
+          checkpoint: '0bb1396b2d74d73c1b9a90f87a014dfc2c301224763ae52b30c51c6f8c08b480'
   name 'WineHQ-staging'
   homepage 'https://www.wine-staging.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.