### PR TITLE
Update toggl-dev to 7.4.156

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.144'
-  sha256 '7bac63b5d2ef6e3fc96d3b712995637bc00b0bc2c0bbaaf68906aae6a6b1a999'
+  version '7.4.156'
+  sha256 'f13d09a5e59296692fe973f6281299f07eb22399eb340ba2ddf0cbfed4fe435b'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '5919eabf10691ffd9f4475694514ba01dbbbf0c2a46d82e90f01c1fc07aa1554'
+          checkpoint: '4dc35ce0305b0b31e6c03845619687e51f15afd904fb1c814e5906b58885c367'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.