### PR TITLE
Update wine-devel to 3.8

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,10 +1,10 @@
 cask 'wine-devel' do
-  version '3.7'
-  sha256 '0f16431871f077972893013a15427ec892e017d31502e0f2cd588ec878cb1d92'
+  version '3.8'
+  sha256 '50f7550fa274b90db4883eb57144556b2e00780a6e5110f047492e892bb6eb50'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html',
-          checkpoint: 'a646a854db130a1f3ce21f4256dc093060645bd086af3490bbc433d849e79dc3'
+          checkpoint: '0bb1396b2d74d73c1b9a90f87a014dfc2c301224763ae52b30c51c6f8c08b480'
   name 'WineHQ-devel'
   homepage 'https://wiki.winehq.org/MacOS'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.