### PR TITLE
Update telegram-alpha to 3.8.4-125109,1033

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-124840,1028'
-  sha256 '896cd36b7fd03a08609577ed53e3ae3188eea2cbadda601cc7e4989a72195d41'
+  version '3.8.4-125109,1033'
+  sha256 '78618337c982b9fd0379a965e4ada514505457a0c706f3ec9c63111e68f89314'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '929eebf63fd93358b4de63e69e2c19aa21c31f53af720e5c785c46fe97414130'
+          checkpoint: '240b9c36aa126141f61edd22c23ff6cd295603c710c503f4f4773e1fe10bb7e1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.