### PR TITLE
Update iterm2-beta to 3.2.0beta1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.1.6beta5'
-  sha256 'adbcdcd321ce7b98ddf39ade13323449603c8a5902e7a78091a55ceada0a0b3a'
+  version '3.2.0beta1'
+  sha256 '38e0e8e549a5808d3c132155615b09ed0e84448134887dff4bf64e34a9b5aaf3'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: 'd2f5dd8fba81f1e49d6ab6dfa2e9b6eb8ec82665cf2d0c7bfc88a195c68d5729'
+          checkpoint: '054047359f9517d98770b9dfd01c53f46855dc38624bce28de748182a05002f1'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.