### PR TITLE
Update airmail-beta to 3.5.5.486,345

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,11 @@
 cask 'airmail-beta' do
-  version '3.5.5.485,343'
-  sha256 '70c5c3fafc6922724166b99345be9f3de7774575a71d2e755f7dad49bb983327'
+  version '3.5.5.486,345'
+  sha256 '6c537da439fd0af50873183bb9e2b40cf34e915803471e605382fa2fcc93263b'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04',
-          checkpoint: '9f7bf77c5a41f5a954528764d7089e153f31e5dcdcc5ff8e28d89233ec7b27db'
+          checkpoint: 'e3affe93a7814ed97516d26e1e92796de77f22900861dd91ab6ee690746ba623'
   name 'Airmail'
   homepage 'http://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.