### PR TITLE
Update telegram-alpha to 3.9.1-125453,1043

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9-125220,1038'
-  sha256 '8f2d8dbd619664456c2055b16764ec80d774d76c998870d99c89c36a46235ba1'
+  version '3.9.1-125453,1043'
+  sha256 '31d4084756ececa9afca4d9845aa387cfbd5dff905ec10d906fac3e7203f6f78'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '6e33ba3f7095e333837c625bb1767d55683ceaca65a47c929e2d9d0413b0f5f3'
+          checkpoint: 'f953a6390a9ab9c8e62ac549929fdda5f4803b016b66023cf771f9ec31ef6878'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.