### PR TITLE
Update telegram-alpha to 3.8.4-125121,1035

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.8.4-125112,1034'
-  sha256 'd3fe0e6e9a08f1c51746cbf7eafe31b492218f01b3c785fca1db6a49e7c4b77b'
+  version '3.8.4-125121,1035'
+  sha256 'c2bd6175b193343214be1cddcbf727a809f64160a40d0481b7b6ce31ab3a176c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '0d2de6507a1df5970f4a18619a450f32a900a5c06351d8fba30dabf4a6980f75'
+          checkpoint: 'c7d709311742a956453c44b680e80fe64eb5d94738231a8cb323190ed1e1faa4'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.