### PR TITLE
Update telegram-alpha to 3.8.4-124840,1028

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-124839,1027'
-  sha256 '526c64112f2a6d88fcd1bc6f92166271dc60396a5b14e78f6ee745d79e91dc17'
+  version '3.8.4-124840,1028'
+  sha256 '896cd36b7fd03a08609577ed53e3ae3188eea2cbadda601cc7e4989a72195d41'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'ccc84c0db0a078e804d9363fe80feec0762b011bc3712e94c4e046a8451b5775'
+          checkpoint: '929eebf63fd93358b4de63e69e2c19aa21c31f53af720e5c785c46fe97414130'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.