### PR TITLE
Update toggl-dev to 7.4.159

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.156'
-  sha256 'f13d09a5e59296692fe973f6281299f07eb22399eb340ba2ddf0cbfed4fe435b'
+  version '7.4.159'
+  sha256 'ce9ccd1b0be4ee05b1cd5553f38421305e8740836ee997b9ba98c7a53e804e79'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '4dc35ce0305b0b31e6c03845619687e51f15afd904fb1c814e5906b58885c367'
+          checkpoint: '6b382a6878f98b0e615889d7834fdd236af4d791a72b980f75b5bd6ecd3cc4c0'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.