### PR TITLE
Update telegram-alpha to 3.8.4-125112,1034

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-125109,1033'
-  sha256 '78618337c982b9fd0379a965e4ada514505457a0c706f3ec9c63111e68f89314'
+  version '3.8.4-125112,1034'
+  sha256 'd3fe0e6e9a08f1c51746cbf7eafe31b492218f01b3c785fca1db6a49e7c4b77b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '240b9c36aa126141f61edd22c23ff6cd295603c710c503f4f4773e1fe10bb7e1'
+          checkpoint: '0d2de6507a1df5970f4a18619a450f32a900a5c06351d8fba30dabf4a6980f75'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.