### PR TITLE
Update telegram-alpha to 3.8.4-124785,1025

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-124709,1021'
-  sha256 'd94eaa1e3311b5004ceb33adbe75e5378c810b6cc7d9511a1aa45ab7983f38ad'
+  version '3.8.4-124785,1025'
+  sha256 'a228f71ddbffd90b0def01faaac8a9c0b84897d0585bc2b31b484cce701937e4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '5a1285fabdb5270e75fd49b325f1929c376d2bcb7401124eeda412ba9c027a33'
+          checkpoint: '184df940c6fb056b1363f3000ffd321c804524b989a9d86a30eb8af857e86518'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.