### PR TITLE
Update sketch-beta to 50.1,55040

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,11 +1,11 @@
 cask 'sketch-beta' do
-  version '50,54983'
-  sha256 'c4da80540c55ba0bcb5b034adfb10996a3ca316dae5e2c63d50111c9ad4b3057'
+  version '50.1,55040'
+  sha256 'a8f30f6129a97e90309f079116e3f820c7502df6249f932982917bc29c282f74'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b',
-          checkpoint: 'ff4c59fcc6e7d644f98aa52a8e41fc4f32d1ee512ad95fc4ca644f5cc8796988'
+          checkpoint: '33dfc3e54754f44b75c95ed7012f5396aaf19e6192c7205aafc5ab1edfcc9e4e'
   name 'Sketch'
   homepage 'https://www.sketchapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.