### PR TITLE
Update tower-beta to 3.0.0-147,147-56e90fa0

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '3.0.0-146,146-977d8c27'
-  sha256 '0f6673ead752458e3ea628f03c0361ff7c0d39e674ee7e6a9826df4ac3512f39'
+  version '3.0.0-147,147-56e90fa0'
+  sha256 '32df0b12ae7d8f9336147acfb361565f5929e3e4dc1da2ac6db318f08f4819c2'
 
   # amazonaws.com/apps/tower3-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma}/Tower-#{version.before_comma}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/beta",
-          checkpoint: 'fe649d222ef01e0ce6a5a54946ca7f6817354ad3f753cb1b0ee88564a43becd5'
+          checkpoint: '735540e0e39f40256ed8ccaaf7eac596f4f9eca9b5c4715f41396f826c35ca69'
   name 'Tower'
   homepage 'https://www.git-tower.com/public-beta-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.