### PR TITLE
Update libreoffice-still to 5.4.7

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -1,11 +1,11 @@
 cask 'libreoffice-still' do
-  version '5.4.6'
-  sha256 '6a9d74a999f4c51b57ce4eeb431cc9b8be00c2200f2bdf579c06aabe1928f479'
+  version '5.4.7'
+  sha256 '541b43b958820048f919d50ee6b52515d9ba98608731392eb4a4ae4590ce3e82'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"
   appcast 'https://download.documentfoundation.org/libreoffice/stable/',
-          checkpoint: '0810423ee662c57a69ca39a40ee9c1c1ce8f2d1584451ac14e6428edae048a80'
+          checkpoint: '2aa7f8e78791bf00be6ce82df62168407f8d252af1ac51a6f4052f464d9dfb27'
   name 'LibreOffice Still'
   homepage 'https://www.libreoffice.org/download/libreoffice-still/'
   gpg "#{url}.asc", key_id: 'c2839ecad9408fbe9531c3e9f434a1efafeeaea3'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.