### PR TITLE
Update dropbox-beta to 50.3.68

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '50.3.67'
-  sha256 '8571ed399ee480d819ad9e6b4660f5608d711dfdc1e152c5334913942447439b'
+  version '50.3.68'
+  sha256 'ca483efd1a4a2cb54d630f52487f85e65fd7ab7c047e4307aeb4e979583416c8'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.