### PR TITLE
Update visual-studio-code-insiders to 1.24.0,a521c01d56ec7f07bea2471880f28a77f37983af

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,11 +1,11 @@
 cask 'visual-studio-code-insiders' do
-  version '1.24.0,987c3dccf45ef0447b7b4c52c81794fab2b6dad5'
-  sha256 '46544787e5ba649f8fc01d0f8c9ac96ca79b11cda854bbdcba445995cc7a787b'
+  version '1.24.0,a521c01d56ec7f07bea2471880f28a77f37983af'
+  sha256 'f17d41d4133402b797268756ab182ad3920b9ee388f1c9bce265cd80fca6bf7d'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"
   appcast 'https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION',
-          checkpoint: '41b5bea737980d2fe98a069e856a6ec867f09911660ee2eec7e9d6364c84639d'
+          checkpoint: '368eab10630fe773face3765197ffa8b9ac558ca9a78f03f3fa704c5470f3507'
   name 'Microsoft Visual Studio Code'
   name 'VS Code - Insiders'
   homepage 'https://code.visualstudio.com/insiders'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.